### PR TITLE
Updated trait Node::initialize to return ZFResult<State>

### DIFF
--- a/zenoh-flow/src/macros.rs
+++ b/zenoh-flow/src/macros.rs
@@ -69,6 +69,8 @@ macro_rules! zf_spin_lock {
 #[macro_export]
 macro_rules! zf_empty_state {
     () => {
-        zenoh_flow::State::from::<zenoh_flow::EmptyState>(zenoh_flow::EmptyState {})
+        Ok(zenoh_flow::State::from::<zenoh_flow::EmptyState>(
+            zenoh_flow::EmptyState {},
+        ))
     };
 }

--- a/zenoh-flow/src/runtime/dataflow/node.rs
+++ b/zenoh-flow/src/runtime/dataflow/node.rs
@@ -45,7 +45,7 @@ impl TryFrom<SourceRecord> for SourceLoaded {
             ))
         })?;
         let (library, source) = load_source(uri)?;
-        let state = source.initialize(&value.configuration);
+        let state = source.initialize(&value.configuration)?;
 
         Ok(Self {
             id: value.id,
@@ -78,7 +78,7 @@ impl TryFrom<OperatorRecord> for OperatorLoaded {
             ))
         })?;
         let (library, operator) = load_operator(uri)?;
-        let state = operator.initialize(&value.configuration);
+        let state = operator.initialize(&value.configuration)?;
 
         let inputs: HashMap<PortId, String> = value
             .inputs
@@ -122,7 +122,7 @@ impl TryFrom<SinkRecord> for SinkLoaded {
             ))
         })?;
         let (library, sink) = load_sink(uri)?;
-        let state = sink.initialize(&value.configuration);
+        let state = sink.initialize(&value.configuration)?;
 
         Ok(Self {
             id: value.id,

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -42,7 +42,7 @@ pub trait ZFState: Debug + Send + Sync {
 }
 
 pub trait Node {
-    fn initialize(&self, configuration: &Option<HashMap<String, String>>) -> State;
+    fn initialize(&self, configuration: &Option<HashMap<String, String>>) -> ZFResult<State>;
 
     fn finalize(&self, state: &mut State) -> ZFResult<()>;
 }

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -80,7 +80,7 @@ impl Source for CountSource {
 }
 
 impl Node for CountSource {
-    fn initialize(&self, _configuration: &Option<HashMap<String, String>>) -> State {
+    fn initialize(&self, _configuration: &Option<HashMap<String, String>>) -> ZFResult<State> {
         zf_empty_state!()
     }
 
@@ -111,7 +111,7 @@ impl Sink for ExampleGenericSink {
 }
 
 impl Node for ExampleGenericSink {
-    fn initialize(&self, _configuration: &Option<HashMap<String, String>>) -> State {
+    fn initialize(&self, _configuration: &Option<HashMap<String, String>>) -> ZFResult<State> {
         zf_empty_state!()
     }
 
@@ -166,7 +166,7 @@ impl Operator for NoOp {
 }
 
 impl Node for NoOp {
-    fn initialize(&self, _configuration: &Option<HashMap<String, String>>) -> State {
+    fn initialize(&self, _configuration: &Option<HashMap<String, String>>) -> ZFResult<State> {
         zf_empty_state!()
     }
 
@@ -206,7 +206,7 @@ async fn single_runtime() {
             port_id: String::from(SOURCE),
             port_type: String::from("int"),
         },
-        source.initialize(&None),
+        source.initialize(&None).unwrap(),
         source,
     );
 
@@ -216,7 +216,7 @@ async fn single_runtime() {
             port_id: String::from(SOURCE),
             port_type: String::from("int"),
         },
-        sink.initialize(&None),
+        sink.initialize(&None).unwrap(),
         sink,
     );
 
@@ -230,7 +230,7 @@ async fn single_runtime() {
             port_id: String::from(DESTINATION),
             port_type: String::from("int"),
         }],
-        operator.initialize(&None),
+        operator.initialize(&None).unwrap(),
         operator,
     );
 


### PR DESCRIPTION
Updating the trait `Node`, the function `Node::initialize` now return `ZFResult<State>` because initalization can fail.