### PR TITLE
Meta packages from RPM and deb

### DIFF
--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -45,7 +45,7 @@ maintainer = "ADLINK Zenoh team <zenoh@adlink-labs.tech>"
 copyright = "2021, ADLINK Technology Inc"
 extended-description = "Eclipse Zenoh Flow Daemon"
 license-file = ["../LICENSE", "0"]
-depends = "$auto, zenohd (=0.6.0~dev.0), zenoh-plugin-storages (=0.6.0~dev.0)"
+depends = "$auto"
 section = "utils"
 priority = "optional"
 assets = [

--- a/zenoh-flow-daemon/resources/rpm/template.hbs
+++ b/zenoh-flow-daemon/resources/rpm/template.hbs
@@ -57,4 +57,3 @@ rm -rf %{buildroot}
 /usr/bin/zenoh-flow-daemon
 /var/zenoh-flow/placeholder
 /lib/systemd/system/zenoh-flow.service
-%{_unitdir}/zenoh-flow.service

--- a/zenoh-flow/resources/debian/zenoh-flow
+++ b/zenoh-flow/resources/debian/zenoh-flow
@@ -1,0 +1,29 @@
+##
+## Copyright (c) 2017, 2021 ADLINK Technology Inc.
+##
+## This program and the accompanying materials are made available under the
+## terms of the Eclipse Public License 2.0 which is available at
+## http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+## which is available at https://www.apache.org/licenses/LICENSE-2.0.
+##
+## SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##
+## Contributors:
+##   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+##
+
+Section: utils
+Priority: optional
+# Homepage: <enter URL here; no default>
+Standards-Version: 3.9.2
+
+Package: zenoh-flow
+Version: 0.1.0
+Maintainer: ADLINK Zenoh team <zenoh@adlink-labs.tech>
+Depends: zenohd (=0.6.0~dev.0), zenoh-plugin-storages (=0.6.0~dev.0), zenoh-backend-influxdb (=0.6.0~dev.0), zenoh-flow-daemon (=0.1.0), zenoh-flow-ctl(=0.1.0)
+Vcs-Browser: https://github.com/eclipse-zenoh/zenoh-flow
+Vcs-Git: https://github.com/eclipse-zenoh/zenoh-flow
+Homepage: http://zenoh.io
+Architecture: all
+Description: Zenoh-Flow: zenoh-based data-flow programming framework for computations that
+  span from the cloud to the device.

--- a/zenoh-flow/resources/rpm/zenoh-flow
+++ b/zenoh-flow/resources/rpm/zenoh-flow
@@ -1,0 +1,9 @@
+%package -n zenoh-flow
+Summary: zenoh-based data-flow programming framework for computations that span from the cloud to the device.
+Requires: zenohd
+Requires: zenoh-plugin-storages
+Requires: zenoh-backend-influxdb
+Requires: zenoh-flow-daemon
+Requires: zenoh-flow-ctl
+%description -n  zenoh-flow
+zenoh-flow

--- a/zenoh-flow/resources/rpm/zenoh-flow.spec
+++ b/zenoh-flow/resources/rpm/zenoh-flow.spec
@@ -1,9 +1,13 @@
-%package -n zenoh-flow
+%define _rpmdir ./
+
+Name: zenoh-flow
+Version: 0.1.0
+Release: 0.1.0
+License: EPL 2.0 OR Apache 2.0
 Summary: zenoh-based data-flow programming framework for computations that span from the cloud to the device.
 Requires: zenohd
 Requires: zenoh-plugin-storages
 Requires: zenoh-backend-influxdb
 Requires: zenoh-flow-daemon
 Requires: zenoh-flow-ctl
-%description -n  zenoh-flow
-zenoh-flow
+%description -n zenoh-flow


### PR DESCRIPTION
This PR implements #73, providing meta-package definitions, for both Debian files and rpm files.
It also updates the dependencies for zenoh-flow-daemon.

