### PR TITLE
feat: local deadlines for Operator nodes

### DIFF
--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -205,6 +205,7 @@ async fn main() {
                         uri: Some(uri.clone()),
                         configuration: None,
                         runtime: None,
+                        deadline: None,
                     };
 
                     let metadata_arch = RegistryNodeArchitecture {

--- a/zenoh-flow/src/model/dataflow.rs
+++ b/zenoh-flow/src/model/dataflow.rs
@@ -510,12 +510,12 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
                 Some(m) => {
                     let or = OperatorRecord {
                         id: o.id.clone(),
-                        // name: o.name.clone(),
                         inputs: o.inputs.clone(),
                         outputs: o.outputs.clone(),
                         uri: o.uri.clone(),
                         configuration: o.configuration.clone(),
                         runtime: m,
+                        deadline: o.deadline.as_ref().map(|period| period.to_duration()),
                     };
                     dfr.operators.push(or)
                 }

--- a/zenoh-flow/src/model/node.rs
+++ b/zenoh-flow/src/model/node.rs
@@ -12,12 +12,12 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use std::time::Duration;
-use serde::{Deserialize, Serialize};
 use crate::model::link::PortDescriptor;
 use crate::model::period::PeriodDescriptor;
 use crate::types::{Configuration, NodeId, RuntimeId};
 use crate::PortType;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 // Descriptors
 
@@ -124,13 +124,13 @@ impl SourceRecord {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperatorRecord {
-    pub (crate) id: NodeId,
-    pub (crate) inputs: Vec<PortDescriptor>,
-    pub (crate) outputs: Vec<PortDescriptor>,
-    pub (crate) uri: Option<String>,
-    pub (crate) configuration: Option<Configuration>,
-    pub (crate) deadline: Option<Duration>,
-    pub (crate) runtime: RuntimeId,
+    pub(crate) id: NodeId,
+    pub(crate) inputs: Vec<PortDescriptor>,
+    pub(crate) outputs: Vec<PortDescriptor>,
+    pub(crate) uri: Option<String>,
+    pub(crate) configuration: Option<Configuration>,
+    pub(crate) deadline: Option<Duration>,
+    pub(crate) runtime: RuntimeId,
 }
 
 impl std::fmt::Display for OperatorRecord {

--- a/zenoh-flow/src/model/node.rs
+++ b/zenoh-flow/src/model/node.rs
@@ -12,11 +12,12 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
+use std::time::Duration;
+use serde::{Deserialize, Serialize};
 use crate::model::link::PortDescriptor;
 use crate::model::period::PeriodDescriptor;
 use crate::types::{Configuration, NodeId, RuntimeId};
 use crate::PortType;
-use serde::{Deserialize, Serialize};
 
 // Descriptors
 
@@ -58,6 +59,7 @@ pub struct OperatorDescriptor {
     pub outputs: Vec<PortDescriptor>,
     pub uri: Option<String>,
     pub configuration: Option<Configuration>,
+    pub deadline: Option<PeriodDescriptor>,
     pub runtime: Option<RuntimeId>, // to be removed
 }
 
@@ -122,12 +124,13 @@ impl SourceRecord {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperatorRecord {
-    pub id: NodeId,
-    pub inputs: Vec<PortDescriptor>,
-    pub outputs: Vec<PortDescriptor>,
-    pub uri: Option<String>,
-    pub configuration: Option<Configuration>,
-    pub runtime: RuntimeId,
+    pub (crate) id: NodeId,
+    pub (crate) inputs: Vec<PortDescriptor>,
+    pub (crate) outputs: Vec<PortDescriptor>,
+    pub (crate) uri: Option<String>,
+    pub (crate) configuration: Option<Configuration>,
+    pub (crate) deadline: Option<Duration>,
+    pub (crate) runtime: RuntimeId,
 }
 
 impl std::fmt::Display for OperatorRecord {

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -20,8 +20,8 @@ use crate::runtime::dataflow::node::OperatorLoaded;
 use crate::runtime::message::Message;
 use crate::runtime::RuntimeContext;
 use crate::{
-    Context, DataMessage, NodeId, Operator, PortId, PortType, State, Token, TokenAction, ZFError,
-    ZFResult,
+    Context, DataMessage, DeadlineMiss, NodeId, Operator, PortId, PortType, State, Token,
+    TokenAction, ZFError, ZFResult,
 };
 use async_trait::async_trait;
 use futures::{future, Future};
@@ -302,28 +302,33 @@ impl Runner for OperatorRunner {
             };
 
             // Running
-            let start_timestamp = self.runtime_context.hlc.new_timestamp();
+            let start = self.runtime_context.hlc.new_timestamp();
             let run_outputs = self.operator.run(&mut context, &mut state, &mut data)?;
-            let end_timestamp = self.runtime_context.hlc.new_timestamp();
+            let end = self.runtime_context.hlc.new_timestamp();
 
-            let elapsed_time = end_timestamp.get_diff_duration(&start_timestamp);
+            let elapsed = end.get_diff_duration(&start);
             log::debug!(
                 "[Operator: {}] `run` executed in {} ms",
                 self.id,
-                elapsed_time.as_micros()
+                elapsed.as_micros()
             );
 
-            let mut deadline_miss = false;
+            let mut deadline_miss = None;
 
             if let Some(deadline) = self.deadline {
-                if elapsed_time > deadline {
+                if elapsed > deadline {
                     log::warn!(
                         "[Operator: {}] Deadline miss detected for `run`: {} ms (expected < {} ms)",
                         self.id,
-                        elapsed_time.as_micros(),
+                        elapsed.as_micros(),
                         deadline.as_micros()
                     );
-                    deadline_miss = true;
+                    deadline_miss = Some(DeadlineMiss {
+                        start,
+                        end,
+                        deadline,
+                        elapsed,
+                    });
                 }
             }
 

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use futures::{future, Future};
 use libloading::Library;
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Default)]
 pub struct OperatorIO {
@@ -302,11 +302,10 @@ impl Runner for OperatorRunner {
             };
 
             // Running
-            let start = self.runtime_context.hlc.new_timestamp();
+            let start = Instant::now();
             let run_outputs = self.operator.run(&mut context, &mut state, &mut data)?;
-            let end = self.runtime_context.hlc.new_timestamp();
+            let elapsed = start.elapsed();
 
-            let elapsed = end.get_diff_duration(&start);
             log::debug!(
                 "[Operator: {}] `run` executed in {} ms",
                 self.id,
@@ -325,7 +324,6 @@ impl Runner for OperatorRunner {
                     );
                     deadline_miss = Some(DeadlineMiss {
                         start,
-                        end,
                         deadline,
                         elapsed,
                     });

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -19,6 +19,7 @@ pub mod node;
 use async_std::sync::{Arc, RwLock};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::time::Duration;
 use uuid::Uuid;
 
 use crate::model::connector::ZFConnectorRecord;
@@ -145,6 +146,7 @@ impl Dataflow {
         id: NodeId,
         inputs: Vec<PortDescriptor>,
         outputs: Vec<PortDescriptor>,
+        deadline: Option<Duration>,
         state: State,
         operator: Arc<dyn Operator>,
     ) {
@@ -163,6 +165,7 @@ impl Dataflow {
                 id,
                 inputs,
                 outputs,
+                deadline,
                 state: Arc::new(RwLock::new(state)),
                 operator,
                 library: None,

--- a/zenoh-flow/src/runtime/dataflow/node.rs
+++ b/zenoh-flow/src/runtime/dataflow/node.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::time::Duration;
 
 use crate::model::link::PortDescriptor;
 use crate::model::node::{OperatorRecord, SinkRecord, SourceRecord};
@@ -60,6 +61,7 @@ pub struct OperatorLoaded {
     pub(crate) id: NodeId,
     pub(crate) inputs: HashMap<PortId, PortType>,
     pub(crate) outputs: HashMap<PortId, PortType>,
+    pub(crate) deadline: Option<Duration>,
     pub(crate) state: Arc<RwLock<State>>,
     pub(crate) operator: Arc<dyn Operator>,
     pub(crate) library: Option<Arc<Library>>,
@@ -94,6 +96,7 @@ impl TryFrom<OperatorRecord> for OperatorLoaded {
             id: value.id,
             inputs,
             outputs,
+            deadline: value.deadline,
             state: Arc::new(RwLock::new(state)),
             operator,
             library: Some(Arc::new(library)),

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -13,7 +13,9 @@
 //
 
 use crate::runtime::message::DataMessage;
-use crate::{Configuration, Context, Data, NodeOutput, PortId, State, Token, ZFResult};
+use crate::{
+    Configuration, Context, Data, DeadlineMiss, NodeOutput, PortId, State, Token, ZFResult,
+};
 use async_trait::async_trait;
 use std::any::Any;
 use std::collections::HashMap;
@@ -67,7 +69,7 @@ pub trait Operator: Node + Send + Sync {
         context: &mut Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
-        deadline_miss: bool,
+        deadline_miss: Option<DeadlineMiss>,
     ) -> ZFResult<HashMap<PortId, NodeOutput>>;
 }
 

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -67,6 +67,7 @@ pub trait Operator: Node + Send + Sync {
         context: &mut Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
+        deadline_miss: bool,
     ) -> ZFResult<HashMap<PortId, NodeOutput>>;
 }
 

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -16,6 +16,8 @@ use crate::async_std::sync::Arc;
 use crate::serde::{Deserialize, Serialize};
 use crate::{ControlMessage, DataMessage, Token, ZFData, ZFState};
 use std::collections::HashMap;
+use std::time::Duration;
+use uhlc::Timestamp;
 
 pub type NodeId = Arc<str>;
 pub type PortId = Arc<str>;
@@ -221,3 +223,19 @@ pub fn default_input_rule(
 }
 
 pub type Configuration = serde_json::Value;
+
+/// A structure containing all the information regarding a missed deadline.
+///
+/// Its field are:
+/// - `start`: the `uhlc::Timestamp` at which the execution started,
+/// - `end`: the `uhlc::Timestamp` at which the execution ended,
+/// - `elapsed`: the `std::time::Duration` of the execution,
+/// - `deadline`: the `std::time::Duration` of the deadline.
+///
+/// The `elapsed` value can be retrieved by subtracting `end` from `start`.
+pub struct DeadlineMiss {
+    pub start: Timestamp,
+    pub end: Timestamp,
+    pub deadline: Duration,
+    pub elapsed: Duration,
+}

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -16,8 +16,7 @@ use crate::async_std::sync::Arc;
 use crate::serde::{Deserialize, Serialize};
 use crate::{ControlMessage, DataMessage, Token, ZFData, ZFState};
 use std::collections::HashMap;
-use std::time::Duration;
-use uhlc::Timestamp;
+use std::time::{Duration, Instant};
 
 pub type NodeId = Arc<str>;
 pub type PortId = Arc<str>;
@@ -234,8 +233,7 @@ pub type Configuration = serde_json::Value;
 ///
 /// The `elapsed` value can be retrieved by subtracting `end` from `start`.
 pub struct DeadlineMiss {
-    pub start: Timestamp,
-    pub end: Timestamp,
+    pub start: Instant,
     pub deadline: Duration,
     pub elapsed: Duration,
 }

--- a/zenoh-flow/tests/data.rs
+++ b/zenoh-flow/tests/data.rs
@@ -59,7 +59,7 @@ fn data_wrapping_unwrapping() {
 
     assert_eq!(unwrapped_data.field1, test_data.field1);
     assert_eq!(unwrapped_data.field2, test_data.field2);
-    assert_eq!(unwrapped_data.field3, test_data.field3);
+    assert!((unwrapped_data.field3 - test_data.field3).abs() < f64::EPSILON);
 
     let arc_data = Arc::new(test_data.clone());
 
@@ -68,7 +68,7 @@ fn data_wrapping_unwrapping() {
 
     assert_eq!(unwrapped_data.field1, test_data.field1);
     assert_eq!(unwrapped_data.field2, test_data.field2);
-    assert_eq!(unwrapped_data.field3, test_data.field3);
+    assert!((unwrapped_data.field3 - test_data.field3).abs() < f64::EPSILON);
 
     let serialized_data = test_data.try_serialize().unwrap();
 
@@ -83,5 +83,5 @@ fn data_wrapping_unwrapping() {
 
     assert_eq!(unwrapped_data.field1, test_data.field1);
     assert_eq!(unwrapped_data.field2, test_data.field2);
-    assert_eq!(unwrapped_data.field3, test_data.field3);
+    assert!((unwrapped_data.field3 - test_data.field3).abs() < f64::EPSILON);
 }

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -162,7 +162,9 @@ impl Operator for NoOp {
         _context: &mut zenoh_flow::Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
+        deadline_miss: bool,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(!deadline_miss, "Expected `deadline_miss` to be: false");
         default_output_rule(state, outputs)
     }
 }
@@ -232,6 +234,7 @@ async fn single_runtime() {
             port_id: DESTINATION.into(),
             port_type: "int".into(),
         }],
+        None,
         operator.initialize(&None).unwrap(),
         operator,
     );

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -24,8 +24,8 @@ use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::zenoh_flow_derive::ZFData;
 use zenoh_flow::{
     default_input_rule, default_output_rule, zf_empty_state, Configuration, Context, Data,
-    Deserializable, Node, NodeOutput, Operator, PortId, Sink, Source, State, ZFData, ZFError,
-    ZFResult,
+    DeadlineMiss, Deserializable, Node, NodeOutput, Operator, PortId, Sink, Source, State, ZFData,
+    ZFError, ZFResult,
 };
 
 // Data Type
@@ -162,9 +162,12 @@ impl Operator for NoOp {
         _context: &mut zenoh_flow::Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
-        deadline_miss: bool,
+        deadline_miss: Option<DeadlineMiss>,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
-        assert!(!deadline_miss, "Expected `deadline_miss` to be: false");
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`."
+        );
         default_output_rule(state, outputs)
     }
 }

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -23,8 +23,8 @@ use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescript
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::{
-    default_output_rule, zf_empty_state, Configuration, Context, Data, Node, NodeOutput, Operator,
-    PortId, Sink, Source, State, Token, ZFError, ZFResult,
+    default_output_rule, zf_empty_state, Configuration, Context, Data, DeadlineMiss, Node,
+    NodeOutput, Operator, PortId, Sink, Source, State, Token, ZFError, ZFResult,
 };
 
 static SOURCE: &str = "Source";
@@ -152,8 +152,12 @@ impl Operator for DropOdd {
         _context: &mut zenoh_flow::Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
-        _deadline_miss: bool,
+        deadline_miss: Option<DeadlineMiss>,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`."
+        );
         default_output_rule(state, outputs)
     }
 }

--- a/zenoh-flow/tests/input_rule_keep.rs
+++ b/zenoh-flow/tests/input_rule_keep.rs
@@ -21,8 +21,8 @@ use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescript
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::{
-    default_output_rule, zf_empty_state, Configuration, Data, Node, NodeOutput, Operator, PortId,
-    State, Token, ZFError, ZFResult,
+    default_output_rule, zf_empty_state, Configuration, Data, DeadlineMiss, Node, NodeOutput,
+    Operator, PortId, State, Token, ZFError, ZFResult,
 };
 
 static SOURCE_1: &str = "Source1";
@@ -104,8 +104,12 @@ impl Operator for OperatorKeep {
         _context: &mut zenoh_flow::Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
-        _deadline_miss: bool,
+        deadline_miss: Option<DeadlineMiss>,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`."
+        );
         default_output_rule(state, outputs)
     }
 }

--- a/zenoh-flow/tests/input_rule_keep.rs
+++ b/zenoh-flow/tests/input_rule_keep.rs
@@ -104,6 +104,7 @@ impl Operator for OperatorKeep {
         _context: &mut zenoh_flow::Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
+        _deadline_miss: bool,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
         default_output_rule(state, outputs)
     }
@@ -182,6 +183,7 @@ async fn single_runtime() {
             port_id: SINK.into(),
             port_type: "int".into(),
         }],
+        None,
         operator.initialize(&None).unwrap(),
         operator,
     );

--- a/zenoh-flow/tests/local_deadline.rs
+++ b/zenoh-flow/tests/local_deadline.rs
@@ -21,7 +21,10 @@ use types::{VecSink, VecSource, ZFUsize};
 use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::RuntimeContext;
-use zenoh_flow::{Configuration, Data, Node, NodeOutput, Operator, PortId, State, ZFError, ZFResult, default_input_rule, default_output_rule, zf_empty_state};
+use zenoh_flow::{
+    default_input_rule, default_output_rule, zf_empty_state, Configuration, Data, Node, NodeOutput,
+    Operator, PortId, State, ZFError, ZFResult,
+};
 
 static SOURCE: &str = "Source";
 static OPERATOR: &str = "Operator";
@@ -66,10 +69,7 @@ impl Operator for OperatorDeadline {
             .ok_or_else(|| ZFError::InvalidData("No data".to_string()))?;
         let data = data_msg.data.try_get::<ZFUsize>()?;
 
-        results.insert(
-            SINK.into(),
-            Data::from::<ZFUsize>(ZFUsize(data.0)),
-        );
+        results.insert(SINK.into(), Data::from::<ZFUsize>(ZFUsize(data.0)));
 
         Ok(results)
     }
@@ -133,12 +133,10 @@ async fn single_runtime() {
 
     dataflow.add_static_operator(
         OPERATOR.into(),
-        vec![
-            PortDescriptor {
-                port_id: SOURCE.into(),
-                port_type: "int".into(),
-            },
-        ],
+        vec![PortDescriptor {
+            port_id: SOURCE.into(),
+            port_type: "int".into(),
+        }],
         vec![PortDescriptor {
             port_id: SINK.into(),
             port_type: "int".into(),

--- a/zenoh-flow/tests/local_deadline.rs
+++ b/zenoh-flow/tests/local_deadline.rs
@@ -22,8 +22,8 @@ use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescript
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::{
-    default_input_rule, default_output_rule, zf_empty_state, Configuration, Data, Node, NodeOutput,
-    Operator, PortId, State, ZFError, ZFResult,
+    default_input_rule, default_output_rule, zf_empty_state, Configuration, Data, DeadlineMiss,
+    Node, NodeOutput, Operator, PortId, State, ZFError, ZFResult,
 };
 
 static SOURCE: &str = "Source";
@@ -79,9 +79,12 @@ impl Operator for OperatorDeadline {
         _context: &mut zenoh_flow::Context,
         state: &mut State,
         outputs: HashMap<PortId, Data>,
-        deadline_miss: bool,
+        deadline_miss: Option<DeadlineMiss>,
     ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
-        assert!(deadline_miss, "Expected `deadline_miss` to be: true");
+        assert!(
+            deadline_miss.is_some(),
+            "Expected `deadline_miss` to be `Some`"
+        );
         default_output_rule(state, outputs)
     }
 }

--- a/zenoh-flow/tests/state.rs
+++ b/zenoh-flow/tests/state.rs
@@ -36,7 +36,7 @@ fn state_wrapping_unwrapping() {
 
     assert_eq!(unwrapped_state.field1, test_state.field1);
     assert_eq!(unwrapped_state.field2, test_state.field2);
-    assert_eq!(unwrapped_state.field3, test_state.field3);
+    assert!((unwrapped_state.field3 - test_state.field3).abs() < f64::EPSILON);
 
     let boxed_state = Box::new(test_state.clone());
 
@@ -45,5 +45,5 @@ fn state_wrapping_unwrapping() {
 
     assert_eq!(unwrapped_state.field1, test_state.field1);
     assert_eq!(unwrapped_state.field2, test_state.field2);
-    assert_eq!(unwrapped_state.field3, test_state.field3);
+    assert!((unwrapped_state.field3 - test_state.field3).abs() < f64::EPSILON);
 }


### PR DESCRIPTION
This PR introduces the possibility to add local deadlines for the `run` method of Operator type nodes.

The deadline declaration is:
```yaml
deadline:
  duration: 500
  unit: ms
```

The deadline is simply _checked_ but not enforced: the `run` method of the Operator will execute until completion and, once over, we check if the time it took to execute is superior to the declared deadline.

The information is available as an `Option` in the `output_rule`:
```rust
    fn output_rule(
        &self,
        context: &mut Context,
        state: &mut State,
        outputs: HashMap<PortId, Data>,
        deadline_miss: Option<DeadlineMiss>,
    ) -> ZFResult<HashMap<PortId, NodeOutput>>;
```

This PR introduces a breaking change.