### PR TITLE
Implementing `Loader` to allow easy extensibilty with graph node implementations.

### DIFF
--- a/zenoh-flow-daemon/etc/runtime.yaml
+++ b/zenoh-flow-daemon/etc/runtime.yaml
@@ -4,7 +4,7 @@
     name: runtime
     path : /etc/zenoh-flow
     loader:
-      extentions: []
+      extensions: []
     zenoh :
       kind: peer
       listen: ["tcp/0.0.0.0:7447"]

--- a/zenoh-flow-daemon/etc/runtime.yaml
+++ b/zenoh-flow-daemon/etc/runtime.yaml
@@ -3,6 +3,8 @@
     pid_file : /var/zenoh-flow/runtime.pid
     name: runtime
     path : /etc/zenoh-flow
+    loader:
+      extentions: []
     zenoh :
       kind: peer
       listen: ["tcp/0.0.0.0:7447"]

--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -23,6 +23,7 @@ use zenoh_flow::model::{
 };
 use zenoh_flow::runtime::dataflow::instance::runners::{RunnerKind, RunnerManager};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
+use zenoh_flow::runtime::dataflow::loader::Loader;
 use zenoh_flow::runtime::dataflow::Dataflow;
 use zenoh_flow::runtime::message::ControlMessage;
 use zenoh_flow::runtime::resources::DataStore;
@@ -87,10 +88,12 @@ impl Daemon {
         let session = Arc::new(zenoh::net::open(zn_properties.into()).wait()?);
         let z = Arc::new(zenoh::Zenoh::new(zenoh_properties.into()).wait()?);
         let hlc = Arc::new(HLC::default());
+        let loader = Arc::new(Loader::new(config.loader.clone()));
 
         let ctx = RuntimeContext {
             session,
             hlc,
+            loader,
             runtime_name: name.into(),
             runtime_uuid: uuid,
         };

--- a/zenoh-flow/src/bin/runtime.rs
+++ b/zenoh-flow/src/bin/runtime.rs
@@ -53,7 +53,7 @@ async fn main() {
             let yaml_conf = read_to_string(config).unwrap();
             serde_yaml::from_str::<LoaderConfig>(&yaml_conf).unwrap()
         }
-        None => LoaderConfig { extentions: vec![] },
+        None => LoaderConfig { extensions: vec![] },
     };
 
     let session =

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
@@ -16,22 +16,13 @@ use std::{collections::HashMap, convert::TryInto};
 use uhlc::HLC;
 use zenoh::ZFuture;
 
-use crate::{
-    default_output_rule,
-    runtime::{
-        dataflow::instance::{
+use crate::{Configuration, Context, Data, DataMessage, DeadlineMiss, Deserializable, DowncastAny, EmptyState, Message, Node, NodeOutput, Operator, PortId, PortType, State, Token, TokenAction, ZFData, ZFError, ZFResult, default_output_rule, runtime::{RuntimeContext, dataflow::{instance::{
             link::{LinkReceiver, LinkSender},
             runners::{
                 operator::{OperatorIO, OperatorRunner},
                 NodeRunner,
             },
-        },
-        RuntimeContext,
-    },
-    Configuration, Context, Data, DataMessage, DeadlineMiss, Deserializable, DowncastAny,
-    EmptyState, Message, Node, NodeOutput, Operator, PortId, PortType, State, Token, TokenAction,
-    ZFData, ZFError, ZFResult,
-};
+        }, loader::{Loader, LoaderConfig}}}};
 
 // ZFUsize implements Data.
 #[derive(Debug, Clone)]
@@ -184,6 +175,7 @@ fn input_rule_keep() {
     let runtime_context = RuntimeContext {
         session: Arc::new(session),
         hlc: hlc.clone(),
+        loader: Arc::new(Loader::new(LoaderConfig { extensions: vec![] })),
         runtime_name: "test-runtime-input-rule-keep".into(),
         runtime_uuid: uuid,
     };

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
@@ -16,13 +16,25 @@ use std::{collections::HashMap, convert::TryInto};
 use uhlc::HLC;
 use zenoh::ZFuture;
 
-use crate::{Configuration, Context, Data, DataMessage, DeadlineMiss, Deserializable, DowncastAny, EmptyState, Message, Node, NodeOutput, Operator, PortId, PortType, State, Token, TokenAction, ZFData, ZFError, ZFResult, default_output_rule, runtime::{RuntimeContext, dataflow::{instance::{
-            link::{LinkReceiver, LinkSender},
-            runners::{
-                operator::{OperatorIO, OperatorRunner},
-                NodeRunner,
+use crate::{
+    default_output_rule,
+    runtime::{
+        dataflow::{
+            instance::{
+                link::{LinkReceiver, LinkSender},
+                runners::{
+                    operator::{OperatorIO, OperatorRunner},
+                    NodeRunner,
+                },
             },
-        }, loader::{Loader, LoaderConfig}}}};
+            loader::{Loader, LoaderConfig},
+        },
+        RuntimeContext,
+    },
+    Configuration, Context, Data, DataMessage, DeadlineMiss, Deserializable, DowncastAny,
+    EmptyState, Message, Node, NodeOutput, Operator, PortId, PortType, State, Token, TokenAction,
+    ZFData, ZFError, ZFResult,
+};
 
 // ZFUsize implements Data.
 #[derive(Debug, Clone)]

--- a/zenoh-flow/src/runtime/dataflow/loader.rs
+++ b/zenoh-flow/src/runtime/dataflow/loader.rs
@@ -12,11 +12,13 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use std::path::PathBuf;
-
-use crate::{Operator, Sink, Source, ZFError, ZFResult};
+use super::node::{OperatorLoaded, SinkLoaded, SourceLoaded};
+use crate::model::node::{OperatorRecord, SinkRecord, SourceRecord};
+use crate::serde::{Deserialize, Serialize};
+use crate::{Configuration, Operator, Sink, Source, ZFError, ZFResult};
 use async_std::sync::Arc;
 use libloading::Library;
+use std::path::{Path, PathBuf};
 use url::Url;
 
 pub static CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -32,41 +34,6 @@ pub struct OperatorDeclaration {
     pub register: OperatorRegisterFn,
 }
 
-/// # Safety
-///
-/// TODO remove all copy-pasted code, make macros/functions instead
-pub fn load_operator(path: &str) -> ZFResult<(Library, Arc<dyn Operator>)> {
-    let uri = Url::parse(path).map_err(|err| ZFError::ParsingError(format!("{}", err)))?;
-
-    match uri.scheme() {
-        "file" => unsafe { load_lib_operator(make_file_path(uri)?) },
-        _ => Err(ZFError::Unimplemented),
-    }
-}
-
-/// Load the library of the operator.
-///
-/// # Safety
-///
-/// This function dynamically loads an external library, things can go wrong:
-/// - it will panic if the symbol `zfoperator_declaration` is not found,
-/// - be sure to *trust* the code you are loading.
-unsafe fn load_lib_operator(path: PathBuf) -> ZFResult<(Library, Arc<dyn Operator>)> {
-    log::debug!("Operator Loading {:#?}", path);
-
-    let library = Library::new(path)?;
-    let decl = library
-        .get::<*mut OperatorDeclaration>(b"zfoperator_declaration\0")?
-        .read();
-
-    // version checks to prevent accidental ABI incompatibilities
-    if decl.rustc_version != RUSTC_VERSION || decl.core_version != CORE_VERSION {
-        return Err(ZFError::VersionMismatch);
-    }
-
-    Ok((library, (decl.register)()?))
-}
-
 // SOURCE
 
 pub type SourceRegisterFn = fn() -> ZFResult<Arc<dyn Source>>;
@@ -75,37 +42,6 @@ pub struct SourceDeclaration {
     pub rustc_version: &'static str,
     pub core_version: &'static str,
     pub register: SourceRegisterFn,
-}
-
-pub fn load_source(path: &str) -> ZFResult<(Library, Arc<dyn Source>)> {
-    let uri = Url::parse(path).map_err(|err| ZFError::ParsingError(format!("{}", err)))?;
-
-    match uri.scheme() {
-        "file" => unsafe { load_lib_source(make_file_path(uri)?) },
-        _ => Err(ZFError::Unimplemented),
-    }
-}
-
-/// Load the library of a source.
-///
-/// # Safety
-///
-/// This function dynamically loads an external library, things can go wrong:
-/// - it will panic if the symbol `zfsource_declaration` is not found,
-/// - be sure to *trust* the code you are loading.
-unsafe fn load_lib_source(path: PathBuf) -> ZFResult<(Library, Arc<dyn Source>)> {
-    log::debug!("Source Loading {:#?}", path);
-    let library = Library::new(path)?;
-    let decl = library
-        .get::<*mut SourceDeclaration>(b"zfsource_declaration\0")?
-        .read();
-
-    // version checks to prevent accidental ABI incompatibilities
-    if decl.rustc_version != RUSTC_VERSION || decl.core_version != CORE_VERSION {
-        return Err(ZFError::VersionMismatch);
-    }
-
-    Ok((library, (decl.register)()?))
 }
 
 // SINK
@@ -118,44 +54,336 @@ pub struct SinkDeclaration {
     pub register: SinkRegisterFn,
 }
 
-pub fn load_sink(path: &str) -> ZFResult<(Library, Arc<dyn Sink>)> {
-    let uri = Url::parse(path).map_err(|err| ZFError::ParsingError(format!("{}", err)))?;
-
-    match uri.scheme() {
-        "file" => unsafe { load_lib_sink(make_file_path(uri)?) },
-        _ => Err(ZFError::Unimplemented),
-    }
+// Extensible support for different implementations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtensibleImplementation {
+    pub(crate) name: String,
+    pub(crate) file_extension: String,
+    pub(crate) source_lib: String,
+    pub(crate) sink_lib: String,
+    pub(crate) operator_lib: String,
+    pub(crate) config_lib_key: String,
 }
 
-/// Load the library of a sink.
-///
-/// # Safety
-///
-/// This function dynamically loads an external library, things can go wrong:
-/// - it will panic if the symbol `zfsink_declaration` is not found,
-/// - be sure to *trust* the code you are loading.
-unsafe fn load_lib_sink(path: PathBuf) -> ZFResult<(Library, Arc<dyn Sink>)> {
-    log::debug!("Sink Loading {:#?}", path);
-    let library = Library::new(path)?;
+// Loader Config
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoaderConfig {
+    pub extentions: Vec<ExtensibleImplementation>,
+}
 
-    let decl = library
-        .get::<*mut SinkDeclaration>(b"zfsink_declaration\0")?
-        .read();
+pub struct Loader {
+    pub(crate) config: LoaderConfig,
+}
 
-    // version checks to prevent accidental ABI incompatibilities
-    if decl.rustc_version != RUSTC_VERSION || decl.core_version != CORE_VERSION {
-        return Err(ZFError::VersionMismatch);
+impl Loader {
+    pub fn new(config: LoaderConfig) -> Self {
+        Self { config }
     }
 
-    Ok((library, (decl.register)()?))
-}
-fn make_file_path(uri: Url) -> ZFResult<PathBuf> {
-    let mut path = PathBuf::new();
-    let file_path = match uri.host_str() {
-        Some(h) => format!("{}{}", h, uri.path()),
-        None => uri.path().to_string(),
-    };
-    path.push(file_path);
-    let path = std::fs::canonicalize(path)?;
-    Ok(path)
+    /// # Safety
+    ///
+    /// TODO remove all copy-pasted code, make macros/functions instead
+    pub fn load_operator(&self, record: OperatorRecord) -> ZFResult<OperatorLoaded> {
+        let uri = record.uri.clone().ok_or_else(|| {
+            ZFError::LoadingError(format!(
+                "Missing URI for dynamically loaded Operator < {} >.",
+                record.id.clone()
+            ))
+        })?;
+
+        let uri = Url::parse(&uri).map_err(|err| ZFError::ParsingError(format!("{}", err)))?;
+
+        match uri.scheme() {
+            "file" => {
+                let file_path = Self::make_file_path(uri)?;
+                let file_extension = Self::get_file_extention(&file_path).ok_or_else(|| {
+                    ZFError::LoadingError(format!(
+                        "Missing file extension for dynamically loaded Operator < {} , {:?}>.",
+                        record.id.clone(),
+                        file_path,
+                    ))
+                })?;
+
+                match Self::is_lib(&file_extension) {
+                    true => {
+                        let (lib, op) = unsafe { Self::load_lib_operator(file_path) }?;
+                        Ok(OperatorLoaded::try_new(record, Some(Arc::new(lib)), op)?)
+                    }
+                    _ => Ok(self.load_operator_from_extension(record, file_path)?),
+                }
+            }
+            _ => Err(ZFError::Unimplemented),
+        }
+    }
+
+    pub fn load_source(&self, record: SourceRecord) -> ZFResult<SourceLoaded> {
+        let uri = record.uri.clone().ok_or_else(|| {
+            ZFError::LoadingError(format!(
+                "Missing URI for dynamically loaded Source < {} >.",
+                record.id.clone()
+            ))
+        })?;
+
+        let uri = Url::parse(&uri).map_err(|err| ZFError::ParsingError(format!("{}", err)))?;
+
+        match uri.scheme() {
+            "file" => {
+                let file_path = Self::make_file_path(uri)?;
+                let file_extension = Self::get_file_extention(&file_path).ok_or_else(|| {
+                    ZFError::LoadingError(format!(
+                        "Missing file extension for dynamically loaded Source < {} , {:?}>.",
+                        record.id.clone(),
+                        file_path,
+                    ))
+                })?;
+
+                match Self::is_lib(&file_extension) {
+                    true => {
+                        let (lib, op) = unsafe { Self::load_lib_source(file_path) }?;
+                        Ok(SourceLoaded::try_new(record, Some(Arc::new(lib)), op)?)
+                    }
+                    _ => Ok(self.load_source_from_extension(record, file_path)?),
+                }
+            }
+            _ => Err(ZFError::Unimplemented),
+        }
+    }
+
+    pub fn load_sink(&self, record: SinkRecord) -> ZFResult<SinkLoaded> {
+        let uri = record.uri.clone().ok_or_else(|| {
+            ZFError::LoadingError(format!(
+                "Missing URI for dynamically loaded Sink < {} >.",
+                record.id.clone()
+            ))
+        })?;
+
+        let uri = Url::parse(&uri).map_err(|err| ZFError::ParsingError(format!("{}", err)))?;
+
+        match uri.scheme() {
+            "file" => {
+                let file_path = Self::make_file_path(uri)?;
+                let file_extension = Self::get_file_extention(&file_path).ok_or_else(|| {
+                    ZFError::LoadingError(format!(
+                        "Missing file extension for dynamically loaded Sink < {} , {:?}>.",
+                        record.id.clone(),
+                        file_path,
+                    ))
+                })?;
+
+                match Self::is_lib(&file_extension) {
+                    true => {
+                        let (lib, op) = unsafe { Self::load_lib_sink(file_path) }?;
+                        Ok(SinkLoaded::try_new(record, Some(Arc::new(lib)), op)?)
+                    }
+                    _ => Ok(self.load_sink_from_extension(record, file_path)?),
+                }
+            }
+            _ => Err(ZFError::Unimplemented),
+        }
+    }
+
+    /// Load the library of the operator.
+    ///
+    /// # Safety
+    ///
+    /// This function dynamically loads an external library, things can go wrong:
+    /// - it will panic if the symbol `zfoperator_declaration` is not found,
+    /// - be sure to *trust* the code you are loading.
+    unsafe fn load_lib_operator(path: PathBuf) -> ZFResult<(Library, Arc<dyn Operator>)> {
+        log::debug!("Operator Loading {:#?}", path);
+
+        let library = Library::new(path)?;
+        let decl = library
+            .get::<*mut OperatorDeclaration>(b"zfoperator_declaration\0")?
+            .read();
+
+        // version checks to prevent accidental ABI incompatibilities
+        if decl.rustc_version != RUSTC_VERSION || decl.core_version != CORE_VERSION {
+            return Err(ZFError::VersionMismatch);
+        }
+
+        Ok((library, (decl.register)()?))
+    }
+
+    /// Load the library of a source.
+    ///
+    /// # Safety
+    ///
+    /// This function dynamically loads an external library, things can go wrong:
+    /// - it will panic if the symbol `zfsource_declaration` is not found,
+    /// - be sure to *trust* the code you are loading.
+    unsafe fn load_lib_source(path: PathBuf) -> ZFResult<(Library, Arc<dyn Source>)> {
+        log::debug!("Source Loading {:#?}", path);
+        let library = Library::new(path)?;
+        let decl = library
+            .get::<*mut SourceDeclaration>(b"zfsource_declaration\0")?
+            .read();
+
+        // version checks to prevent accidental ABI incompatibilities
+        if decl.rustc_version != RUSTC_VERSION || decl.core_version != CORE_VERSION {
+            return Err(ZFError::VersionMismatch);
+        }
+
+        Ok((library, (decl.register)()?))
+    }
+
+    /// Load the library of a sink.
+    ///
+    /// # Safety
+    ///
+    /// This function dynamically loads an external library, things can go wrong:
+    /// - it will panic if the symbol `zfsink_declaration` is not found,
+    /// - be sure to *trust* the code you are loading.
+    unsafe fn load_lib_sink(path: PathBuf) -> ZFResult<(Library, Arc<dyn Sink>)> {
+        log::debug!("Sink Loading {:#?}", path);
+        let library = Library::new(path)?;
+
+        let decl = library
+            .get::<*mut SinkDeclaration>(b"zfsink_declaration\0")?
+            .read();
+
+        // version checks to prevent accidental ABI incompatibilities
+        if decl.rustc_version != RUSTC_VERSION || decl.core_version != CORE_VERSION {
+            return Err(ZFError::VersionMismatch);
+        }
+
+        Ok((library, (decl.register)()?))
+    }
+    fn make_file_path(uri: Url) -> ZFResult<PathBuf> {
+        let mut path = PathBuf::new();
+        let file_path = match uri.host_str() {
+            Some(h) => format!("{}{}", h, uri.path()),
+            None => uri.path().to_string(),
+        };
+        path.push(file_path);
+        let path = std::fs::canonicalize(path)?;
+        Ok(path)
+    }
+
+    fn is_lib(ext: &str) -> bool {
+        if ext == std::env::consts::DLL_EXTENSION {
+            return true;
+        }
+        false
+    }
+
+    fn get_file_extention(file: &Path) -> Option<String> {
+        if let Some(ext) = file.extension() {
+            if let Some(ext) = ext.to_str() {
+                return Some(String::from(ext));
+            }
+        }
+        None
+    }
+
+    fn load_operator_from_extension(
+        &self,
+        mut record: OperatorRecord,
+        file_path: PathBuf,
+    ) -> ZFResult<OperatorLoaded> {
+        let file_extension = Self::get_file_extention(&file_path).ok_or_else(|| {
+            ZFError::LoadingError(format!(
+                "Missing file extension for dynamically loaded Operator < {} , {:?}>.",
+                record.id.clone(),
+                file_path,
+            ))
+        })?;
+
+        match self
+            .config
+            .extentions
+            .iter()
+            .find(|e| e.file_extension == file_extension)
+        {
+            Some(e) => {
+                let wrapper_file_path = std::fs::canonicalize(&e.operator_lib)?;
+                let mut new_config: serde_json::map::Map<String, Configuration> =
+                    serde_json::map::Map::new();
+                new_config.insert(e.config_lib_key.clone(), file_path.to_str().unwrap().into());
+
+                if let Some(config) = record.configuration {
+                    new_config.insert(String::from("configuration"), config);
+                }
+                record.configuration = Some(new_config.into());
+
+                let (lib, op) = unsafe { Self::load_lib_operator(wrapper_file_path) }?;
+                Ok(OperatorLoaded::try_new(record, Some(Arc::new(lib)), op)?)
+            }
+            _ => Err(ZFError::Unimplemented),
+        }
+    }
+
+    fn load_source_from_extension(
+        &self,
+        mut record: SourceRecord,
+        file_path: PathBuf,
+    ) -> ZFResult<SourceLoaded> {
+        let file_extension = Self::get_file_extention(&file_path).ok_or_else(|| {
+            ZFError::LoadingError(format!(
+                "Missing file extension for dynamically loaded Operator < {} , {:?}>.",
+                record.id.clone(),
+                file_path,
+            ))
+        })?;
+
+        match self
+            .config
+            .extentions
+            .iter()
+            .find(|e| e.file_extension == file_extension)
+        {
+            Some(e) => {
+                let wrapper_file_path = std::fs::canonicalize(&e.source_lib)?;
+                let mut new_config: serde_json::map::Map<String, Configuration> =
+                    serde_json::map::Map::new();
+                new_config.insert(e.config_lib_key.clone(), file_path.to_str().unwrap().into());
+
+                if let Some(config) = record.configuration {
+                    new_config.insert(String::from("configuration"), config);
+                }
+                record.configuration = Some(new_config.into());
+
+                let (lib, op) = unsafe { Self::load_lib_source(wrapper_file_path) }?;
+                Ok(SourceLoaded::try_new(record, Some(Arc::new(lib)), op)?)
+            }
+            _ => Err(ZFError::Unimplemented),
+        }
+    }
+
+    fn load_sink_from_extension(
+        &self,
+        mut record: SinkRecord,
+        file_path: PathBuf,
+    ) -> ZFResult<SinkLoaded> {
+        let file_extension = Self::get_file_extention(&file_path).ok_or_else(|| {
+            ZFError::LoadingError(format!(
+                "Missing file extension for dynamically loaded Operator < {} , {:?}>.",
+                record.id.clone(),
+                file_path,
+            ))
+        })?;
+
+        match self
+            .config
+            .extentions
+            .iter()
+            .find(|e| e.file_extension == file_extension)
+        {
+            Some(e) => {
+                let wrapper_file_path = std::fs::canonicalize(&e.sink_lib)?;
+                let mut new_config: serde_json::map::Map<String, Configuration> =
+                    serde_json::map::Map::new();
+                new_config.insert(e.config_lib_key.clone(), file_path.to_str().unwrap().into());
+
+                if let Some(config) = record.configuration {
+                    new_config.insert(String::from("configuration"), config);
+                }
+                record.configuration = Some(new_config.into());
+
+                let (lib, op) = unsafe { Self::load_lib_sink(wrapper_file_path) }?;
+                Ok(SinkLoaded::try_new(record, Some(Arc::new(lib)), op)?)
+            }
+            _ => Err(ZFError::Unimplemented),
+        }
+    }
 }

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -18,7 +18,6 @@ pub mod node;
 
 use async_std::sync::{Arc, RwLock};
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -72,7 +71,7 @@ impl Dataflow {
             .sources
             .into_iter()
             .filter(|source| source.runtime == context.runtime_name)
-            .map(SourceLoaded::try_from)
+            .map(|r| context.loader.load_source(r))
             .collect();
         let sources: HashMap<_, _> = res_sources?
             .into_iter()
@@ -83,7 +82,7 @@ impl Dataflow {
             .operators
             .into_iter()
             .filter(|operator| operator.runtime == context.runtime_name)
-            .map(OperatorLoaded::try_from)
+            .map(|r| context.loader.load_operator(r))
             .collect();
         let operators: HashMap<_, _> = res_operators?
             .into_iter()
@@ -94,7 +93,7 @@ impl Dataflow {
             .sinks
             .into_iter()
             .filter(|sink| sink.runtime == context.runtime_name)
-            .map(SinkLoaded::try_from)
+            .map(|r| context.loader.load_sink(r))
             .collect();
         let sinks: HashMap<_, _> = res_sinks?
             .into_iter()

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use uuid::Uuid;
 
+use crate::runtime::dataflow::loader::Loader;
 use crate::RuntimeId;
 use crate::{
     model::dataflow::{DataFlowDescriptor, Mapping},
@@ -42,6 +43,8 @@ use zrpc::zrpcresult::{ZRPCError, ZRPCResult};
 // use async_std::prelude::FutureExt;
 use uhlc::HLC;
 use zenoh::net::Session;
+
+use self::dataflow::loader::LoaderConfig;
 pub mod dataflow;
 pub mod message;
 pub mod resources;
@@ -50,6 +53,7 @@ pub mod token;
 #[derive(Clone)]
 pub struct RuntimeContext {
     pub session: Arc<Session>,
+    pub loader: Arc<Loader>,
     pub hlc: Arc<HLC>,
     pub runtime_name: RuntimeId,
     pub runtime_uuid: Uuid,
@@ -172,6 +176,7 @@ pub struct RuntimeConfig {
     pub name: Option<String>,
     pub uuid: Option<Uuid>,
     pub zenoh: ZenohConfig,
+    pub loader: LoaderConfig,
 }
 
 /// The interface the Runtime expose to a client

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -196,7 +196,7 @@ async fn single_runtime() {
     let ctx = RuntimeContext {
         session,
         hlc,
-        loader: Arc::new(Loader::new(LoaderConfig { extentions: vec![] })),
+        loader: Arc::new(Loader::new(LoaderConfig { extensions: vec![] })),
         runtime_name: format!("test-runtime-{}", rt_uuid).into(),
         runtime_uuid: rt_uuid,
     };

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -20,6 +20,7 @@ use std::convert::TryInto;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
+use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::zenoh_flow_derive::ZFData;
 use zenoh_flow::{
@@ -195,6 +196,7 @@ async fn single_runtime() {
     let ctx = RuntimeContext {
         session,
         hlc,
+        loader: Arc::new(Loader::new(LoaderConfig { extentions: vec![] })),
         runtime_name: format!("test-runtime-{}", rt_uuid).into(),
         runtime_uuid: rt_uuid,
     };

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use types::{CounterState, ZFUsize};
 use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
+use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::{
     default_output_rule, zf_empty_state, Configuration, Context, Data, DeadlineMiss, Node,
@@ -185,6 +186,7 @@ async fn single_runtime() {
     let ctx = RuntimeContext {
         session,
         hlc,
+        loader: Arc::new(Loader::new(LoaderConfig { extentions: vec![] })),
         runtime_name: format!("test-runtime-{}", rt_uuid).into(),
         runtime_uuid: rt_uuid,
     };

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -186,7 +186,7 @@ async fn single_runtime() {
     let ctx = RuntimeContext {
         session,
         hlc,
-        loader: Arc::new(Loader::new(LoaderConfig { extentions: vec![] })),
+        loader: Arc::new(Loader::new(LoaderConfig { extensions: vec![] })),
         runtime_name: format!("test-runtime-{}", rt_uuid).into(),
         runtime_uuid: rt_uuid,
     };

--- a/zenoh-flow/tests/local_deadline.rs
+++ b/zenoh-flow/tests/local_deadline.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use types::{VecSink, VecSource, ZFUsize};
 use zenoh_flow::model::link::{LinkFromDescriptor, LinkToDescriptor, PortDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
+use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::{
     default_input_rule, default_output_rule, zf_empty_state, Configuration, Data, DeadlineMiss,
@@ -102,6 +103,7 @@ async fn single_runtime() {
     let ctx = RuntimeContext {
         session,
         hlc,
+        loader: Arc::new(Loader::new(LoaderConfig { extentions: vec![] })),
         runtime_name: format!("test-runtime-{}", rt_uuid).into(),
         runtime_uuid: rt_uuid,
     };

--- a/zenoh-flow/tests/local_deadline.rs
+++ b/zenoh-flow/tests/local_deadline.rs
@@ -103,7 +103,7 @@ async fn single_runtime() {
     let ctx = RuntimeContext {
         session,
         hlc,
-        loader: Arc::new(Loader::new(LoaderConfig { extentions: vec![] })),
+        loader: Arc::new(Loader::new(LoaderConfig { extensions: vec![] })),
         runtime_name: format!("test-runtime-{}", rt_uuid).into(),
         runtime_uuid: rt_uuid,
     };


### PR DESCRIPTION
Implementing the `Loader`, this struct comes with a configuration that allows for extensibility w.r.t. supporting different languages for the implementation of nodes of the graph.

An example configuration is:
```yaml
extentions:
  - name: python
    file_extension: py
    source_lib: /some/path/to/target/debug/libpy_source.dylib
    sink_lib:  /some/path/to/target/debug/libpy_sink.dylib
    operator_lib:  /some/path/to/target/debug/libpy_op.dylib
    config_lib_key: python-script
```

Which will add support for Python nodes.
The idea is that languages that require a runtime/interpreter can be supported by the means of simple wrappers and then the loader will load the wrapper and then the wrappers loads and runs the actual user code.

An example of such a pattern can be found in the [Python API](https://github.com/atolab/zenoh-flow-python) 
