### PR TITLE
refacto: Source now uses `port_id` from YAML declaration

### DIFF
--- a/zenoh-flow-examples/examples/camera-source.rs
+++ b/zenoh-flow-examples/examples/camera-source.rs
@@ -43,8 +43,6 @@ impl std::fmt::Debug for CameraState {
     }
 }
 
-static SOURCE: &str = "Frame";
-
 impl CameraState {
     fn new(configuration: &Option<HashMap<String, String>>) -> Self {
         let (camera, resolution, delay) = match configuration {
@@ -118,7 +116,7 @@ impl Source for CameraSource {
         &self,
         _context: &mut zenoh_flow::Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<(zenoh_flow::PortId, SerDeData)> {
+    ) -> ZFResult<SerDeData> {
         let state = downcast_mut!(CameraState, dyn_state).unwrap();
 
         let mut cam = zf_spin_lock!(state.camera);
@@ -143,7 +141,7 @@ impl Source for CameraSource {
 
         async_std::task::sleep(std::time::Duration::from_millis(state.delay)).await;
 
-        Ok((SOURCE.into(), zf_data_raw!(buf.into())))
+        Ok(zf_data_raw!(buf.into()))
     }
 }
 

--- a/zenoh-flow-examples/examples/counter-source.rs
+++ b/zenoh-flow-examples/examples/counter-source.rs
@@ -22,8 +22,6 @@ use zenoh_flow::{
 use zenoh_flow::{Node, Source};
 use zenoh_flow_examples::ZFUsize;
 
-static SOURCE: &str = "Counter";
-
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, ZFState)]
@@ -35,10 +33,10 @@ impl Source for CountSource {
         &self,
         _context: &mut zenoh_flow::Context,
         _state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<(zenoh_flow::PortId, SerDeData)> {
+    ) -> ZFResult<SerDeData> {
         let d = ZFUsize(COUNTER.fetch_add(1, Ordering::AcqRel));
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
-        Ok((SOURCE.into(), zf_data!(d)))
+        Ok(zf_data!(d))
     }
 }
 

--- a/zenoh-flow-examples/examples/manual-source.rs
+++ b/zenoh-flow-examples/examples/manual-source.rs
@@ -15,13 +15,11 @@
 use async_trait::async_trait;
 use std::{collections::HashMap, sync::Arc, usize};
 use zenoh_flow::{
-    zf_data, zf_empty_state, Context, Node, PortId, SerDeData, Source, State, ZFError, ZFResult,
+    zf_data, zf_empty_state, Context, Node, SerDeData, Source, State, ZFError, ZFResult,
 };
 use zenoh_flow_examples::ZFUsize;
 
 struct ManualSource;
-
-static LINK_ID_INPUT_INT: &str = "Int";
 
 #[async_trait]
 impl Source for ManualSource {
@@ -29,7 +27,7 @@ impl Source for ManualSource {
         &self,
         _context: &mut Context,
         _state: &mut Box<dyn State>,
-    ) -> ZFResult<(PortId, SerDeData)> {
+    ) -> ZFResult<SerDeData> {
         println!("> Please input a number: ");
         let mut number = String::new();
         async_std::io::stdin()
@@ -42,7 +40,7 @@ impl Source for ManualSource {
             Err(_) => return Err(ZFError::GenericError),
         };
 
-        Ok((LINK_ID_INPUT_INT.into(), zf_data!(ZFUsize(value))))
+        Ok(zf_data!(ZFUsize(value)))
     }
 }
 

--- a/zenoh-flow-examples/examples/random-source.rs
+++ b/zenoh-flow-examples/examples/random-source.rs
@@ -16,11 +16,9 @@ use async_std::sync::Arc;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use zenoh_flow::{
-    types::ZFResult, zf_data, zf_empty_state, Context, Node, PortId, SerDeData, Source, State,
+    types::ZFResult, zf_data, zf_empty_state, Context, Node, SerDeData, Source, State,
 };
 use zenoh_flow_examples::ZFUsize;
-
-static SOURCE: &str = "Random";
 
 #[derive(Debug)]
 struct ExampleRandomSource;
@@ -44,9 +42,9 @@ impl Source for ExampleRandomSource {
         &self,
         _context: &mut Context,
         _state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<(PortId, SerDeData)> {
+    ) -> ZFResult<SerDeData> {
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
-        Ok((SOURCE.into(), zf_data!(ZFUsize(rand::random::<usize>()))))
+        Ok(zf_data!(ZFUsize(rand::random::<usize>())))
     }
 }
 

--- a/zenoh-flow-examples/examples/simple-pipeline.rs
+++ b/zenoh-flow-examples/examples/simple-pipeline.rs
@@ -51,10 +51,10 @@ impl Source for CountSource {
         &self,
         _context: &mut Context,
         _state: &mut Box<dyn zenoh_flow::State>,
-    ) -> zenoh_flow::ZFResult<(zenoh_flow::PortId, SerDeData)> {
+    ) -> zenoh_flow::ZFResult<SerDeData> {
         let d = ZFUsize(COUNTER.fetch_add(1, Ordering::AcqRel));
         async_std::task::sleep(std::time::Duration::from_secs(1)).await;
-        Ok((SOURCE.into(), zf_data!(d)))
+        Ok(zf_data!(d))
     }
 }
 

--- a/zenoh-flow-examples/examples/video-file-source.rs
+++ b/zenoh-flow-examples/examples/video-file-source.rs
@@ -45,8 +45,6 @@ impl std::fmt::Debug for VideoSourceState {
     }
 }
 
-static SOURCE: &str = "Frame";
-
 impl VideoSourceState {
     fn new(configuration: &Option<HashMap<String, String>>) -> Self {
         // Configuration is mandatory
@@ -95,7 +93,7 @@ impl Source for VideoSource {
         &self,
         _context: &mut zenoh_flow::Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
-    ) -> ZFResult<(zenoh_flow::PortId, SerDeData)> {
+    ) -> ZFResult<SerDeData> {
         let state = downcast!(VideoSourceState, dyn_state).unwrap();
 
         let mut cam = zf_spin_lock!(state.camera);
@@ -135,7 +133,7 @@ impl Source for VideoSource {
 
         async_std::task::sleep(std::time::Duration::from_millis(state.delay)).await;
 
-        Ok((SOURCE.into(), zf_data_raw!(buf.into())))
+        Ok(zf_data_raw!(buf.into()))
     }
 }
 

--- a/zenoh-flow-examples/examples/video-pipeline.rs
+++ b/zenoh-flow-examples/examples/video-pipeline.rs
@@ -79,7 +79,7 @@ impl Source for CameraSource {
         &self,
         _context: &mut zenoh_flow::Context,
         dyn_state: &mut Box<dyn zenoh_flow::State>,
-    ) -> zenoh_flow::ZFResult<(zenoh_flow::PortId, SerDeData)> {
+    ) -> zenoh_flow::ZFResult<SerDeData> {
         // Downcasting to right type
         let state = downcast!(CameraState, dyn_state).unwrap();
         let data: Vec<u8>;
@@ -112,7 +112,7 @@ impl Source for CameraSource {
         }
 
         async_std::task::sleep(std::time::Duration::from_millis(state.delay)).await;
-        Ok((SOURCE.into(), zf_data_raw!(data)))
+        Ok(zf_data_raw!(data))
     }
 }
 

--- a/zenoh-flow/src/runtime/runners/source.rs
+++ b/zenoh-flow/src/runtime/runners/source.rs
@@ -80,6 +80,7 @@ impl SourceRunner {
 
     pub async fn run(&self) -> ZFResult<()> {
         let mut context = Context::default();
+        let id: Arc<str> = self.record.output.port_id.clone().into();
 
         loop {
             // Guards are taken at the beginning of each iteration to allow interleaving.
@@ -87,7 +88,7 @@ impl SourceRunner {
             let mut state = self.state.write().await;
 
             // Running
-            let (id, output) = self.source.run(&mut context, &mut state).await?;
+            let output = self.source.run(&mut context, &mut state).await?;
 
             let timestamp = self.hlc.new_timestamp();
 

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -72,11 +72,7 @@ pub trait Operator: Node + Send + Sync {
 
 #[async_trait]
 pub trait Source: Node + Send + Sync {
-    async fn run(
-        &self,
-        context: &mut Context,
-        state: &mut Box<dyn State>,
-    ) -> ZFResult<(PortId, SerDeData)>;
+    async fn run(&self, context: &mut Context, state: &mut Box<dyn State>) -> ZFResult<SerDeData>;
 }
 
 #[async_trait]


### PR DESCRIPTION
To have similar behavior compared to Sink — which gets the input based on the `port_id` declared in the YAML file.