### PR TITLE
Simplified links declaration in YAML 

### DIFF
--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -17,7 +17,7 @@ use opencv::{core, highgui, prelude::*, videoio};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
-use zenoh_flow::model::link::{ZFPortFrom, ZFPortTo};
+use zenoh_flow::model::link::{ZFLinkFromDescriptor, ZFLinkToDescriptor};
 use zenoh_flow::{
     downcast, downcast_mut, get_input,
     model::link::ZFPortDescriptor,
@@ -252,12 +252,12 @@ async fn main() {
 
     zf_graph
         .add_link(
-            ZFPortFrom {
-                id: "camera-source".to_string(),
+            ZFLinkFromDescriptor {
+                component_id: "camera-source".to_string(),
                 output_id: String::from(SOURCE),
             },
-            ZFPortTo {
-                id: "video-sink".to_string(),
+            ZFLinkToDescriptor {
+                component_id: "video-sink".to_string(),
                 input_id: String::from(INPUT),
             },
             None,

--- a/zenoh-flow-examples/graphs/car-pipeline-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/car-pipeline-multi-runtime.yaml
@@ -27,20 +27,12 @@ sinks: # sources can have only ONE input
     input:
       id: Frame
       type: image
-links:
-- from:
-    id : Camera0
-    output_id : Frame # Output
-  to:
-    id : ObjectDetection
-    input_id : Frame # Input
-- from:
-    id : ObjectDetection
-    output_id : Frame
-  to:
-    id : Window
-    input_id : Frame
 
+links:
+- from: Camera0.Frame
+  to: ObjectDetection.Frame
+- from: ObjectDetection.Frame
+  to: Window.Frame
 
 mapping:
   - id: Window

--- a/zenoh-flow-examples/graphs/dnn-object-detection-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection-multi-runtime.yaml
@@ -28,20 +28,12 @@ sinks: # sources can have only ONE input
     input:
       id: Frame
       type: image
-links:
-- from:
-    id : Camera0
-    output_id : Frame # Output
-  to:
-    id : ObjectDetection
-    input_id : Frame # Input
-- from:
-    id : ObjectDetection
-    output_id : Frame
-  to:
-    id : Window
-    input_id : Frame
 
+links:
+- from: Camera0.Frame
+  to: ObjectDetection.Frame
+- from: ObjectDetection.Frame
+  to: Window.Frame
 
 mapping:
   - id: Window

--- a/zenoh-flow-examples/graphs/dnn-object-detection.yaml
+++ b/zenoh-flow-examples/graphs/dnn-object-detection.yaml
@@ -28,16 +28,9 @@ sinks: # sources can have only ONE input
     input:
       id: Frame
       type: image
+
 links:
-- from:
-    id : Camera0
-    output_id : Frame # Output
-  to:
-    id : ObjectDetection
-    input_id : Frame # Input
-- from:
-    id : ObjectDetection
-    output_id : Frame
-  to:
-    id : Window
-    input_id : Frame
+- from: Camera0.Frame
+  to: ObjectDetection.Frame
+- from: ObjectDetection.Frame
+  to: Window.Frame

--- a/zenoh-flow-examples/graphs/face-detection-multi-runtime.yaml
+++ b/zenoh-flow-examples/graphs/face-detection-multi-runtime.yaml
@@ -28,19 +28,12 @@ sinks: # sources can have only ONE input
     input:
       id: Frame
       type: image
+
 links:
-- from:
-    id : Camera0
-    output_id : Frame # Output
-  to:
-    id : FaceDetection
-    input_id : Frame # Input
-- from:
-    id : FaceDetection
-    output_id : Frame
-  to:
-    id : Window
-    input_id : Frame
+- from: Camera0.Frame
+  to: FaceDetection.Frame
+- from: FaceDetection.Frame
+  to: Window.Frame
 
 
 mapping:

--- a/zenoh-flow-examples/graphs/face_detection.yaml
+++ b/zenoh-flow-examples/graphs/face_detection.yaml
@@ -28,16 +28,9 @@ sinks: # sources can have only ONE input
     input:
       id: Frame
       type: image
+
 links:
-- from:
-    id : Camera0
-    output_id : Frame # Output
-  to:
-    id : FaceDetection
-    input_id : Frame # Input
-- from:
-    id : FaceDetection
-    output_id : Frame
-  to:
-    id : Window
-    input_id : Frame
+- from: Camera0.Frame
+  to: FaceDetection.Frame
+- from: FaceDetection.Frame
+  to: Window.Frame

--- a/zenoh-flow-examples/graphs/fizz-buzz-multiple-runtimes.yaml
+++ b/zenoh-flow-examples/graphs/fizz-buzz-multiple-runtimes.yaml
@@ -75,79 +75,38 @@ sinks:
       type: string
 
 links:
-  - from:
-      id: ManualSenderOperator
-      output_id: Int
-    to:
-      id: FizzOperator
-      input_id: Int
+  - from: ManualSenderOperator.Int
+    to: FizzOperator.Int
 
-  # FizzOperator -> BuzzOperator
-  - from:
-      id: FizzOperator
-      output_id: Int
-    to:
-      id: BuzzOperator
-      input_id: Int
+  # FizzOperator -> BuzzOperator -> ReceiverOperator
+  - from: FizzOperator.Int
+    to: BuzzOperator.Int
 
-  - from:
-      id: FizzOperator
-      output_id: Str
-    to:
-      id: BuzzOperator
-      input_id: Str
+  - from: FizzOperator.Str
+    to: BuzzOperator.Str
 
-  - from:
-      id: BuzzOperator
-      output_id: Str
-    to:
-      id: ReceiverOperator
-      input_id: Str
+  - from: BuzzOperator.Str
+    to: ReceiverOperator.Str
 
-  # FizzOperator -> BuzzOperator2
-  - from:
-      id: FizzOperator
-      output_id: Int
-    to:
-      id: BuzzOperator2
-      input_id: Int
+  # FizzOperator -> BuzzOperator2 -> ReceiverOperator2
+  - from: FizzOperator.Int
+    to: BuzzOperator2.Int
 
-  - from:
-      id: FizzOperator
-      output_id: Str
-    to:
-      id: BuzzOperator2
-      input_id: Str
+  - from: FizzOperator.Str
+    to: BuzzOperator2.Str
 
-  - from:
-      id: BuzzOperator2
-      output_id: Str
-    to:
-      id: ReceiverOperator2
-      input_id: Str
+  - from: BuzzOperator2.Str
+    to: ReceiverOperator2.Str
 
-  # FizzOperator -> BuzzOperator3
-  - from:
-      id: FizzOperator
-      output_id: Int
-    to:
-      id: BuzzOperator3
-      input_id: Int
+  # FizzOperator -> BuzzOperator3 -> ReceiverOperator3
+  - from: FizzOperator.Int
+    to: BuzzOperator3.Int
 
-  - from:
-      id: FizzOperator
-      output_id: Str
-    to:
-      id: BuzzOperator3
-      input_id: Str
+  - from: FizzOperator.Str
+    to: BuzzOperator3.Str
 
-  - from:
-      id: BuzzOperator3
-      output_id: Str
-    to:
-      id: ReceiverOperator3
-      input_id: Str
-
+  - from: BuzzOperator3.Str
+    to: ReceiverOperator3.Str
 
 mapping:
   - id: ManualSenderOperator

--- a/zenoh-flow-examples/graphs/fizz_buzz_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/fizz_buzz_pipeline.yaml
@@ -37,30 +37,14 @@ sinks:
       type: string
 
 links:
-  - from:
-      id: ManualSenderOperator
-      output_id: Int
-    to:
-      id: FizzOperator
-      input_id: Int
+  - from: ManualSenderOperator.Int
+    to: FizzOperator.Int
 
-  - from:
-      id: FizzOperator
-      output_id: Int
-    to:
-      id: BuzzOperator
-      input_id: Int
+  - from: FizzOperator.Int
+    to: BuzzOperator.Int
 
-  - from:
-      id: FizzOperator
-      output_id: Str
-    to:
-      id: BuzzOperator
-      input_id: Str
+  - from: FizzOperator.Str
+    to: BuzzOperator.Str
 
-  - from:
-      id: BuzzOperator
-      output_id: Str
-    to:
-      id: ReceiverOperator
-      input_id: Str
+  - from: BuzzOperator.Str
+    to: ReceiverOperator.Str

--- a/zenoh-flow-examples/graphs/random_source.yaml
+++ b/zenoh-flow-examples/graphs/random_source.yaml
@@ -13,9 +13,5 @@ sinks:
         id: Data
         type: usize
 links:
-- from:
-    id : RandomGenerator
-    output_id : Random
-  to:
-    id : PrintSink
-    input_id : Data
+- from: RandomGenerator.Random
+  to: PrintSink.Data

--- a/zenoh-flow-examples/graphs/simple_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/simple_pipeline.yaml
@@ -22,15 +22,7 @@ sinks:
       type: usize
 
 links:
-- from:
-    id : Counter
-    output_id : Counter
-  to:
-    id : SumOperator
-    input_id : Number
-- from:
-    id : SumOperator
-    output_id : Sum
-  to:
-    id : PrintSink
-    input_id : Data
+- from: Counter.Counter
+  to: SumOperator.Number
+- from: SumOperator.Sum
+  to: PrintSink.Data

--- a/zenoh-flow-examples/graphs/stereo-car-camera-pipeline.yaml
+++ b/zenoh-flow-examples/graphs/stereo-car-camera-pipeline.yaml
@@ -33,22 +33,11 @@ sinks: # sources can have only ONE input
     input:
       id: Frame
       type: image
+
 links:
-- from:
-    id : Camera0
-    output_id : Frame # Output
-  to:
-    id : Concatenation
-    input_id : Frame1 # Input
-- from:
-    id : Camera1
-    output_id : Frame
-  to:
-    id : Concatenation
-    input_id : Frame2
-- from:
-      id: Concatenation
-      output_id : Frame
-  to:
-      id: Window
-      input_id : Frame
+- from: Camera0.Frame
+  to: Concatenation.Frame1
+- from: Camera1.Frame
+  to: Concatenation.Frame2
+- from: Concatenation.Frame
+  to: Window.Frame

--- a/zenoh-flow-examples/graphs/video_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/video_pipeline.yaml
@@ -14,9 +14,5 @@ sinks:
       type: image
 
 links:
-- from:
-    id : Camera
-    output_id : Frame
-  to:
-    id : Window
-    input_id : Frame
+- from: Camera.Frame
+  to: Window.Frame

--- a/zenoh-flow-examples/graphs/zface_detection.yaml
+++ b/zenoh-flow-examples/graphs/zface_detection.yaml
@@ -21,15 +21,7 @@ sinks:
       id: Data
       type: image
 links:
-- from:
-    id : Camera0
-    output_id : Frame
-  to:
-    id : FaceDetection
-    input_id : Frame
-- from:
-    id : FaceDetection
-    output_id : Frame
-  to:
-    id : ZSink
-    input_id : Data
+- from: Camera0.Frame
+  to: FaceDetection.Frame
+- from: FaceDetection.Frame
+  to: ZSink.Data

--- a/zenoh-flow-examples/graphs/zvideo_pipeline.yaml
+++ b/zenoh-flow-examples/graphs/zvideo_pipeline.yaml
@@ -13,9 +13,5 @@ sinks:
       id: Data
       type: image
 links:
-- from:
-    id : Camera
-    output_id : Frame
-  to:
-    id : ZSink
-    input_id : Data
+- from: Camera.Frame
+  to: ZSink.Data

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -58,14 +58,16 @@ impl<'de> Visitor<'de> for ZFLinkFromVisitor {
     where
         E: serde::de::Error,
     {
-        let tokens: Vec<&str> = v.split('.').collect();
-        if tokens.len() != 2 {
-            return Err(E::custom(format!("invalid 'from' descriptor: {}", v)));
-        }
+        let index_dot = match v.find('.') {
+            Some(index) => index,
+            None => return Err(E::custom(format!("invalid 'from' descriptor: {}", v))),
+        };
+
+        let (component_id, output_id) = v.split_at(index_dot);
 
         Ok(ZFLinkFromDescriptor {
-            component_id: tokens[0].to_string(),
-            output_id: tokens[1].to_string(),
+            component_id: component_id.to_string(),
+            output_id: output_id[1..].to_string(),
         })
     }
 
@@ -119,14 +121,16 @@ impl<'de> Visitor<'de> for ZFLinkToVisitor {
     where
         E: serde::de::Error,
     {
-        let tokens: Vec<&str> = v.split('.').collect();
-        if tokens.len() != 2 {
-            return Err(E::custom(format!("invalid 'to' descriptor: {}", v)));
-        }
+        let index_dot = match v.find('.') {
+            Some(index) => index,
+            None => return Err(E::custom(format!("invalid 'from' descriptor: {}", v))),
+        };
+
+        let (component_id, input_id) = v.split_at(index_dot);
 
         Ok(ZFLinkToDescriptor {
-            component_id: tokens[0].to_string(),
-            input_id: tokens[1].to_string(),
+            component_id: component_id.to_string(),
+            input_id: input_id[1..].to_string(),
         })
     }
 

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -13,27 +13,17 @@
 //
 
 use crate::ZFOperatorId;
+use serde::{de::Visitor, Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFLinkDescriptor {
-    pub from: ZFPortFrom,
-    pub to: ZFPortTo,
+    pub from: ZFLinkFromDescriptor,
+    pub to: ZFLinkToDescriptor,
     pub size: Option<usize>,
     pub queueing_policy: Option<String>,
     pub priority: Option<usize>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ZFPortFrom {
-    pub id: ZFOperatorId,
-    pub output_id: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ZFPortTo {
-    pub id: ZFOperatorId,
-    pub input_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -42,4 +32,126 @@ pub struct ZFPortDescriptor {
     pub port_id: String,
     #[serde(alias = "type")]
     pub port_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ZFLinkFromDescriptor {
+    pub component_id: ZFOperatorId,
+    pub output_id: String,
+}
+
+impl fmt::Display for ZFLinkFromDescriptor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}.{}", self.component_id, self.output_id))
+    }
+}
+
+struct ZFLinkFromVisitor;
+impl<'de> Visitor<'de> for ZFLinkFromVisitor {
+    type Value = ZFLinkFromDescriptor;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an output port descriptor: 'operator_id.output_id'")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let tokens: Vec<&str> = v.split('.').collect();
+        if tokens.len() != 2 {
+            return Err(E::custom(format!("invalid 'from' descriptor: {}", v)));
+        }
+
+        Ok(ZFLinkFromDescriptor {
+            component_id: tokens[0].to_string(),
+            output_id: tokens[1].to_string(),
+        })
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_str(v.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ZFLinkFromDescriptor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(ZFLinkFromVisitor)
+    }
+}
+
+impl Serialize for ZFLinkFromDescriptor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ZFLinkToDescriptor {
+    pub component_id: ZFOperatorId,
+    pub input_id: String,
+}
+
+impl fmt::Display for ZFLinkToDescriptor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("{}.{}", self.component_id, self.input_id))
+    }
+}
+
+struct ZFLinkToVisitor;
+impl<'de> Visitor<'de> for ZFLinkToVisitor {
+    type Value = ZFLinkToDescriptor;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an input port descriptor: 'operator_id.input_id'")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let tokens: Vec<&str> = v.split('.').collect();
+        if tokens.len() != 2 {
+            return Err(E::custom(format!("invalid 'to' descriptor: {}", v)));
+        }
+
+        Ok(ZFLinkToDescriptor {
+            component_id: tokens[0].to_string(),
+            input_id: tokens[1].to_string(),
+        })
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_str(v.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ZFLinkToDescriptor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ZFLinkToVisitor)
+    }
+}
+
+impl Serialize for ZFLinkToDescriptor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
 }

--- a/zenoh-flow/src/runtime/message.rs
+++ b/zenoh-flow/src/runtime/message.rs
@@ -36,7 +36,7 @@ impl ZFDataMessage {
 
     pub fn serialized_data(&self) -> &[u8] {
         match self {
-            Self::Serialized(data) => &data,
+            Self::Serialized(data) => data,
             _ => panic!(),
         }
     }


### PR DESCRIPTION
The new syntax to declare links is:

```yaml
links:
  - from: component_id.output_id
    to: component_id.input_id
```

To achieve this change, customs serializer / deserializer and new descriptors
were implemented.

The core of the changes are in `src/model/link.rs`. The serializers simply take
a string as input and split it at the '.' character.

All the examples were updated accordingly.