### PR TITLE
Initial implementation of record and replay

### DIFF
--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -650,7 +650,7 @@ impl Runtime for Daemon {
 
         match _state.graphs.get_mut(&instance_id) {
             Some(mut instance) => {
-                if !(instance.node_is_running(&source_id).await?) {
+                if !(instance.is_node_running(&source_id).await?) {
                     let replay_id = instance.start_replay(&source_id, key_expr).await?;
                     Ok(replay_id)
                 } else {

--- a/zenoh-flow/src/runtime/dataflow/instance/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/mod.rs
@@ -258,7 +258,7 @@ impl DataflowInstance {
         Err(ZFError::Unimplemented)
     }
 
-    pub async fn node_is_running(&self, node_id: &NodeId) -> ZFResult<bool> {
+    pub async fn is_node_running(&self, node_id: &NodeId) -> ZFResult<bool> {
         self.runners
             .get(node_id)
             .ok_or_else(|| ZFError::NodeNotFound(node_id.clone()))?;
@@ -304,8 +304,12 @@ impl DataflowInstance {
         manager.stop_recording().await
     }
 
+    /// Assumes the source is already stopped before calling the start replay!
+    /// This method is called by the daemon, that always check that the node
+    /// is not running prior to call this function.
+    /// If someone is using directly the DataflowInstance need to stop and check
+    /// if the node is running before calling this function.
     pub async fn start_replay(&mut self, source_id: &NodeId, resource: String) -> ZFResult<NodeId> {
-        // Assumes the source is already stopped before calling the start replay!
         let runner = self
             .runners
             .get(source_id)

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -100,12 +100,12 @@ impl Runner for ZenohSender {
         loop {
             match self.iteration().await {
                 Ok(_) => {
-                    log::debug!("ZenohSender [{}] iteration ok", self.id);
+                    log::debug!("[ZenohSender: {}] iteration ok", self.id);
                     continue;
                 }
                 Err(e) => {
                     log::error!(
-                        "ZenohSender [{}] iteration failed with error: {}",
+                        "[ZenohSender: {}] iteration failed with error: {}",
                         self.id,
                         e
                     );

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/mod.rs
@@ -136,6 +136,10 @@ pub trait Runner: Send + Sync {
     async fn stop_recording(&self) -> ZFResult<String>;
 
     async fn is_recording(&self) -> bool;
+
+    async fn is_running(&self) -> bool;
+
+    async fn stop(&self);
 }
 
 #[derive(Clone)]
@@ -177,6 +181,7 @@ impl NodeRunner {
                             "[Node: {}] Received kill command, killing runner",
                             self.get_id()
                         );
+                        self.stop().await;
                         return Ok(());
                     }
                 }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -518,7 +518,7 @@ impl Runner for OperatorRunner {
             match self.iteration(context, tokens, data).await {
                 Ok((ctx, tkn, d)) => {
                     log::debug!(
-                        "Operator [{}] iteration ok with new context {:?}",
+                        "[Operator: {}] iteration ok with new context {:?}",
                         self.id,
                         ctx
                     );
@@ -528,7 +528,7 @@ impl Runner for OperatorRunner {
                     continue;
                 }
                 Err(e) => {
-                    log::error!("Operator [{}] iteration failed with error: {}", self.id, e);
+                    log::error!("[Operator: {}] iteration failed with error: {}", self.id, e);
                     self.stop().await;
                     break Err(e);
                 }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
@@ -200,12 +200,16 @@ impl Runner for SinkRunner {
         loop {
             match self.iteration(context).await {
                 Ok(ctx) => {
-                    log::debug!("Sink [{}] iteration ok with new context {:?}", self.id, ctx);
+                    log::debug!(
+                        "[Sink: {}] iteration ok with new context {:?}",
+                        self.id,
+                        ctx
+                    );
                     context = ctx;
                     continue;
                 }
                 Err(e) => {
-                    log::error!("Sink [{}] iteration failed with error: {}", self.id, e);
+                    log::error!("[Sink: {}] iteration failed with error: {}", self.id, e);
                     self.stop().await;
                     break Err(e);
                 }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
@@ -44,6 +44,7 @@ pub struct SinkRunner {
     pub(crate) input: PortDescriptor,
     pub(crate) link: Arc<Mutex<Option<LinkReceiver<Message>>>>,
     pub(crate) _end_to_end_deadlines: Vec<E2EDeadlineRecord>, //FIXME
+    pub(crate) is_running: Arc<Mutex<bool>>,
     pub(crate) state: Arc<Mutex<State>>,
     pub(crate) sink: Arc<dyn Sink>,
     pub(crate) _library: Option<Arc<Library>>,
@@ -66,10 +67,58 @@ impl SinkRunner {
             input: sink.input,
             link: Arc::new(Mutex::new(Some(link))),
             _end_to_end_deadlines: sink.end_to_end_deadlines,
+            is_running: Arc::new(Mutex::new(false)),
             state: sink.state,
             sink: sink.sink,
             _library: sink.library,
         })
+    }
+
+    async fn start(&self) {
+        *self.is_running.lock().await = true;
+    }
+    async fn iteration(&self, mut context: Context) -> ZFResult<Context> {
+        // Guards are taken at the beginning of each iteration to allow interleaving.
+        if let Some(link) = &*self.link.lock().await {
+            let mut state = self.state.lock().await;
+
+            let (port_id, message) = link.recv().await?;
+            let input = match message.as_ref() {
+                Message::Data(data_message) => {
+                    if let Err(error) = self
+                        .context
+                        .runtime
+                        .hlc
+                        .update_with_timestamp(&data_message.timestamp)
+                    {
+                        log::error!(
+                            "[Sink: {}][HLC] Could not update HLC with timestamp {:?}: {:?}",
+                            self.id,
+                            data_message.timestamp,
+                            error
+                        );
+                    }
+                    let now = self.context.runtime.hlc.new_timestamp();
+                    let mut input = data_message.clone();
+
+                    data_message
+                        .end_to_end_deadlines
+                        .iter()
+                        .for_each(|e2e_deadline| {
+                            if let Some(miss) = e2e_deadline.check(&self.id, &port_id, &now) {
+                                input.missed_end_to_end_deadlines.push(miss);
+                            }
+                        });
+
+                    input
+                }
+
+                Message::Control(_) => return Err(ZFError::Unimplemented),
+            };
+
+            self.sink.run(&mut context, &mut state, input).await?;
+        }
+        Ok(context)
     }
 }
 
@@ -132,49 +181,34 @@ impl Runner for SinkRunner {
         false
     }
 
+    async fn is_running(&self) -> bool {
+        *self.is_running.lock().await
+    }
+
+    async fn stop(&self) {
+        *self.is_running.lock().await = false;
+    }
+
     async fn run(&self) -> ZFResult<()> {
+        self.start().await;
+
         let mut context = Context::default();
+        // Looping on iteration, each iteration is a single
+        // run of the source, as a run can fail in case of error it
+        // stops and returns the error to the caller (the RunnerManager)
 
         loop {
-            // Guards are taken at the beginning of each iteration to allow interleaving.
-            if let Some(link) = &*self.link.lock().await {
-                let mut state = self.state.lock().await;
-
-                let (port_id, message) = link.recv().await?;
-                let input = match message.as_ref() {
-                    Message::Data(data_message) => {
-                        if let Err(error) = self
-                            .context
-                            .runtime
-                            .hlc
-                            .update_with_timestamp(&data_message.timestamp)
-                        {
-                            log::error!(
-                                "[Sink: {}][HLC] Could not update HLC with timestamp {:?}: {:?}",
-                                self.id,
-                                data_message.timestamp,
-                                error
-                            );
-                        }
-                        let now = self.context.runtime.hlc.new_timestamp();
-                        let mut input = data_message.clone();
-
-                        data_message
-                            .end_to_end_deadlines
-                            .iter()
-                            .for_each(|e2e_deadline| {
-                                if let Some(miss) = e2e_deadline.check(&self.id, &port_id, &now) {
-                                    input.missed_end_to_end_deadlines.push(miss);
-                                }
-                            });
-
-                        input
-                    }
-
-                    Message::Control(_) => return Err(ZFError::Unimplemented),
-                };
-
-                self.sink.run(&mut context, &mut state, input).await?;
+            match self.iteration(context).await {
+                Ok(ctx) => {
+                    log::debug!("Sink [{}] iteration ok with new context {:?}", self.id, ctx);
+                    context = ctx;
+                    continue;
+                }
+                Err(e) => {
+                    log::error!("Sink [{}] iteration failed with error: {}", self.id, e);
+                    self.stop().await;
+                    break Err(e);
+                }
             }
         }
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -313,7 +313,7 @@ impl Runner for SourceRunner {
             match self.iteration(context).await {
                 Ok(ctx) => {
                     log::debug!(
-                        "Source [{}] iteration ok with new context {:?}",
+                        "[Source: {}] iteration ok with new context {:?}",
                         self.id,
                         ctx
                     );
@@ -321,7 +321,7 @@ impl Runner for SourceRunner {
                     continue;
                 }
                 Err(e) => {
-                    log::error!("Source [{}] iteration failed with error: {}", self.id, e);
+                    log::error!("[Source: {}] iteration failed with error: {}", self.id, e);
                     self.stop().await;
                     break Err(e);
                 }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
@@ -251,6 +251,7 @@ fn e2e_deadline() {
         inputs,
         outputs,
         local_deadline: None,
+        is_running: Arc::new(Mutex::new(false)),
         state: Arc::new(Mutex::new(operator.initialize(&None).unwrap())),
         operator: Arc::new(operator),
         _library: None,

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
@@ -262,6 +262,7 @@ fn input_rule_keep() {
         outputs,
         local_deadline: None,
         state: Arc::new(Mutex::new(operator.initialize(&None).unwrap())),
+        is_running: Arc::new(Mutex::new(false)),
         operator: Arc::new(operator),
         _library: None,
         end_to_end_deadlines: vec![],

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/sink_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/sink_e2e_deadline_tests.rs
@@ -162,6 +162,7 @@ fn sink_e2e_deadline() {
             port_type: "ZFUsize".into(),
         },
         link: Arc::new(Mutex::new(Some(receiver_input))),
+        is_running: Arc::new(Mutex::new(false)),
         state: Arc::new(Mutex::new(sink.initialize(&None).unwrap())),
         sink: Arc::new(sink),
         _library: None,

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/source_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/source_e2e_deadline_tests.rs
@@ -155,6 +155,7 @@ fn source_e2e_deadline() {
             port_type: "ZFUsize".into(),
         },
         links: Arc::new(Mutex::new(vec![sender_output])),
+        is_running: Arc::new(Mutex::new(false)),
         state: Arc::new(Mutex::new(source.initialize(&None).unwrap())),
         end_to_end_deadlines: vec![e2e_deadline_1.clone(), e2e_deadline_2.clone()],
         base_resource_name: "test".into(),

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 use crate::runtime::dataflow::loader::Loader;
 use crate::runtime::message::ControlMessage;
-use crate::{RuntimeId, ZFError, ZFResult};
+use crate::{NodeId, RuntimeId, ZFError, ZFResult};
 use uhlc::HLC;
 use zenoh::Session;
 use znrpc_macros::znservice;
@@ -254,6 +254,31 @@ pub trait Runtime {
     /// Stops the given graph node from the given instance.
     /// A graph node can be a source, a sink, a connector, or an operator.
     async fn stop_node(&self, record_id: Uuid, node: String) -> ZFResult<()>;
+
+    /// Start a recording for the given source.
+    async fn start_record(&self, instance_id: Uuid, source_id: NodeId) -> ZFResult<String>;
+
+    /// Stops the recording for the given source.
+    async fn stop_record(&self, instance_id: Uuid, source_id: NodeId) -> ZFResult<String>;
+
+    /// Starts the replay for the given source.
+    /// The replay creates a new node that has the same port and links as the
+    /// source is replaying.
+    async fn start_replay(
+        &self,
+        instance_id: Uuid,
+        source_id: NodeId,
+        key_expr: String,
+    ) -> ZFResult<NodeId>;
+
+    /// Stops the replay for the given source.
+    /// This stops and removes the replay node from the graph.
+    async fn stop_replay(
+        &self,
+        instance_id: Uuid,
+        source_id: NodeId,
+        replay_id: NodeId,
+    ) -> ZFResult<NodeId>;
 
     /// Gets the state of the given graph node for the given instance.
     /// A graph node can be a source, a sink, a connector, or an operator.

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -30,7 +30,7 @@ pub use crate::ZFError;
 
 /// ZFContext is a structure provided by Zenoh Flow to access the execution context directly from
 /// the nodes.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Context {
     pub mode: usize,
 }


### PR DESCRIPTION
This PR contains the code with the initial implementation of logging and replay.

- Sources can be **recorded** 
  - Data coming from sources is serialized and sent to zenoh in order to be stored in some time-series storages
  - Markers are sent when starting and stopping the logging
  - Users can read the recording directly from zenoh using the key expression provided when recording.

- Sources can be **replayed** 
  - Data will come from zenoh and the replay will happen in order and with the same pace of the recording.
  
  
In order for the logging/replay to work a zenoh storage in InfluxDB needs to be present, and example configuration of zenoh with a storage is provided below

```json
{
    "listeners": ["tcp/127.0.0.1:7887"],
    "link_state":true,
    "plugins_search_dirs":["/usr/lib/"],
    "plugins":{
        "storages":{
        "required":true,
        "backends":{
            "memory":{
                "required":true,
                "storages":{
                    "zfrpc":{
                        "key_expr":"/zf/runtime/**"
                        },
                        "zf":{
                            "key_expr":"/zenoh-flow/**"
                           }
                    }
                },
            "influxdb":{
                "url":"http://localhost:8086",
                "db":"zf_log_example",
                "storages":{
                    "replay":{
                        "key_expr":"/zf/record/**"
                        }
                    }
                }
            }
        }
    }
}
```  