### PR TITLE
Add explicit support for raw data sent by the user

### DIFF
--- a/zenoh-flow-examples/examples/camera-source.rs
+++ b/zenoh-flow-examples/examples/camera-source.rs
@@ -18,7 +18,7 @@ use opencv::{core, prelude::*, videoio};
 use std::collections::HashMap;
 use zenoh_flow::{
     default_output_rule, downcast_mut, types::ZFResult, zenoh_flow_derive::ZFState, zf_data_raw,
-    zf_spin_lock, Component, SerDeData, OutputRule, Source, State,
+    zf_spin_lock, Component, OutputRule, SerDeData, Source, State,
 };
 
 #[derive(Debug)]
@@ -153,7 +153,6 @@ impl Source for CameraSource {
 
         let mut buf = opencv::types::VectorOfu8::new();
         opencv::imgcodecs::imencode(".jpg", &reduced, &mut buf, &encode_options).unwrap();
-
 
         results.insert(SOURCE.into(), zf_data_raw!(buf.into()));
 

--- a/zenoh-flow-examples/examples/counter-source.rs
+++ b/zenoh-flow-examples/examples/counter-source.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use zenoh_flow::{default_output_rule, Component, OutputRule, PortId, Source};
 use zenoh_flow::{
-    types::ZFResult, zenoh_flow_derive::ZFState, zf_data, zf_empty_state, Data, State,
+    types::ZFResult, zenoh_flow_derive::ZFState, zf_data, zf_empty_state, SerDeData, State,
 };
 use zenoh_flow_examples::ZFUsize;
 
@@ -35,8 +35,8 @@ impl Source for CountSource {
         &self,
         _context: &mut zenoh_flow::Context,
         _state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn Data>>> {
-        let mut results: HashMap<PortId, Arc<dyn Data>> = HashMap::new();
+    ) -> ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
+        let mut results: HashMap<PortId, SerDeData> = HashMap::new();
         let d = ZFUsize(COUNTER.fetch_add(1, Ordering::AcqRel));
         results.insert(SOURCE.into(), zf_data!(d));
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
@@ -49,7 +49,7 @@ impl OutputRule for CountSource {
         &self,
         _context: &mut zenoh_flow::Context,
         state: &mut Box<dyn zenoh_flow::State>,
-        outputs: HashMap<PortId, Arc<dyn Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> ZFResult<HashMap<zenoh_flow::PortId, zenoh_flow::ComponentOutput>> {
         default_output_rule(state, outputs)
     }

--- a/zenoh-flow-examples/examples/example-buzz.rs
+++ b/zenoh-flow-examples/examples/example-buzz.rs
@@ -20,7 +20,7 @@ use zenoh_flow::{
     default_input_rule, default_output_rule, export_operator, get_input, types::ZFResult, zf_data,
     Component, ComponentOutput, InputRule, Operator, OutputRule, State, Token,
 };
-use zenoh_flow::{downcast, Context, Data};
+use zenoh_flow::{downcast, Context, SerDeData};
 use zenoh_flow_examples::{ZFString, ZFUsize};
 
 struct BuzzOperator;
@@ -40,8 +40,8 @@ impl Operator for BuzzOperator {
         _context: &mut Context,
         dyn_state: &mut Box<dyn State>,
         inputs: &mut HashMap<zenoh_flow::PortId, DataMessage>,
-    ) -> ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn Data>>> {
-        let mut results = HashMap::<zenoh_flow::PortId, Arc<dyn Data>>::with_capacity(1);
+    ) -> ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
+        let mut results = HashMap::<zenoh_flow::PortId, SerDeData>::with_capacity(1);
 
         let state = downcast!(BuzzState, dyn_state).unwrap();
         let (_, fizz) = get_input!(ZFString, String::from(LINK_ID_INPUT_STR), inputs)?;
@@ -97,7 +97,7 @@ impl OutputRule for BuzzOperator {
         &self,
         _context: &mut Context,
         state: &mut Box<dyn State>,
-        outputs: HashMap<zenoh_flow::PortId, Arc<dyn Data>>,
+        outputs: HashMap<zenoh_flow::PortId, SerDeData>,
     ) -> ZFResult<HashMap<zenoh_flow::PortId, ComponentOutput>> {
         default_output_rule(state, outputs)
     }

--- a/zenoh-flow-examples/examples/example-fizz.rs
+++ b/zenoh-flow-examples/examples/example-fizz.rs
@@ -20,7 +20,7 @@ use zenoh_flow::{
     default_input_rule, default_output_rule, export_operator, get_input, types::ZFResult, zf_data,
     zf_empty_state, Component, ComponentOutput, InputRule, Operator, OutputRule, State,
 };
-use zenoh_flow::{Context, Data, PortId};
+use zenoh_flow::{Context, PortId, SerDeData};
 use zenoh_flow_examples::{ZFString, ZFUsize};
 
 struct FizzOperator;
@@ -56,8 +56,8 @@ impl Operator for FizzOperator {
         _context: &mut Context,
         _state: &mut Box<dyn State>,
         inputs: &mut HashMap<PortId, DataMessage>,
-    ) -> ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn zenoh_flow::Data>>> {
-        let mut results = HashMap::<PortId, Arc<dyn Data>>::with_capacity(2);
+    ) -> ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
+        let mut results = HashMap::<PortId, SerDeData>::with_capacity(2);
 
         let mut fizz = ZFString::from("");
 
@@ -79,7 +79,7 @@ impl OutputRule for FizzOperator {
         &self,
         _context: &mut Context,
         state: &mut Box<dyn State>,
-        outputs: HashMap<PortId, Arc<dyn Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> ZFResult<HashMap<zenoh_flow::PortId, ComponentOutput>> {
         default_output_rule(state, outputs)
     }

--- a/zenoh-flow-examples/examples/manual-source.rs
+++ b/zenoh-flow-examples/examples/manual-source.rs
@@ -15,8 +15,8 @@
 use async_trait::async_trait;
 use std::{collections::HashMap, sync::Arc, usize};
 use zenoh_flow::{
-    zf_data, zf_empty_state, Component, Context, Data, OutputRule, PortId, Source, State, ZFError,
-    ZFResult,
+    zf_data, zf_empty_state, Component, Context, OutputRule, PortId, SerDeData, Source, State,
+    ZFError, ZFResult,
 };
 use zenoh_flow_examples::ZFUsize;
 
@@ -30,8 +30,8 @@ impl Source for ManualSource {
         &self,
         _context: &mut Context,
         _state: &mut Box<dyn State>,
-    ) -> ZFResult<HashMap<PortId, Arc<dyn Data>>> {
-        let mut results: HashMap<PortId, Arc<dyn Data>> = HashMap::with_capacity(1);
+    ) -> ZFResult<HashMap<PortId, SerDeData>> {
+        let mut results: HashMap<PortId, SerDeData> = HashMap::with_capacity(1);
 
         println!("> Please input a number: ");
         let mut number = String::new();
@@ -66,7 +66,7 @@ impl OutputRule for ManualSource {
         &self,
         _context: &mut Context,
         state: &mut Box<dyn State>,
-        outputs: HashMap<PortId, Arc<dyn Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> ZFResult<HashMap<PortId, zenoh_flow::ComponentOutput>> {
         zenoh_flow::default_output_rule(state, outputs)
     }

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -20,16 +20,16 @@ use std::{
     path::Path,
 };
 use zenoh_flow::{
-    default_input_rule, default_output_rule, Component, ComponentOutput, Context, Data, InputRule,
+    default_input_rule, default_output_rule, Component, ComponentOutput, Context, SerDeData, InputRule,
     Operator, OutputRule, PortId, State,
 };
 use zenoh_flow::{
-    downcast, get_input,
+    downcast, get_input_raw,
     types::{Token, ZFResult},
     zenoh_flow_derive::ZFState,
-    zf_data, zf_spin_lock,
+    zf_data_raw, zf_spin_lock,
 };
-use zenoh_flow_examples::ZFBytes;
+
 
 use opencv::core::prelude::MatTrait;
 use opencv::dnn::NetTrait;
@@ -123,7 +123,7 @@ impl OutputRule for ObjDetection {
         &self,
         _context: &mut Context,
         state: &mut Box<dyn zenoh_flow::State>,
-        outputs: HashMap<PortId, Arc<dyn zenoh_flow::Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> ZFResult<HashMap<zenoh_flow::PortId, ComponentOutput>> {
         default_output_rule(state, outputs)
     }
@@ -135,11 +135,11 @@ impl Operator for ObjDetection {
         _context: &mut Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
         inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
-    ) -> ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn zenoh_flow::Data>>> {
+    ) -> ZFResult<HashMap<zenoh_flow::PortId,SerDeData>> {
         let scale = 1.0 / 255.0;
         let mean = core::Scalar::new(0f64, 0f64, 0f64, 0f64);
 
-        let mut results: HashMap<PortId, Arc<dyn Data>> = HashMap::with_capacity(1);
+        let mut results: HashMap<PortId, SerDeData> = HashMap::with_capacity(1);
 
         let mut detections: opencv::types::VectorOfMat = core::Vector::new();
 
@@ -161,11 +161,11 @@ impl Operator for ObjDetection {
             core::Scalar::new(255f64, 0f64, 0f64, -1f64),
         ];
 
-        let (_, data) = get_input!(ZFBytes, String::from(INPUT), inputs).unwrap();
+        let (_, data) = get_input_raw!(String::from(INPUT), inputs).unwrap();
 
         // Decode Image
         let mut frame = opencv::imgcodecs::imdecode(
-            &opencv::types::VectorOfu8::from_iter(data.0),
+            &opencv::types::VectorOfu8::from_iter(data),
             opencv::imgcodecs::IMREAD_COLOR,
         )
         .unwrap();
@@ -319,7 +319,7 @@ impl Operator for ObjDetection {
         let mut buf = opencv::types::VectorOfu8::new();
         opencv::imgcodecs::imencode(".jpg", &frame, &mut buf, &encode_options).unwrap();
 
-        results.insert(OUTPUT.into(), zf_data!(ZFBytes(buf.into())));
+        results.insert(OUTPUT.into(), zf_data_raw!(buf.into()));
 
         Ok(results)
     }

--- a/zenoh-flow-examples/examples/object-detection-dnn.rs
+++ b/zenoh-flow-examples/examples/object-detection-dnn.rs
@@ -20,8 +20,8 @@ use std::{
     path::Path,
 };
 use zenoh_flow::{
-    default_input_rule, default_output_rule, Component, ComponentOutput, Context, SerDeData, InputRule,
-    Operator, OutputRule, PortId, State,
+    default_input_rule, default_output_rule, Component, ComponentOutput, Context, InputRule,
+    Operator, OutputRule, PortId, SerDeData, State,
 };
 use zenoh_flow::{
     downcast, get_input_raw,
@@ -29,7 +29,6 @@ use zenoh_flow::{
     zenoh_flow_derive::ZFState,
     zf_data_raw, zf_spin_lock,
 };
-
 
 use opencv::core::prelude::MatTrait;
 use opencv::dnn::NetTrait;
@@ -135,7 +134,7 @@ impl Operator for ObjDetection {
         _context: &mut Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
         inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
-    ) -> ZFResult<HashMap<zenoh_flow::PortId,SerDeData>> {
+    ) -> ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
         let scale = 1.0 / 255.0;
         let mean = core::Scalar::new(0f64, 0f64, 0f64, 0f64);
 

--- a/zenoh-flow-examples/examples/random-source.rs
+++ b/zenoh-flow-examples/examples/random-source.rs
@@ -16,8 +16,8 @@ use async_std::sync::Arc;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use zenoh_flow::{
-    default_output_rule, types::ZFResult, zf_data, zf_empty_state, Component, Context, Data,
-    OutputRule, PortId, Source, State,
+    default_output_rule, types::ZFResult, zf_data, zf_empty_state, Component, Context, OutputRule,
+    PortId, SerDeData, Source, State,
 };
 use zenoh_flow_examples::ZFUsize;
 
@@ -44,7 +44,7 @@ impl OutputRule for ExampleRandomSource {
         &self,
         _context: &mut Context,
         state: &mut Box<dyn zenoh_flow::State>,
-        outputs: HashMap<PortId, Arc<dyn zenoh_flow::Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> ZFResult<HashMap<PortId, zenoh_flow::ComponentOutput>> {
         default_output_rule(state, outputs)
     }
@@ -56,8 +56,8 @@ impl Source for ExampleRandomSource {
         &self,
         _context: &mut Context,
         _state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<HashMap<PortId, Arc<dyn Data>>> {
-        let mut results: HashMap<PortId, Arc<dyn Data>> = HashMap::with_capacity(1);
+    ) -> ZFResult<HashMap<PortId, SerDeData>> {
+        let mut results: HashMap<PortId, SerDeData> = HashMap::with_capacity(1);
         results.insert(SOURCE.into(), zf_data!(ZFUsize(rand::random::<usize>())));
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
         Ok(results)

--- a/zenoh-flow-examples/examples/simple-pipeline.rs
+++ b/zenoh-flow-examples/examples/simple-pipeline.rs
@@ -22,8 +22,8 @@ use zenoh_flow::async_std::stream::StreamExt;
 use zenoh_flow::async_std::sync::Arc;
 use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor};
 use zenoh_flow::{
-    default_input_rule, default_output_rule, Component, Context, Data, InputRule, OutputRule,
-    PortId, Sink, Source,
+    default_input_rule, default_output_rule, Component, Context, InputRule, OutputRule, PortId,
+    SerDeData, Sink, Source,
 };
 use zenoh_flow::{model::link::PortDescriptor, zf_data, zf_empty_state};
 use zenoh_flow::{State, ZFResult};
@@ -54,8 +54,8 @@ impl Source for CountSource {
         &self,
         _context: &mut Context,
         _state: &mut Box<dyn zenoh_flow::State>,
-    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn zenoh_flow::Data>>> {
-        let mut results: HashMap<PortId, Arc<dyn Data>> = HashMap::new();
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
+        let mut results: HashMap<PortId, SerDeData> = HashMap::new();
         let d = ZFUsize(COUNTER.fetch_add(1, Ordering::AcqRel));
         results.insert(SOURCE.into(), zf_data!(d));
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
@@ -68,7 +68,7 @@ impl OutputRule for CountSource {
         &self,
         _context: &mut Context,
         state: &mut Box<dyn zenoh_flow::State>,
-        outputs: HashMap<PortId, Arc<dyn Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, zenoh_flow::ComponentOutput>> {
         default_output_rule(state, outputs)
     }

--- a/zenoh-flow-examples/examples/sum-and-send.rs
+++ b/zenoh-flow-examples/examples/sum-and-send.rs
@@ -18,7 +18,7 @@ use zenoh_flow::zenoh_flow_derive::ZFState;
 use zenoh_flow::PortId;
 use zenoh_flow::{
     default_input_rule, default_output_rule, downcast_mut, get_input, zf_data, Component,
-    ComponentOutput, Data, InputRule, Operator, OutputRule, State, ZFResult,
+    ComponentOutput, InputRule, Operator, OutputRule, SerDeData, State, ZFResult,
 };
 use zenoh_flow_examples::ZFUsize;
 
@@ -39,8 +39,8 @@ impl Operator for SumAndSend {
         _context: &mut zenoh_flow::Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
         inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
-    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn Data>>> {
-        let mut results: HashMap<PortId, Arc<dyn Data>> = HashMap::new();
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
+        let mut results: HashMap<PortId, SerDeData> = HashMap::new();
 
         // Downcasting state to right type
         let mut state = downcast_mut!(SumAndSendState, dyn_state).unwrap();
@@ -71,7 +71,7 @@ impl OutputRule for SumAndSend {
         &self,
         _context: &mut zenoh_flow::Context,
         state: &mut Box<dyn zenoh_flow::State>,
-        outputs: HashMap<PortId, Arc<dyn Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, ComponentOutput>> {
         default_output_rule(state, outputs)
     }

--- a/zenoh-flow-examples/examples/video-file-source.rs
+++ b/zenoh-flow-examples/examples/video-file-source.rs
@@ -20,9 +20,8 @@ use zenoh_flow::{
     default_output_rule, downcast,
     types::{ZFError, ZFResult},
     zenoh_flow_derive::ZFState,
-    zf_data, zf_spin_lock, Component, Data, OutputRule, Source, State,
+    zf_data_raw, zf_spin_lock, Component, OutputRule, SerDeData, Source, State,
 };
-use zenoh_flow_examples::ZFBytes;
 
 #[derive(Debug)]
 struct VideoSource;
@@ -95,7 +94,7 @@ impl OutputRule for VideoSource {
         &self,
         _context: &mut zenoh_flow::Context,
         state: &mut Box<dyn zenoh_flow::State>,
-        outputs: HashMap<zenoh_flow::PortId, Arc<dyn zenoh_flow::Data>>,
+        outputs: HashMap<zenoh_flow::PortId, SerDeData>,
     ) -> ZFResult<HashMap<zenoh_flow::PortId, zenoh_flow::ComponentOutput>> {
         default_output_rule(state, outputs)
     }
@@ -107,8 +106,8 @@ impl Source for VideoSource {
         &self,
         _context: &mut zenoh_flow::Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<HashMap<zenoh_flow::PortId, Arc<dyn zenoh_flow::Data>>> {
-        let mut results: HashMap<zenoh_flow::PortId, Arc<dyn Data>> = HashMap::new();
+    ) -> ZFResult<HashMap<zenoh_flow::PortId, SerDeData>> {
+        let mut results: HashMap<zenoh_flow::PortId, SerDeData> = HashMap::new();
 
         let state = downcast!(VideoSourceState, dyn_state).unwrap();
 
@@ -143,7 +142,7 @@ impl Source for VideoSource {
         let mut buf = opencv::types::VectorOfu8::new();
         opencv::imgcodecs::imencode(".jpg", &frame, &mut buf, &encode_options).unwrap();
 
-        results.insert(SOURCE.into(), zf_data!(ZFBytes(buf.into())));
+        results.insert(SOURCE.into(), zf_data_raw!(buf.into()));
 
         drop(cam);
         drop(encode_options);

--- a/zenoh-flow-examples/examples/video-sink.rs
+++ b/zenoh-flow-examples/examples/video-sink.rs
@@ -17,10 +17,10 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use zenoh_flow::State;
 use zenoh_flow::{
-    default_input_rule, downcast, get_input, types::ZFResult, zenoh_flow_derive::ZFState,
+    default_input_rule, downcast, get_input_raw, types::ZFResult, zenoh_flow_derive::ZFState,
     Component, InputRule, Sink, ZFError,
 };
-use zenoh_flow_examples::ZFBytes;
+
 
 use opencv::{highgui, prelude::*};
 
@@ -81,10 +81,10 @@ impl Sink for VideoSink {
         // Downcasting to right type
         let state = downcast!(VideoState, dyn_state).unwrap();
 
-        let (_, data) = get_input!(ZFBytes, String::from(INPUT), inputs).unwrap();
+        let (_, data) = get_input_raw!(String::from(INPUT), inputs).unwrap();
 
         let decoded = opencv::imgcodecs::imdecode(
-            &opencv::types::VectorOfu8::from_iter(data.0),
+            &opencv::types::VectorOfu8::from_iter(data),
             opencv::imgcodecs::IMREAD_COLOR,
         )
         .unwrap();

--- a/zenoh-flow-examples/examples/video-sink.rs
+++ b/zenoh-flow-examples/examples/video-sink.rs
@@ -21,7 +21,6 @@ use zenoh_flow::{
     Component, InputRule, Sink, ZFError,
 };
 
-
 use opencv::{highgui, prelude::*};
 
 static INPUT: &str = "Frame";

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -13,8 +13,7 @@
 //
 
 use crate::runtime::message::DataMessage;
-use crate::{ComponentOutput, Context, PortId, Token, ZFResult};
-use async_std::sync::Arc;
+use crate::{ComponentOutput, Context, PortId, SerDeData, Token, ZFResult};
 use async_trait::async_trait;
 use std::any::Any;
 use std::collections::HashMap;
@@ -62,7 +61,7 @@ pub trait OutputRule {
         &self,
         context: &mut Context,
         state: &mut Box<dyn State>,
-        outputs: HashMap<PortId, Arc<dyn Data>>,
+        outputs: HashMap<PortId, SerDeData>,
     ) -> ZFResult<HashMap<PortId, ComponentOutput>>;
 }
 
@@ -72,7 +71,7 @@ pub trait Operator: Component + InputRule + OutputRule + Send + Sync {
         context: &mut Context,
         state: &mut Box<dyn State>,
         inputs: &mut HashMap<PortId, DataMessage>,
-    ) -> ZFResult<HashMap<PortId, Arc<dyn Data>>>;
+    ) -> ZFResult<HashMap<PortId, SerDeData>>;
 }
 
 #[async_trait]
@@ -81,7 +80,7 @@ pub trait Source: Component + OutputRule + Send + Sync {
         &self,
         context: &mut Context,
         state: &mut Box<dyn State>,
-    ) -> ZFResult<HashMap<PortId, Arc<dyn Data>>>;
+    ) -> ZFResult<HashMap<PortId, SerDeData>>;
 }
 
 #[async_trait]

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -41,9 +41,17 @@ impl Default for Context {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SerDeData {
+    Serialized(Arc<Vec<u8>>),
+    #[serde(skip_serializing, skip_deserializing)]
+    // Deserialized data is never serialized directly
+    Deserialized(Arc<dyn Data>),
+}
+
 #[derive(Debug, Clone)]
 pub enum ComponentOutput {
-    Data(Arc<dyn Data>),
+    Data(SerDeData),
     // TODO Users should not have access to all control messages. When implementing the control
     // messages change this to an enum with a "limited scope".
     Control(ControlMessage),
@@ -218,7 +226,7 @@ impl State for EmptyState {
 
 pub fn default_output_rule(
     _state: &mut Box<dyn State>,
-    outputs: HashMap<PortId, Arc<dyn Data>>,
+    outputs: HashMap<PortId, SerDeData>,
 ) -> ZFResult<HashMap<PortId, ComponentOutput>> {
     let mut results = HashMap::with_capacity(outputs.len());
     for (k, v) in outputs {


### PR DESCRIPTION
This PR contains the code that enables users to explicitly sent `raw` data as a `Vec<u8>` instead of wrapping it on some specific structure.

This is beneficial for rust->c++->rust graphs.

