### PR TITLE
refacto: rename `{From|To}Descriptor` to `{Output|Input}Descriptor`

### DIFF
--- a/zenoh-flow/src/model/dataflow/record.rs
+++ b/zenoh-flow/src/model/dataflow/record.rs
@@ -17,7 +17,7 @@ use crate::model::dataflow::descriptor::DataFlowDescriptor;
 use crate::model::deadline::E2EDeadlineRecord;
 use crate::model::link::{LinkDescriptor, PortDescriptor};
 use crate::model::node::{OperatorRecord, SinkRecord, SourceRecord};
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::serde::{Deserialize, Serialize};
 use crate::types::{RuntimeId, ZFError, ZFResult};
 use crate::PortType;
@@ -194,7 +194,7 @@ impl DataFlowRecord {
                     // creating link between node and sender
                     let link_sender = LinkDescriptor {
                         from: l.from.clone(),
-                        to: ToDescriptor {
+                        to: InputDescriptor {
                             node: sender_id.into(),
                             input: l.from.output.clone(),
                         },
@@ -227,7 +227,7 @@ impl DataFlowRecord {
 
                 // Creating link between receiver and node
                 let link_receiver = LinkDescriptor {
-                    from: FromDescriptor {
+                    from: OutputDescriptor {
                         node: receiver_id.into(),
                         output: l.to.input.clone(),
                     },

--- a/zenoh-flow/src/model/dataflow/validator.rs
+++ b/zenoh-flow/src/model/dataflow/validator.rs
@@ -14,7 +14,7 @@
 
 use crate::model::dataflow::descriptor::DataFlowDescriptor;
 use crate::model::link::PortDescriptor;
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::types::{NodeId, ZFError, ZFResult};
 use crate::{PortId, PortType};
 use petgraph::graph::{EdgeIndex, NodeIndex};
@@ -217,8 +217,8 @@ impl DataflowValidator {
 
     pub(crate) fn try_add_link(
         &mut self,
-        from: &FromDescriptor,
-        to: &ToDescriptor,
+        from: &OutputDescriptor,
+        to: &InputDescriptor,
     ) -> ZFResult<()> {
         let from_graph_checker_idx = self
             .map_id_to_graph_checker_idx
@@ -343,8 +343,8 @@ impl DataflowValidator {
     /// NOTE: . Hence the extra steps.
     pub(crate) fn validate_deadline(
         &self,
-        from: &FromDescriptor,
-        to: &ToDescriptor,
+        from: &OutputDescriptor,
+        to: &InputDescriptor,
     ) -> ZFResult<()> {
         let to_idx = self
             .map_id_to_graph_checker_idx

--- a/zenoh-flow/src/model/deadline.rs
+++ b/zenoh-flow/src/model/deadline.rs
@@ -12,7 +12,7 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::runtime::deadline::E2EDeadline;
 use crate::DurationDescriptor;
 use serde::{Deserialize, Serialize};
@@ -20,15 +20,15 @@ use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineDescriptor {
-    pub(crate) from: FromDescriptor,
-    pub(crate) to: ToDescriptor,
+    pub(crate) from: OutputDescriptor,
+    pub(crate) to: InputDescriptor,
     pub(crate) duration: DurationDescriptor,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineRecord {
-    pub(crate) from: FromDescriptor,
-    pub(crate) to: ToDescriptor,
+    pub(crate) from: OutputDescriptor,
+    pub(crate) to: InputDescriptor,
     pub(crate) duration: Duration,
 }
 

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -12,14 +12,14 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::{PortId, PortType};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LinkDescriptor {
-    pub from: FromDescriptor,
-    pub to: ToDescriptor,
+    pub from: OutputDescriptor,
+    pub to: InputDescriptor,
     pub size: Option<usize>,
     pub queueing_policy: Option<String>,
     pub priority: Option<usize>,

--- a/zenoh-flow/src/model/mod.rs
+++ b/zenoh-flow/src/model/mod.rs
@@ -25,24 +25,24 @@ use crate::{DurationDescriptor, NodeId, PortId};
 use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FromDescriptor {
+pub struct OutputDescriptor {
     pub node: NodeId,
     pub output: PortId,
 }
 
-impl fmt::Display for FromDescriptor {
+impl fmt::Display for OutputDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{}.{}", self.node, self.output))
     }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct ToDescriptor {
+pub struct InputDescriptor {
     pub node: NodeId,
     pub input: PortId,
 }
 
-impl fmt::Display for ToDescriptor {
+impl fmt::Display for InputDescriptor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!("{}.{}", self.node, self.input))
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::model::deadline::E2EDeadlineRecord;
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
 use crate::runtime::dataflow::instance::runners::operator::{OperatorIO, OperatorRunner};
 use crate::runtime::dataflow::instance::runners::NodeRunner;
@@ -233,11 +233,11 @@ fn e2e_deadline() {
     };
     let operator_id: NodeId = "TestOperatorDeadlineViolated".into();
     let operator_deadline = E2EDeadlineRecord {
-        from: FromDescriptor {
+        from: OutputDescriptor {
             node: operator_id.clone(),
             output: output.clone(),
         },
-        to: ToDescriptor {
+        to: InputDescriptor {
             node: "future-not-violated".into(),
             input: input1.clone(),
         },
@@ -271,11 +271,11 @@ fn e2e_deadline() {
             // is not supposed to check it as it’s not the "to" node.
             let deadline_violated_to_propagate = E2EDeadline {
                 duration: Duration::from_millis(100),
-                from: FromDescriptor {
+                from: OutputDescriptor {
                     node: "past".into(),
                     output: output.clone(),
                 },
-                to: ToDescriptor {
+                to: InputDescriptor {
                     node: "future".into(),
                     input: input1.clone(),
                 },
@@ -299,11 +299,11 @@ fn e2e_deadline() {
                 vec![
                     E2EDeadline {
                         duration: Duration::from_millis(100),
-                        from: FromDescriptor {
+                        from: OutputDescriptor {
                             node: "past".into(),
                             output: output.clone(),
                         },
-                        to: ToDescriptor {
+                        to: InputDescriptor {
                             node: operator_id.clone(),
                             input: input1.clone(),
                         },
@@ -311,11 +311,11 @@ fn e2e_deadline() {
                     },
                     E2EDeadline {
                         duration: Duration::from_millis(100),
-                        from: FromDescriptor {
+                        from: OutputDescriptor {
                             node: "past".into(),
                             output: output.clone(),
                         },
-                        to: ToDescriptor {
+                        to: InputDescriptor {
                             node: operator_id.clone(),
                             input: input2.clone(),
                         },

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/sink_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/sink_e2e_deadline_tests.rs
@@ -14,7 +14,7 @@
 
 use crate::model::deadline::E2EDeadlineRecord;
 use crate::model::link::PortDescriptor;
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
 use crate::runtime::dataflow::instance::runners::sink::SinkRunner;
 use crate::runtime::dataflow::instance::runners::NodeRunner;
@@ -131,11 +131,11 @@ fn sink_e2e_deadline() {
     let sink = TestSinkE2EDeadline {};
 
     let e2e_deadline_miss = E2EDeadlineRecord {
-        from: FromDescriptor {
+        from: OutputDescriptor {
             node: "past-missed".into(),
             output: input.clone(),
         },
-        to: ToDescriptor {
+        to: InputDescriptor {
             node: sink_id.clone(),
             input: input.clone(),
         },
@@ -143,11 +143,11 @@ fn sink_e2e_deadline() {
     };
 
     let e2e_deadline_ok = E2EDeadlineRecord {
-        from: FromDescriptor {
+        from: OutputDescriptor {
             node: "past-ok".into(),
             output: input.clone(),
         },
-        to: ToDescriptor {
+        to: InputDescriptor {
             node: sink_id.clone(),
             input: input.clone(),
         },

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/source_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/source_e2e_deadline_tests.rs
@@ -14,7 +14,7 @@
 
 use crate::model::deadline::E2EDeadlineRecord;
 use crate::model::link::PortDescriptor;
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
 use crate::runtime::dataflow::instance::runners::source::SourceRunner;
 use crate::runtime::dataflow::instance::runners::NodeRunner;
@@ -123,11 +123,11 @@ fn source_e2e_deadline() {
     let source = TestSourceE2EDeadline {};
 
     let e2e_deadline_1 = E2EDeadlineRecord {
-        from: FromDescriptor {
+        from: OutputDescriptor {
             node: source_id.clone(),
             output: output.clone(),
         },
-        to: ToDescriptor {
+        to: InputDescriptor {
             node: "future".into(),
             input: "future-input".into(),
         },
@@ -135,11 +135,11 @@ fn source_e2e_deadline() {
     };
 
     let e2e_deadline_2 = E2EDeadlineRecord {
-        from: FromDescriptor {
+        from: OutputDescriptor {
             node: source_id.clone(),
             output: output.clone(),
         },
-        to: ToDescriptor {
+        to: InputDescriptor {
             node: "future2".into(),
             input: "future2-input".into(),
         },

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -26,7 +26,7 @@ use crate::model::dataflow::record::DataFlowRecord;
 use crate::model::dataflow::validator::DataflowValidator;
 use crate::model::deadline::E2EDeadlineRecord;
 use crate::model::link::{LinkDescriptor, PortDescriptor};
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::runtime::dataflow::node::{OperatorLoaded, SinkLoaded, SourceLoaded};
 use crate::runtime::RuntimeContext;
 use crate::{
@@ -231,8 +231,8 @@ impl Dataflow {
     /// identical.
     pub fn try_add_link(
         &mut self,
-        from: FromDescriptor,
-        to: ToDescriptor,
+        from: OutputDescriptor,
+        to: InputDescriptor,
         size: Option<usize>,
         queueing_policy: Option<String>,
         priority: Option<usize>,
@@ -252,8 +252,8 @@ impl Dataflow {
 
     pub fn try_add_deadline(
         &mut self,
-        from: FromDescriptor,
-        to: ToDescriptor,
+        from: OutputDescriptor,
+        to: InputDescriptor,
         duration: Duration,
     ) -> ZFResult<()> {
         self.validator.validate_deadline(&from, &to)?;

--- a/zenoh-flow/src/runtime/deadline.rs
+++ b/zenoh-flow/src/runtime/deadline.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::model::deadline::E2EDeadlineRecord;
-use crate::model::{FromDescriptor, ToDescriptor};
+use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::{NodeId, PortId};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
@@ -34,8 +34,8 @@ pub struct LocalDeadlineMiss {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineMiss {
     pub duration: Duration,
-    pub from: FromDescriptor,
-    pub to: ToDescriptor,
+    pub from: OutputDescriptor,
+    pub to: InputDescriptor,
     pub start: Timestamp,
     pub end: Timestamp,
 }
@@ -56,8 +56,8 @@ impl E2EDeadlineMiss {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct E2EDeadline {
     pub duration: Duration,
-    pub from: FromDescriptor,
-    pub to: ToDescriptor,
+    pub from: OutputDescriptor,
+    pub to: InputDescriptor,
     pub start: Timestamp,
 }
 

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use zenoh_flow::model::link::PortDescriptor;
-use zenoh_flow::model::{FromDescriptor, ToDescriptor};
+use zenoh_flow::model::{InputDescriptor, OutputDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
@@ -252,11 +252,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: "counter-source".into(),
                 output: SOURCE.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: "noop".into(),
                 input: SOURCE.into(),
             },
@@ -268,11 +268,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: "noop".into(),
                 output: DESTINATION.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: "generic-sink".into(),
                 input: SOURCE.into(),
             },

--- a/zenoh-flow/tests/e2e_deadline.rs
+++ b/zenoh-flow/tests/e2e_deadline.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use types::{VecSource, ZFUsize};
 use zenoh_flow::model::link::PortDescriptor;
-use zenoh_flow::model::{FromDescriptor, ToDescriptor};
+use zenoh_flow::model::{InputDescriptor, OutputDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
@@ -203,11 +203,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: SOURCE.into(),
                 output: SOURCE.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: OPERATOR.into(),
                 input: SOURCE.into(),
             },
@@ -219,11 +219,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: OPERATOR.into(),
                 output: SINK.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: SINK.into(),
                 input: SINK.into(),
             },
@@ -236,11 +236,11 @@ async fn single_runtime() {
     // A deadline starting at SINK and going to OPERATOR is impossible and should return an error.
     assert!(dataflow
         .try_add_deadline(
-            FromDescriptor {
+            OutputDescriptor {
                 node: SINK.into(),
                 output: SINK.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: OPERATOR.into(),
                 input: SOURCE.into(),
             },
@@ -251,11 +251,11 @@ async fn single_runtime() {
     // Correct end to end deadline between SOURCE and SINK.
     assert!(dataflow
         .try_add_deadline(
-            FromDescriptor {
+            OutputDescriptor {
                 node: SOURCE.into(),
                 output: SOURCE.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: SINK.into(),
                 input: SINK.into(),
             },

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -20,7 +20,7 @@ use flume::{bounded, Receiver};
 use std::collections::HashMap;
 use types::{CounterState, ZFUsize};
 use zenoh_flow::model::link::PortDescriptor;
-use zenoh_flow::model::{FromDescriptor, ToDescriptor};
+use zenoh_flow::model::{InputDescriptor, OutputDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
@@ -242,11 +242,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: SOURCE.into(),
                 output: SOURCE.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: "noop".into(),
                 input: SOURCE.into(),
             },
@@ -258,11 +258,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: "noop".into(),
                 output: DESTINATION.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: "generic-sink".into(),
                 input: DESTINATION.into(),
             },

--- a/zenoh-flow/tests/local_deadline.rs
+++ b/zenoh-flow/tests/local_deadline.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use types::{VecSink, VecSource, ZFUsize};
 use zenoh_flow::model::link::PortDescriptor;
-use zenoh_flow::model::{FromDescriptor, ToDescriptor};
+use zenoh_flow::model::{InputDescriptor, OutputDescriptor};
 use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
@@ -159,11 +159,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: SOURCE.into(),
                 output: SOURCE.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: OPERATOR.into(),
                 input: SOURCE.into(),
             },
@@ -175,11 +175,11 @@ async fn single_runtime() {
 
     dataflow
         .try_add_link(
-            FromDescriptor {
+            OutputDescriptor {
                 node: OPERATOR.into(),
                 output: SINK.into(),
             },
-            ToDescriptor {
+            InputDescriptor {
                 node: SINK.into(),
                 input: SINK.into(),
             },


### PR DESCRIPTION
This modification is in preparation for the implementation of Loops. Indeed, for
a Loop, the "from" (resp. "to") corresponds to an Input (resp. Output).

Renaming both aims at removing this ambiguity.