### PR TITLE
Refactoring the Runner enum into a trait

### DIFF
--- a/zenoh-flow/src/runtime/dataflow/instance/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/mod.rs
@@ -26,7 +26,7 @@ use crate::runtime::dataflow::instance::runners::connector::{ZenohReceiver, Zeno
 use crate::runtime::dataflow::instance::runners::operator::{OperatorIO, OperatorRunner};
 use crate::runtime::dataflow::instance::runners::sink::SinkRunner;
 use crate::runtime::dataflow::instance::runners::source::SourceRunner;
-use crate::runtime::dataflow::instance::runners::Runner;
+use crate::runtime::dataflow::instance::runners::{Runner, RunnerKind};
 use crate::runtime::dataflow::Dataflow;
 use crate::runtime::RuntimeContext;
 use crate::{FlowId, Message, NodeId, ZFError, ZFResult};
@@ -35,7 +35,7 @@ pub struct DataflowInstance {
     pub(crate) uuid: Uuid,
     pub(crate) flow_id: FlowId,
     pub(crate) context: RuntimeContext,
-    pub(crate) runners: HashMap<NodeId, Runner>,
+    pub(crate) runners: HashMap<NodeId, Arc<dyn Runner>>,
 }
 
 fn create_links(
@@ -101,7 +101,7 @@ impl DataflowInstance {
         let mut links = create_links(&node_ids, &dataflow.links)?;
 
         // The links were created, we can generate the Runners.
-        let mut runners: HashMap<NodeId, Runner> = HashMap::with_capacity(node_ids.len());
+        let mut runners: HashMap<NodeId, Arc<dyn Runner>> = HashMap::with_capacity(node_ids.len());
 
         for (id, source) in dataflow.sources.into_iter() {
             let io = links.remove(&id).ok_or_else(|| {
@@ -112,7 +112,7 @@ impl DataflowInstance {
             })?;
             runners.insert(
                 id,
-                Runner::Source(SourceRunner::try_new(dataflow.context.clone(), source, io)?),
+                Arc::new(SourceRunner::try_new(dataflow.context.clone(), source, io)?),
             );
         }
 
@@ -125,7 +125,7 @@ impl DataflowInstance {
             })?;
             runners.insert(
                 id,
-                Runner::Operator(OperatorRunner::try_new(
+                Arc::new(OperatorRunner::try_new(
                     dataflow.context.clone(),
                     operator,
                     io,
@@ -139,7 +139,7 @@ impl DataflowInstance {
             })?;
             runners.insert(
                 id,
-                Runner::Sink(SinkRunner::try_new(dataflow.context.clone(), sink, io)?),
+                Arc::new(SinkRunner::try_new(dataflow.context.clone(), sink, io)?),
             );
         }
 
@@ -154,7 +154,7 @@ impl DataflowInstance {
                 ZFConnectorKind::Sender => {
                     runners.insert(
                         id,
-                        Runner::Sender(ZenohSender::try_new(
+                        Arc::new(ZenohSender::try_new(
                             dataflow.context.clone(),
                             connector,
                             io,
@@ -164,7 +164,7 @@ impl DataflowInstance {
                 ZFConnectorKind::Receiver => {
                     runners.insert(
                         id,
-                        Runner::Receiver(ZenohReceiver::try_new(
+                        Arc::new(ZenohReceiver::try_new(
                             dataflow.context.clone(),
                             connector,
                             io,
@@ -194,39 +194,46 @@ impl DataflowInstance {
         self.context.clone()
     }
 
-    pub fn get_runner(&self, operator_id: &NodeId) -> Option<&Runner> {
-        self.runners.get(operator_id)
+    pub fn get_runner(&self, operator_id: &NodeId) -> Option<Arc<dyn Runner>> {
+        match self.runners.get(operator_id) {
+            Some(r) => Some(r.clone()),
+            _ => None,
+        }
     }
 
-    pub fn get_runners(&self) -> Vec<&Runner> {
-        self.runners.values().collect()
+    pub fn get_runners(&self) -> Vec<Arc<dyn Runner>> {
+        self.runners.values().cloned().collect()
     }
 
-    pub fn get_sources(&self) -> Vec<&Runner> {
+    pub fn get_sources(&self) -> Vec<Arc<dyn Runner>> {
         self.runners
             .values()
-            .filter(|runner| matches!(runner, Runner::Source(_)))
+            .filter(|runner| matches!(runner.get_kind(), RunnerKind::Source))
+            .cloned()
             .collect()
     }
 
-    pub fn get_sinks(&self) -> Vec<&Runner> {
+    pub fn get_sinks(&self) -> Vec<Arc<dyn Runner>> {
         self.runners
             .values()
-            .filter(|runner| matches!(runner, Runner::Sink(_)))
+            .filter(|runner| matches!(runner.get_kind(), RunnerKind::Sink))
+            .cloned()
             .collect()
     }
 
-    pub fn get_operators(&self) -> Vec<&Runner> {
+    pub fn get_operators(&self) -> Vec<Arc<dyn Runner>> {
         self.runners
             .values()
-            .filter(|runner| matches!(runner, Runner::Operator(_)))
+            .filter(|runner| matches!(runner.get_kind(), RunnerKind::Operator))
+            .cloned()
             .collect()
     }
 
-    pub fn get_connectors(&self) -> Vec<&Runner> {
+    pub fn get_connectors(&self) -> Vec<Arc<dyn Runner>> {
         self.runners
             .values()
-            .filter(|runner| matches!(runner, Runner::Receiver(_) | Runner::Sender(_)))
+            .filter(|runner| matches!(runner.get_kind(), RunnerKind::Connector))
+            .cloned()
             .collect()
     }
 }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -12,18 +12,16 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use crate::async_std::channel::{bounded, Receiver};
 use crate::async_std::sync::{Arc, RwLock};
 use crate::model::connector::ZFConnectorRecord;
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
 use crate::runtime::dataflow::instance::runners::operator::OperatorIO;
-use crate::runtime::dataflow::instance::runners::{RunAction, Runner, RunnerKind, RunnerManager};
+use crate::runtime::dataflow::instance::runners::{Runner, RunnerKind};
 use crate::runtime::message::Message;
 use crate::runtime::RuntimeContext;
 use crate::{NodeId, ZFError, ZFResult};
 use async_trait::async_trait;
 use futures::prelude::*;
-use futures_lite::future::FutureExt;
 use zenoh::net::{Reliability, SubInfo, SubMode};
 
 #[derive(Clone)]
@@ -56,49 +54,12 @@ impl ZenohSender {
             link: Arc::new(RwLock::new(link)),
         })
     }
-
-    pub async fn run_stoppable(&self, stop: Receiver<()>) -> ZFResult<()> {
-        loop {
-            let run = async {
-                match self.run().await {
-                    Ok(_) => RunAction::RestartRun(None),
-                    Err(e) => RunAction::RestartRun(Some(e)),
-                }
-            };
-            let stopper = async {
-                match stop.recv().await {
-                    Ok(_) => RunAction::Stop,
-                    Err(e) => RunAction::StopError(e),
-                }
-            };
-
-            match run.race(stopper).await {
-                RunAction::RestartRun(e) => {
-                    log::error!("The run loop exited with {:?}, restarting...", e);
-                    continue;
-                }
-                RunAction::Stop => {
-                    log::trace!("Received kill command, killing runner");
-                    break Ok(());
-                }
-                RunAction::StopError(e) => {
-                    log::error!("The stopper recv got an error: {}, exiting...", e);
-                    break Err(e.into());
-                }
-            }
-        }
-    }
 }
 #[async_trait]
 impl Runner for ZenohSender {
-    fn start(&self) -> RunnerManager {
-        let (s, r) = bounded::<()>(1);
-        let cloned_self = self.clone();
-
-        let h = async_std::task::spawn(async move { cloned_self.run_stoppable(r).await });
-        RunnerManager::new(s, h, self.get_kind())
+    fn get_id(&self) -> NodeId {
+        self.id.clone()
     }
-
     fn get_kind(&self) -> RunnerKind {
         RunnerKind::Connector
     }
@@ -174,50 +135,13 @@ impl ZenohReceiver {
             link: Arc::new(RwLock::new(link)),
         })
     }
-
-    pub async fn run_stoppable(&self, stop: Receiver<()>) -> ZFResult<()> {
-        loop {
-            let run = async {
-                match self.run().await {
-                    Ok(_) => RunAction::RestartRun(None),
-                    Err(e) => RunAction::RestartRun(Some(e)),
-                }
-            };
-            let stopper = async {
-                match stop.recv().await {
-                    Ok(_) => RunAction::Stop,
-                    Err(e) => RunAction::StopError(e),
-                }
-            };
-
-            match run.race(stopper).await {
-                RunAction::RestartRun(e) => {
-                    log::error!("The run loop exited with {:?}, restarting...", e);
-                    continue;
-                }
-                RunAction::Stop => {
-                    log::trace!("Received kill command, killing runner");
-                    break Ok(());
-                }
-                RunAction::StopError(e) => {
-                    log::error!("The stopper recv got an error: {}, exiting...", e);
-                    break Err(e.into());
-                }
-            }
-        }
-    }
 }
 
 #[async_trait]
 impl Runner for ZenohReceiver {
-    fn start(&self) -> RunnerManager {
-        let (s, r) = bounded::<()>(1);
-        let cloned_self = self.clone();
-
-        let h = async_std::task::spawn(async move { cloned_self.run_stoppable(r).await });
-        RunnerManager::new(s, h, self.get_kind())
+    fn get_id(&self) -> NodeId {
+        self.id.clone()
     }
-
     fn get_kind(&self) -> RunnerKind {
         RunnerKind::Connector
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -12,9 +12,11 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
+use crate::async_std::channel::{bounded, Receiver};
 use crate::async_std::sync::{Arc, RwLock};
 use crate::model::node::OperatorRecord;
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
+use crate::runtime::dataflow::instance::runners::{RunAction, Runner, RunnerKind, RunnerManager};
 use crate::runtime::dataflow::node::OperatorLoaded;
 use crate::runtime::message::Message;
 use crate::runtime::RuntimeContext;
@@ -22,7 +24,9 @@ use crate::{
     Context, DataMessage, NodeId, Operator, PortId, PortType, State, Token, TokenAction, ZFError,
     ZFResult,
 };
+use async_trait::async_trait;
 use futures::{future, Future};
+use futures_lite::future::FutureExt;
 use libloading::Library;
 use std::collections::HashMap;
 
@@ -118,13 +122,61 @@ impl OperatorRunner {
         })
     }
 
-    pub async fn add_input(&self, input: LinkReceiver<Message>) {
+    pub async fn run_stoppable(&self, stop: Receiver<()>) -> ZFResult<()> {
+        loop {
+            let run = async {
+                match self.run().await {
+                    Ok(_) => RunAction::RestartRun(None),
+                    Err(e) => RunAction::RestartRun(Some(e)),
+                }
+            };
+            let stopper = async {
+                match stop.recv().await {
+                    Ok(_) => RunAction::Stop,
+                    Err(e) => RunAction::StopError(e),
+                }
+            };
+
+            match run.race(stopper).await {
+                RunAction::RestartRun(e) => {
+                    log::error!("The run loop exited with {:?}, restarting...", e);
+                    continue;
+                }
+                RunAction::Stop => {
+                    log::trace!("Received kill command, killing runner");
+                    break Ok(());
+                }
+                RunAction::StopError(e) => {
+                    log::error!("The stopper recv got an error: {}, exiting...", e);
+                    break Err(e.into());
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Runner for OperatorRunner {
+    fn start(&self) -> RunnerManager {
+        let (s, r) = bounded::<()>(1);
+        let cloned_self = self.clone();
+
+        let h = async_std::task::spawn(async move { cloned_self.run_stoppable(r).await });
+        RunnerManager::new(s, h, self.get_kind())
+    }
+
+    fn get_kind(&self) -> RunnerKind {
+        RunnerKind::Operator
+    }
+
+    async fn add_input(&self, input: LinkReceiver<Message>) -> ZFResult<()> {
         let mut guard = self.io.write().await;
         let key = input.id();
         guard.inputs.insert(key, input);
+        Ok(())
     }
 
-    pub async fn add_output(&self, output: LinkSender<Message>) {
+    async fn add_output(&self, output: LinkSender<Message>) -> ZFResult<()> {
         let mut guard = self.io.write().await;
         let key = output.id();
         if let Some(links) = guard.outputs.get_mut(key.as_ref()) {
@@ -132,14 +184,15 @@ impl OperatorRunner {
         } else {
             guard.outputs.insert(key, vec![output]);
         }
+        Ok(())
     }
 
-    pub async fn clean(&self) -> ZFResult<()> {
+    async fn clean(&self) -> ZFResult<()> {
         let mut state = self.state.write().await;
         self.operator.finalize(&mut state)
     }
 
-    pub async fn run(&self) -> ZFResult<()> {
+    async fn run(&self) -> ZFResult<()> {
         let mut context = Context::default();
         let mut tokens: HashMap<PortId, Token> = self
             .inputs

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
@@ -12,19 +12,17 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use crate::async_std::channel::{bounded, Receiver};
 use crate::async_std::sync::{Arc, RwLock};
 use crate::model::link::PortDescriptor;
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
 use crate::runtime::dataflow::instance::runners::operator::OperatorIO;
-use crate::runtime::dataflow::instance::runners::{RunAction, Runner, RunnerKind, RunnerManager};
+use crate::runtime::dataflow::instance::runners::{Runner, RunnerKind};
 use crate::runtime::dataflow::node::SinkLoaded;
 use crate::runtime::message::Message;
 use crate::runtime::RuntimeContext;
 use crate::types::ZFResult;
 use crate::{Context, NodeId, Sink, State, ZFError};
 use async_trait::async_trait;
-use futures_lite::future::FutureExt;
 use libloading::Library;
 
 // Do not reorder the fields in this struct.
@@ -64,50 +62,13 @@ impl SinkRunner {
             library: sink.library,
         })
     }
-
-    pub async fn run_stoppable(&self, stop: Receiver<()>) -> ZFResult<()> {
-        loop {
-            let run = async {
-                match self.run().await {
-                    Ok(_) => RunAction::RestartRun(None),
-                    Err(e) => RunAction::RestartRun(Some(e)),
-                }
-            };
-            let stopper = async {
-                match stop.recv().await {
-                    Ok(_) => RunAction::Stop,
-                    Err(e) => RunAction::StopError(e),
-                }
-            };
-
-            match run.race(stopper).await {
-                RunAction::RestartRun(e) => {
-                    log::error!("The run loop exited with {:?}, restarting...", e);
-                    continue;
-                }
-                RunAction::Stop => {
-                    log::trace!("Received kill command, killing runner");
-                    break Ok(());
-                }
-                RunAction::StopError(e) => {
-                    log::error!("The stopper recv got an error: {}, exiting...", e);
-                    break Err(e.into());
-                }
-            }
-        }
-    }
 }
 
 #[async_trait]
 impl Runner for SinkRunner {
-    fn start(&self) -> RunnerManager {
-        let (s, r) = bounded::<()>(1);
-        let cloned_self = self.clone();
-
-        let h = async_std::task::spawn(async move { cloned_self.run_stoppable(r).await });
-        RunnerManager::new(s, h, self.get_kind())
+    fn get_id(&self) -> NodeId {
+        self.id.clone()
     }
-
     fn get_kind(&self) -> RunnerKind {
         RunnerKind::Sink
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -13,18 +13,16 @@
 //
 
 use super::operator::OperatorIO;
-use crate::async_std::channel::{bounded, Receiver};
 use crate::async_std::sync::{Arc, RwLock};
 use crate::model::link::PortDescriptor;
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
-use crate::runtime::dataflow::instance::runners::{RunAction, Runner, RunnerKind, RunnerManager};
+use crate::runtime::dataflow::instance::runners::{Runner, RunnerKind};
 use crate::runtime::dataflow::node::SourceLoaded;
 use crate::runtime::message::Message;
 use crate::runtime::RuntimeContext;
 use crate::types::ZFResult;
 use crate::{Context, NodeId, Source, State, ZFError};
 use async_trait::async_trait;
-use futures_lite::future::FutureExt;
 use libloading::Library;
 use std::time::Duration;
 use uhlc::{Timestamp, NTP64};
@@ -98,50 +96,13 @@ impl SourceRunner {
 
         timestamp
     }
-
-    pub async fn run_stoppable(&self, stop: Receiver<()>) -> ZFResult<()> {
-        loop {
-            let run = async {
-                match self.run().await {
-                    Ok(_) => RunAction::RestartRun(None),
-                    Err(e) => RunAction::RestartRun(Some(e)),
-                }
-            };
-            let stopper = async {
-                match stop.recv().await {
-                    Ok(_) => RunAction::Stop,
-                    Err(e) => RunAction::StopError(e),
-                }
-            };
-
-            match run.race(stopper).await {
-                RunAction::RestartRun(e) => {
-                    log::error!("The run loop exited with {:?}, restarting...", e);
-                    continue;
-                }
-                RunAction::Stop => {
-                    log::trace!("Received kill command, killing runner");
-                    break Ok(());
-                }
-                RunAction::StopError(e) => {
-                    log::error!("The stopper recv got an error: {}, exiting...", e);
-                    break Err(e.into());
-                }
-            }
-        }
-    }
 }
 
 #[async_trait]
 impl Runner for SourceRunner {
-    fn start(&self) -> RunnerManager {
-        let (s, r) = bounded::<()>(1);
-        let cloned_self = self.clone();
-
-        let h = async_std::task::spawn(async move { cloned_self.run_stoppable(r).await });
-        RunnerManager::new(s, h, self.get_kind())
+    fn get_id(&self) -> NodeId {
+        self.id.clone()
     }
-
     fn get_kind(&self) -> RunnerKind {
         RunnerKind::Source
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -12,20 +12,22 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use std::time::Duration;
-
-use libloading::Library;
-use uhlc::{Timestamp, NTP64};
-
 use super::operator::OperatorIO;
+use crate::async_std::channel::{bounded, Receiver};
 use crate::async_std::sync::{Arc, RwLock};
 use crate::model::link::PortDescriptor;
-use crate::runtime::dataflow::instance::link::LinkSender;
+use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
+use crate::runtime::dataflow::instance::runners::{RunAction, Runner, RunnerKind, RunnerManager};
 use crate::runtime::dataflow::node::SourceLoaded;
 use crate::runtime::message::Message;
 use crate::runtime::RuntimeContext;
 use crate::types::ZFResult;
 use crate::{Context, NodeId, Source, State, ZFError};
+use async_trait::async_trait;
+use futures_lite::future::FutureExt;
+use libloading::Library;
+use std::time::Duration;
+use uhlc::{Timestamp, NTP64};
 
 // Do not reorder the fields in this struct.
 // Rust drops fields in a struct in the same order they are declared.
@@ -97,16 +99,67 @@ impl SourceRunner {
         timestamp
     }
 
-    pub async fn add_output(&self, output: LinkSender<Message>) {
-        (*self.links.write().await).push(output)
+    pub async fn run_stoppable(&self, stop: Receiver<()>) -> ZFResult<()> {
+        loop {
+            let run = async {
+                match self.run().await {
+                    Ok(_) => RunAction::RestartRun(None),
+                    Err(e) => RunAction::RestartRun(Some(e)),
+                }
+            };
+            let stopper = async {
+                match stop.recv().await {
+                    Ok(_) => RunAction::Stop,
+                    Err(e) => RunAction::StopError(e),
+                }
+            };
+
+            match run.race(stopper).await {
+                RunAction::RestartRun(e) => {
+                    log::error!("The run loop exited with {:?}, restarting...", e);
+                    continue;
+                }
+                RunAction::Stop => {
+                    log::trace!("Received kill command, killing runner");
+                    break Ok(());
+                }
+                RunAction::StopError(e) => {
+                    log::error!("The stopper recv got an error: {}, exiting...", e);
+                    break Err(e.into());
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Runner for SourceRunner {
+    fn start(&self) -> RunnerManager {
+        let (s, r) = bounded::<()>(1);
+        let cloned_self = self.clone();
+
+        let h = async_std::task::spawn(async move { cloned_self.run_stoppable(r).await });
+        RunnerManager::new(s, h, self.get_kind())
     }
 
-    pub async fn clean(&self) -> ZFResult<()> {
+    fn get_kind(&self) -> RunnerKind {
+        RunnerKind::Source
+    }
+    async fn add_output(&self, output: LinkSender<Message>) -> ZFResult<()> {
+        (*self.links.write().await).push(output);
+        Ok(())
+    }
+
+    async fn add_input(&self, _input: LinkReceiver<Message>) -> ZFResult<()> {
+        Err(ZFError::SourceDoNotHaveInputs)
+    }
+
+    async fn clean(&self) -> ZFResult<()> {
         let mut state = self.state.write().await;
         self.source.finalize(&mut state)
     }
 
-    pub async fn run(&self) -> ZFResult<()> {
+    async fn run(&self) -> ZFResult<()> {
         let mut context = Context::default();
 
         loop {


### PR DESCRIPTION
Refactoring of the `Runner` enum into a `trait`.
Now all the runners must implement `Runner`, this opens the possibility to dynamic loading of different runners to support different languages (e.g., Python. web-assembly).