### PR TITLE
refacto: ZFMessage complete overhaul

### DIFF
--- a/zenoh-flow-examples/examples/camera-source.rs
+++ b/zenoh-flow-examples/examples/camera-source.rs
@@ -19,7 +19,7 @@ use zenoh_flow::{
     downcast_mut,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
+        DataTrait, FnOutputRule, FnSourceRun, FutRunOutput, RunOutput, SourceTrait, StateTrait,
         ZFContext, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -103,7 +103,7 @@ impl CameraSource {
         Self { state }
     }
 
-    async fn run_1(ctx: ZFContext) -> RunResult {
+    async fn run_1(ctx: ZFContext) -> RunOutput {
         let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.async_lock().await;
@@ -156,7 +156,7 @@ impl SourceTrait for CameraSource {
     fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
         let gctx = ctx.lock();
         match gctx.mode {
-            0 => Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) }),
+            0 => Box::new(|ctx: ZFContext| -> FutRunOutput { Box::pin(Self::run_1(ctx)) }),
             _ => panic!("No way"),
         }
     }

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -16,12 +16,11 @@ use async_std::sync::Arc;
 use std::collections::HashMap;
 use zenoh_flow::{
     export_operator, get_input,
-    runtime::message::Message,
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
+        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleOutput, OperatorTrait,
+        OutputRuleOutput, RunOutput, StateTrait, ZFInput, ZFResult,
     },
-    zf_data, zf_empty_state, Token, ZFContext,
+    zf_data, zf_empty_state, Token, ZFComponentOutput, ZFContext,
 };
 use zenoh_flow_examples::{ZFString, ZFUsize};
 
@@ -32,7 +31,7 @@ static LINK_ID_INPUT_STR: &str = "Str";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl BuzzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -43,13 +42,12 @@ impl BuzzOperator {
         Ok(true)
     }
 
-    fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
+    fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunOutput {
         let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(1);
 
-        let (_, fizz) = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?;
+        let (_, mut buzz) = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?;
         let (_, value) = get_input!(ZFUsize, String::from(LINK_ID_INPUT_INT), inputs)?;
 
-        let mut buzz = fizz.clone();
         if value.0 % 3 == 0 {
             buzz.0.push_str("Buzz");
         }
@@ -62,12 +60,12 @@ impl BuzzOperator {
     fn output_rule(
         _ctx: ZFContext,
         outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<String, Message> = HashMap::with_capacity(1);
+    ) -> OutputRuleOutput {
+        let mut zf_outputs: HashMap<String, ZFComponentOutput> = HashMap::with_capacity(1);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),
-            Message::from_data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
+            ZFComponentOutput::Data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
         );
 
         Ok(zf_outputs)

--- a/zenoh-flow-examples/examples/example-buzz2.rs
+++ b/zenoh-flow-examples/examples/example-buzz2.rs
@@ -16,12 +16,11 @@ use async_std::sync::Arc;
 use std::collections::HashMap;
 use zenoh_flow::{
     export_operator, get_input,
-    runtime::message::Message,
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
+        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleOutput, OperatorTrait,
+        OutputRuleOutput, RunOutput, StateTrait, ZFInput, ZFResult,
     },
-    zf_data, zf_empty_state, Token, ZFContext,
+    zf_data, zf_empty_state, Token, ZFComponentOutput, ZFContext,
 };
 use zenoh_flow_examples::{ZFString, ZFUsize};
 
@@ -32,7 +31,7 @@ static LINK_ID_INPUT_STR: &str = "Str";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl BuzzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -43,7 +42,7 @@ impl BuzzOperator {
         Ok(true)
     }
 
-    fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
+    fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunOutput {
         let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(1);
 
         let (_, fizz) = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?;
@@ -62,12 +61,12 @@ impl BuzzOperator {
     fn output_rule(
         _ctx: ZFContext,
         outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<String, Message> = HashMap::with_capacity(1);
+    ) -> OutputRuleOutput {
+        let mut zf_outputs = HashMap::with_capacity(1);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),
-            Message::from_data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
+            ZFComponentOutput::Data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
         );
 
         Ok(zf_outputs)

--- a/zenoh-flow-examples/examples/example-buzz3.rs
+++ b/zenoh-flow-examples/examples/example-buzz3.rs
@@ -16,12 +16,11 @@ use async_std::sync::Arc;
 use std::collections::HashMap;
 use zenoh_flow::{
     export_operator, get_input,
-    runtime::message::Message,
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, ZFInput, ZFResult,
+        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleOutput, OperatorTrait,
+        OutputRuleOutput, RunOutput, StateTrait, ZFInput, ZFResult,
     },
-    zf_data, zf_empty_state, Token, ZFContext,
+    zf_data, zf_empty_state, Token, ZFComponentOutput, ZFContext,
 };
 use zenoh_flow_examples::{ZFString, ZFUsize};
 
@@ -32,7 +31,7 @@ static LINK_ID_INPUT_STR: &str = "Str";
 static LINK_ID_OUTPUT_STR: &str = "Str";
 
 impl BuzzOperator {
-    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    fn input_rule(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         for token in inputs.values() {
             match token {
                 Token::Ready(_) => continue,
@@ -43,7 +42,7 @@ impl BuzzOperator {
         Ok(true)
     }
 
-    fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
+    fn run(_ctx: ZFContext, mut inputs: ZFInput) -> RunOutput {
         let mut results = HashMap::<String, Arc<dyn DataTrait>>::with_capacity(1);
 
         let (_, fizz) = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?;
@@ -62,12 +61,12 @@ impl BuzzOperator {
     fn output_rule(
         _ctx: ZFContext,
         outputs: HashMap<String, Arc<dyn DataTrait>>,
-    ) -> OutputRuleResult {
-        let mut zf_outputs: HashMap<String, Message> = HashMap::with_capacity(1);
+    ) -> OutputRuleOutput {
+        let mut zf_outputs: HashMap<String, ZFComponentOutput> = HashMap::with_capacity(1);
 
         zf_outputs.insert(
             String::from(LINK_ID_OUTPUT_STR),
-            Message::from_data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
+            ZFComponentOutput::Data(outputs.get(LINK_ID_OUTPUT_STR).unwrap().clone()),
         );
 
         Ok(zf_outputs)

--- a/zenoh-flow-examples/examples/face-detection.rs
+++ b/zenoh-flow-examples/examples/face-detection.rs
@@ -18,7 +18,7 @@ use zenoh_flow::{
     downcast, get_input,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait, RunResult,
+        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleOutput, OperatorTrait, RunOutput,
         StateTrait, Token, ZFContext, ZFError, ZFInput, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -75,7 +75,7 @@ impl FaceDetection {
         Self { state }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -86,7 +86,7 @@ impl FaceDetection {
         }
     }
 
-    pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
+    pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunOutput {
         let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let guard = ctx.lock(); //getting state

--- a/zenoh-flow-examples/examples/frame-concat.rs
+++ b/zenoh-flow-examples/examples/frame-concat.rs
@@ -18,7 +18,7 @@ use zenoh_flow::{
     downcast, get_input,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnRun, OperatorTrait, RunResult, StateTrait,
+        DataTrait, FnInputRule, FnOutputRule, FnRun, OperatorTrait, RunOutput, StateTrait,
         ZFContext, ZFInput, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -67,7 +67,7 @@ impl FrameConcat {
         Self { state }
     }
 
-    pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
+    pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunOutput {
         let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let guard = ctx.lock(); //getting state

--- a/zenoh-flow-examples/examples/generic-sink.rs
+++ b/zenoh-flow-examples/examples/generic-sink.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
-        FnInputRule, FnSinkRun, FutSinkResult, InputRuleResult, SinkTrait, StateTrait, Token,
+        FnInputRule, FnSinkRun, FutSinkOutput, InputRuleOutput, SinkTrait, StateTrait, Token,
         ZFContext, ZFInput,
     },
     zenoh_flow_derive::ZFState,
@@ -27,7 +27,7 @@ use zenoh_flow::{
 struct ExampleGenericSink {}
 
 impl ExampleGenericSink {
-    pub fn ir_1(_ctx: ZFContext, _inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, _inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         Ok(true)
     }
 
@@ -53,7 +53,7 @@ impl SinkTrait for ExampleGenericSink {
     fn get_run(&self, ctx: ZFContext) -> FnSinkRun {
         let gctx = ctx.lock();
         match gctx.mode {
-            0 => Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
+            0 => Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkOutput {
                 Box::pin(Self::run_1(ctx, inputs))
             }),
             _ => panic!("No way"),

--- a/zenoh-flow-examples/examples/manual-source.rs
+++ b/zenoh-flow-examples/examples/manual-source.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, sync::Arc, usize};
 
 use zenoh_flow::{
     types::{
-        DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
+        DataTrait, FnOutputRule, FnSourceRun, FutRunOutput, RunOutput, SourceTrait, StateTrait,
     },
     zf_data, zf_empty_state, ZFContext, ZFError, ZFResult,
 };
@@ -27,7 +27,7 @@ struct ManualSource;
 static LINK_ID_INPUT_INT: &str = "Int";
 
 impl ManualSource {
-    async fn run(_ctx: ZFContext) -> RunResult {
+    async fn run(_ctx: ZFContext) -> RunOutput {
         let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::with_capacity(1);
 
         println!("> Please input a number: ");
@@ -49,8 +49,8 @@ impl ManualSource {
 }
 
 impl SourceTrait for ManualSource {
-    fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
-        Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run(ctx)) })
+    fn get_run(&self, _ctx: ZFContext) -> FnSourceRun {
+        Box::new(|ctx: ZFContext| -> FutRunOutput { Box::pin(Self::run(ctx)) })
     }
 
     fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
@@ -65,7 +65,7 @@ impl SourceTrait for ManualSource {
 zenoh_flow::export_source!(register);
 
 extern "C" fn register(
-    configuration: Option<HashMap<String, String>>,
+    _configuration: Option<HashMap<String, String>>,
 ) -> ZFResult<Box<dyn zenoh_flow::SourceTrait + Send>> {
     Ok(Box::new(ManualSource {}) as Box<dyn zenoh_flow::SourceTrait + Send>)
 }

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -19,13 +19,13 @@ use std::{
     io::{prelude::*, BufReader},
     path::Path,
 };
+use zenoh_flow::ZFComponentOutput;
 use zenoh_flow::{
     downcast, get_input,
-    runtime::message::Message,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleResult, OperatorTrait,
-        OutputRuleResult, RunResult, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFResult,
+        DataTrait, FnInputRule, FnOutputRule, FnRun, InputRuleOutput, OperatorTrait,
+        OutputRuleOutput, RunOutput, StateTrait, Token, ZFContext, ZFError, ZFInput, ZFResult,
     },
     zenoh_flow_derive::ZFState,
     zf_data, zf_spin_lock,
@@ -113,7 +113,7 @@ impl ObjDetection {
         Ok(Self { state })
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -124,7 +124,7 @@ impl ObjDetection {
         }
     }
 
-    pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunResult {
+    pub fn run_1(ctx: ZFContext, mut inputs: ZFInput) -> RunOutput {
         let scale = 1.0 / 255.0;
         let mean = core::Scalar::new(0f64, 0f64, 0f64, 0f64);
 
@@ -320,10 +320,10 @@ impl ObjDetection {
         Ok(results)
     }
 
-    pub fn or_1(_ctx: ZFContext, outputs: HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleResult {
+    pub fn or_1(_ctx: ZFContext, outputs: HashMap<String, Arc<dyn DataTrait>>) -> OutputRuleOutput {
         let mut results = HashMap::new();
         for (k, v) in outputs {
-            results.insert(k, Message::from_data(v));
+            results.insert(k, ZFComponentOutput::Data(v));
         }
         Ok(results)
     }

--- a/zenoh-flow-examples/examples/random-source.rs
+++ b/zenoh-flow-examples/examples/random-source.rs
@@ -17,11 +17,11 @@ use std::collections::HashMap;
 use zenoh_flow::{
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
+        DataTrait, FnOutputRule, FnSourceRun, FutRunOutput, RunOutput, SourceTrait, StateTrait,
         ZFContext, ZFResult,
     },
     zenoh_flow_derive::ZFState,
-    zf_data, zf_empty_state,
+    zf_data, zf_empty_state, ZFPortID,
 };
 use zenoh_flow_examples::RandomData;
 
@@ -31,8 +31,8 @@ static SOURCE: &str = "Random";
 struct ExampleRandomSource {}
 
 impl ExampleRandomSource {
-    async fn run_1(_ctx: ZFContext) -> RunResult {
-        let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
+    async fn run_1(_ctx: ZFContext) -> RunOutput {
+        let mut results: HashMap<ZFPortID, Arc<dyn DataTrait>> = HashMap::new();
         let d = RandomData {
             d: rand::random::<u64>(),
         };
@@ -43,8 +43,8 @@ impl ExampleRandomSource {
 }
 
 impl SourceTrait for ExampleRandomSource {
-    fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
-        Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) })
+    fn get_run(&self, _ctx: ZFContext) -> FnSourceRun {
+        Box::new(|ctx: ZFContext| -> FutRunOutput { Box::pin(Self::run_1(ctx)) })
     }
 
     fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
@@ -60,7 +60,7 @@ impl SourceTrait for ExampleRandomSource {
 zenoh_flow::export_source!(register);
 
 extern "C" fn register(
-    configuration: Option<HashMap<String, String>>,
+    _configuration: Option<HashMap<String, String>>,
 ) -> ZFResult<Box<dyn zenoh_flow::SourceTrait + Send>> {
     Ok(Box::new(ExampleRandomSource {}) as Box<dyn zenoh_flow::SourceTrait + Send>)
 }

--- a/zenoh-flow-examples/examples/video-file-source.rs
+++ b/zenoh-flow-examples/examples/video-file-source.rs
@@ -19,7 +19,7 @@ use zenoh_flow::{
     downcast_mut,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnOutputRule, FnSourceRun, FutRunResult, RunResult, SourceTrait, StateTrait,
+        DataTrait, FnOutputRule, FnSourceRun, FutRunOutput, RunOutput, SourceTrait, StateTrait,
         ZFContext, ZFError, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -91,7 +91,7 @@ impl VideoSource {
         Self { state }
     }
 
-    async fn run_1(ctx: ZFContext) -> RunResult {
+    async fn run_1(ctx: ZFContext) -> RunOutput {
         let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.async_lock().await;
@@ -152,7 +152,7 @@ impl SourceTrait for VideoSource {
     fn get_run(&self, ctx: ZFContext) -> FnSourceRun {
         let gctx = ctx.lock();
         match gctx.mode {
-            0 => Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) }),
+            0 => Box::new(|ctx: ZFContext| -> FutRunOutput { Box::pin(Self::run_1(ctx)) }),
             _ => panic!("No way"),
         }
     }

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -23,8 +23,8 @@ use zenoh_flow::{
     model::link::ZFPortDescriptor,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunResult, FutSinkResult,
-        InputRuleResult, RunResult, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
+        DataTrait, FnInputRule, FnOutputRule, FnSinkRun, FnSourceRun, FutRunOutput, FutSinkOutput,
+        InputRuleOutput, RunOutput, SinkTrait, SourceTrait, StateTrait, Token, ZFContext, ZFError,
         ZFInput, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -90,7 +90,7 @@ impl CameraSource {
         Self { state }
     }
 
-    async fn run_1(ctx: ZFContext) -> RunResult {
+    async fn run_1(ctx: ZFContext) -> RunOutput {
         let mut results: HashMap<String, Arc<dyn DataTrait>> = HashMap::new();
 
         let mut guard = ctx.async_lock().await;
@@ -135,7 +135,7 @@ impl CameraSource {
 
 impl SourceTrait for CameraSource {
     fn get_run(&self, _ctx: ZFContext) -> FnSourceRun {
-        Box::new(|ctx: ZFContext| -> FutRunResult { Box::pin(Self::run_1(ctx)) })
+        Box::new(|ctx: ZFContext| -> FutRunOutput { Box::pin(Self::run_1(ctx)) })
     }
 
     fn get_output_rule(&self, _ctx: ZFContext) -> Box<FnOutputRule> {
@@ -167,7 +167,7 @@ impl VideoSink {
         Self { state }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -205,7 +205,7 @@ impl SinkTrait for VideoSink {
     }
 
     fn get_run(&self, _ctx: ZFContext) -> FnSinkRun {
-        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
+        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkOutput {
             Box::pin(Self::run_1(ctx, inputs))
         })
     }

--- a/zenoh-flow-examples/examples/video-sink.rs
+++ b/zenoh-flow-examples/examples/video-sink.rs
@@ -18,7 +18,7 @@ use zenoh_flow::{
     get_input,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnInputRule, FnSinkRun, FutSinkResult, InputRuleResult, SinkTrait, StateTrait,
+        DataTrait, FnInputRule, FnSinkRun, FutSinkOutput, InputRuleOutput, SinkTrait, StateTrait,
         Token, ZFContext, ZFError, ZFInput, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -45,7 +45,7 @@ impl VideoSink {
         Self {}
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -88,7 +88,7 @@ impl SinkTrait for VideoSink {
     }
 
     fn get_run(&self, _ctx: ZFContext) -> FnSinkRun {
-        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
+        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkOutput {
             Box::pin(Self::run_1(ctx, inputs))
         })
     }

--- a/zenoh-flow-examples/examples/zenoh-sink.rs
+++ b/zenoh-flow-examples/examples/zenoh-sink.rs
@@ -18,7 +18,7 @@ use zenoh_flow::{
     downcast, get_input,
     serde::{Deserialize, Serialize},
     types::{
-        DataTrait, FnInputRule, FnSinkRun, FutSinkResult, InputRuleResult, SinkTrait, StateTrait,
+        DataTrait, FnInputRule, FnSinkRun, FutSinkOutput, InputRuleOutput, SinkTrait, StateTrait,
         Token, ZFContext, ZFError, ZFInput, ZFResult,
     },
     zenoh_flow_derive::ZFState,
@@ -59,7 +59,7 @@ impl ExampleGenericZenohSink {
         }
     }
 
-    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleResult {
+    pub fn ir_1(_ctx: ZFContext, inputs: &mut HashMap<String, Token>) -> InputRuleOutput {
         if let Some(token) = inputs.get(INPUT) {
             match token {
                 Token::Ready(_) => Ok(true),
@@ -94,7 +94,7 @@ impl SinkTrait for ExampleGenericZenohSink {
     }
 
     fn get_run(&self, _ctx: ZFContext) -> FnSinkRun {
-        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkResult {
+        Box::new(|ctx: ZFContext, inputs: ZFInput| -> FutSinkOutput {
             Box::pin(Self::run_1(ctx, inputs))
         })
     }

--- a/zenoh-flow/src/macros.rs
+++ b/zenoh-flow/src/macros.rs
@@ -117,23 +117,24 @@ macro_rules! get_state {
 macro_rules! get_input {
     ($ident : ident, $index : expr, $map : expr) => {
         match $map.get_mut(&$index) {
-            Some(mut data) => match &data.value {
-                zenoh_flow::types::ZFValue::Deserialized(de) => {
+            Some(mut data_message) => match &data_message.data {
+                zenoh_flow::runtime::message::ZFSerDeData::Deserialized(de) => {
                     match zenoh_flow::downcast!($ident, de) {
-                        Some(value) => Ok((data.timestamp.clone(), value.clone())),
+                        Some(data) => Ok((data_message.timestamp.clone(), data.clone())),
                         None => Err(zenoh_flow::types::ZFError::InvalidData($index)),
                     }
                 }
-                zenoh_flow::types::ZFValue::Serialized(ser) => {
+                zenoh_flow::runtime::message::ZFSerDeData::Serialized(ser) => {
                     let de: Arc<dyn DataTrait> = bincode::deserialize(&ser)
                         .map_err(|_| zenoh_flow::types::ZFError::DeseralizationError)?;
 
-                    (*data).value = zenoh_flow::types::ZFValue::Deserialized(de);
+                    (*data_message).data =
+                        zenoh_flow::runtime::message::ZFSerDeData::Deserialized(de);
 
-                    match &data.value {
-                        zenoh_flow::types::ZFValue::Deserialized(de) => {
+                    match &data_message.data {
+                        zenoh_flow::runtime::message::ZFSerDeData::Deserialized(de) => {
                             match zenoh_flow::downcast!($ident, de) {
-                                Some(value) => Ok((data.timestamp.clone(), value.clone())),
+                                Some(data) => Ok((data_message.timestamp.clone(), data.clone())),
                                 None => Err(zenoh_flow::types::ZFError::InvalidData($index)),
                             }
                         }

--- a/zenoh-flow/src/runtime/message.rs
+++ b/zenoh-flow/src/runtime/message.rs
@@ -14,95 +14,87 @@
 
 extern crate serde;
 
-use crate::DataTrait;
+use crate::{DataTrait, ZFComponentOutput, ZFError, ZFResult};
 use async_std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use uhlc::Timestamp;
 
-// TODO: improve
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ZFDataMessage {
+pub enum ZFSerDeData {
     Serialized(Arc<Vec<u8>>),
     #[serde(skip_serializing, skip_deserializing)]
     // Deserialized data is never serialized directly
     Deserialized(Arc<dyn DataTrait>),
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZFDataMessage {
+    pub data: ZFSerDeData,
+    pub timestamp: Timestamp,
+}
+
 impl ZFDataMessage {
-    pub fn new_serialized(data: Arc<Vec<u8>>) -> Self {
-        Self::Serialized(data)
+    pub fn new(data: ZFSerDeData, timestamp: Timestamp) -> Self {
+        Self { data, timestamp }
     }
 
-    pub fn serialized_data(&self) -> &[u8] {
-        match self {
-            Self::Serialized(data) => data,
-            _ => panic!(),
+    pub fn new_serialized(data: Arc<Vec<u8>>, timestamp: Timestamp) -> Self {
+        Self {
+            data: ZFSerDeData::Serialized(data),
+            timestamp,
         }
     }
 
-    pub fn new_deserialized(data: Arc<dyn DataTrait>) -> Self {
-        Self::Deserialized(data)
-    }
-
-    pub fn deserialized_data(&self) -> Arc<dyn DataTrait> {
-        match self {
-            Self::Deserialized(data) => data.clone(),
-            _ => panic!(),
+    pub fn new_deserialized(data: Arc<dyn DataTrait>, timestamp: Timestamp) -> Self {
+        Self {
+            data: ZFSerDeData::Deserialized(data),
+            timestamp,
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ZFCtrlMessage {
+pub enum ZFControlMessage {
     ReadyToMigrate,
     ChangeMode(u8, u128),
     Watermark,
 }
 
-//TODO: improve, change name
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Message {
+pub enum ZFMessage {
     Data(ZFDataMessage),
-    Ctrl(ZFCtrlMessage),
-}
-
-impl Message {
-    pub fn from_raw(data: Arc<Vec<u8>>) -> Self {
-        Message::Data(ZFDataMessage::new_serialized(data))
-    }
-
-    pub fn from_data(data: Arc<dyn DataTrait>) -> Self {
-        Message::Data(ZFDataMessage::new_deserialized(data))
-    }
-}
-
-// TODO: improve
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ZFMessage {
-    pub timestamp: Timestamp,
-    pub message: Message,
+    Control(ZFControlMessage),
 }
 
 impl ZFMessage {
-    pub fn from_raw(timestamp: Timestamp, data: Arc<Vec<u8>>) -> Self {
-        Self {
-            timestamp,
-            message: Message::from_raw(data),
+    pub fn from_component_output(output: ZFComponentOutput, timestamp: Timestamp) -> Self {
+        match output {
+            ZFComponentOutput::Control(c) => Self::Control(c),
+            ZFComponentOutput::Data(d) => Self::Data(ZFDataMessage::new_deserialized(d, timestamp)),
         }
     }
 
-    pub fn from_data(timestamp: Timestamp, data: Arc<dyn DataTrait>) -> Self {
-        Self {
-            timestamp,
-            message: Message::from_data(data),
-        }
-    }
+    pub fn serialize_bincode(&self) -> ZFResult<Vec<u8>> {
+        match &self {
+            ZFMessage::Control(_) => {
+                bincode::serialize(&self).map_err(|_| ZFError::SerializationError)
+            }
+            ZFMessage::Data(data_message) => match &data_message.data {
+                ZFSerDeData::Serialized(_) => {
+                    bincode::serialize(&self).map_err(|_| ZFError::SerializationError)
+                }
+                ZFSerDeData::Deserialized(de) => {
+                    let serialized_data =
+                        Arc::new(bincode::serialize(&de).map_err(|_| ZFError::SerializationError)?);
+                    let serialized_message = ZFMessage::Data(ZFDataMessage::new_serialized(
+                        serialized_data,
+                        data_message.timestamp.clone(),
+                    ));
 
-    pub fn from_message(timestamp: Timestamp, msg: ZFDataMessage) -> Self {
-        Self {
-            timestamp,
-            message: Message::Data(msg),
+                    bincode::serialize(&serialized_message).map_err(|_| ZFError::SerializationError)
+                }
+            },
         }
     }
 }

--- a/zenoh-flow/tests/link.rs
+++ b/zenoh-flow/tests/link.rs
@@ -14,7 +14,6 @@
 
 use zenoh_flow::async_std::sync::Arc;
 use zenoh_flow::runtime::graph::link::{link, ZFLinkReceiver, ZFLinkSender};
-use zenoh_flow::{ZFError, ZFResult};
 
 async fn same_task_simple() {
     let size = 2;


### PR DESCRIPTION
To pave the way for the implementation of the deadlines the `ZFMessage`
structure needed a complete redo. This commit tries to achieve that goal.

The most noticeable changes are:
- in `types.rs` the types `*Result` were renamed to `*Output` to reflect more
their nature;

- to better separate what Zenoh Flow exposes to developers, the output of
components has been changed:

  - the run function is expected to return a
  `HashMap<ZFPortID, Arc<dyn DataTrait>>`,

  - the output_rule function is expected to return a
  `HashMap<ZFPortID, ZFComponentOutput>` where a `ZFComponentOutput` is either a
  "Control Message" or some Data (i.e. a `dyn DataTrait`);

- a `ZFMessage` is either a `ZFControlMessage` or a `ZFDataMessage`.
"Intermediary" types (`ZFData`, `Message`, `ZFValue`) were removed.

All examples were updated and they all compile (on my mac for the aarch64
architecture…). The "fizzbuzz-multiple-runtimes" example works.