### PR TITLE
Simplify Zenoh Flow link implementation

### DIFF
--- a/zenoh-flow/src/runtime/graph/link.rs
+++ b/zenoh-flow/src/runtime/graph/link.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::{PortId, ZFResult};
-use async_std::sync::{Arc};
+use async_std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct LinkSender<T> {


### PR DESCRIPTION
This PR simplifies link implementation:
- Remove `peek` function in `Receiver`
- Remove `last_message` inside `Receiver`