### PR TITLE
feat: add Loop support

### DIFF
--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -159,7 +159,7 @@ async fn main() {
             let target = if release {
                 format!(
                     "{}/release/{}{}{}",
-                    target_dir.as_path().display().to_string(),
+                    target_dir.as_path().display(),
                     std::env::consts::DLL_PREFIX,
                     node_info.id,
                     std::env::consts::DLL_SUFFIX
@@ -167,7 +167,7 @@ async fn main() {
             } else {
                 format!(
                     "{}/debug/{}{}{}",
-                    target_dir.as_path().display().to_string(),
+                    target_dir.as_path().display(),
                     std::env::consts::DLL_PREFIX,
                     node_info.id,
                     std::env::consts::DLL_SUFFIX

--- a/zenoh-flow-ctl/src/main.rs
+++ b/zenoh-flow-ctl/src/main.rs
@@ -178,19 +178,19 @@ async fn main() {
                             instance.flow,
                             instance
                                 .operators
-                                .iter()
+                                .values()
                                 .map(|o| format!("{}", o))
                                 .collect::<Vec<String>>()
                                 .join("\n"),
                             instance
                                 .sinks
-                                .iter()
+                                .values()
                                 .map(|o| format!("{}", o))
                                 .collect::<Vec<String>>()
                                 .join("\n"),
                             instance
                                 .sources
-                                .iter()
+                                .values()
                                 .map(|o| format!("{}", o))
                                 .collect::<Vec<String>>()
                                 .join("\n"),

--- a/zenoh-flow/src/error.rs
+++ b/zenoh-flow/src/error.rs
@@ -59,7 +59,7 @@ pub enum ZFError {
     NodeNotFound(NodeId),
     PortNotFound((NodeId, PortId)),
     PortNotConnected((NodeId, PortId)),
-    NotRecoding,
+    NotRecording,
     AlreadyRecording,
     NoPathBetweenNodes(((NodeId, PortId), (NodeId, PortId))),
 }

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -25,6 +25,7 @@ pub use ::typetag;
 pub mod model;
 pub mod runtime;
 pub use runtime::deadline::LocalDeadlineMiss;
+pub use runtime::loops::*;
 pub use runtime::message::*;
 pub use runtime::token::*;
 pub mod types;

--- a/zenoh-flow/src/model/dataflow/record.rs
+++ b/zenoh-flow/src/model/dataflow/record.rs
@@ -332,6 +332,8 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
         //
         // We finally add the loop information to the Ingress and Egress.
         if let Some(loops) = d.loops {
+            // Ciclo is the italian word for "loop" — we cannot use "loop" as it’s a reserved
+            // keyword.
             for ciclo in loops {
                 // Update the ingress / egress.
                 let ingress = dfr

--- a/zenoh-flow/src/model/dataflow/record.rs
+++ b/zenoh-flow/src/model/dataflow/record.rs
@@ -20,7 +20,8 @@ use crate::model::node::{OperatorRecord, SinkRecord, SourceRecord};
 use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::serde::{Deserialize, Serialize};
 use crate::types::{RuntimeId, ZFError, ZFResult};
-use crate::PortType;
+use crate::{NodeId, PortType};
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
@@ -29,9 +30,9 @@ use uuid::Uuid;
 pub struct DataFlowRecord {
     pub uuid: Uuid,
     pub flow: String,
-    pub operators: Vec<OperatorRecord>,
-    pub sinks: Vec<SinkRecord>,
-    pub sources: Vec<SourceRecord>,
+    pub operators: HashMap<NodeId, OperatorRecord>,
+    pub sinks: HashMap<NodeId, SinkRecord>,
+    pub sources: HashMap<NodeId, SourceRecord>,
     pub connectors: Vec<ZFConnectorRecord>,
     pub links: Vec<LinkDescriptor>,
     pub end_to_end_deadlines: Option<Vec<E2EDeadlineRecord>>,
@@ -57,23 +58,20 @@ impl DataFlowRecord {
     }
 
     pub fn find_node_runtime(&self, id: &str) -> Option<RuntimeId> {
-        match self.get_operator(id) {
-            Some(o) => Some(o.runtime),
-            None => match self.get_source(id) {
-                Some(s) => Some(s.runtime),
-                None => match self.get_sink(id) {
-                    Some(s) => Some(s.runtime),
-                    None => None,
-                },
+        match self.operators.get(id) {
+            Some(o) => Some(o.runtime.clone()),
+            None => match self.sources.get(id) {
+                Some(s) => Some(s.runtime.clone()),
+                None => self.sinks.get(id).map(|s| s.runtime.clone()),
             },
         }
     }
 
     pub fn find_node_output_type(&self, id: &str, output: &str) -> Option<PortType> {
         log::trace!("find_node_output_type({:?},{:?})", id, output);
-        match self.get_operator(id) {
+        match self.operators.get(id) {
             Some(o) => o.get_output_type(output),
-            None => match self.get_source(id) {
+            None => match self.sources.get(id) {
                 Some(s) => s.get_output_type(output),
                 None => None,
             },
@@ -82,49 +80,37 @@ impl DataFlowRecord {
 
     pub fn find_node_input_type(&self, id: &str, input: &str) -> Option<PortType> {
         log::trace!("find_node_input_type({:?},{:?})", id, input);
-        match self.get_operator(id) {
+        match self.operators.get(id) {
             Some(o) => o.get_input_type(input),
-            None => match self.get_sink(id) {
+            None => match self.sinks.get(id) {
                 Some(s) => s.get_input_type(input),
                 None => None,
             },
         }
     }
 
-    fn get_operator(&self, id: &str) -> Option<OperatorRecord> {
-        self.operators
-            .iter()
-            .find(|&o| o.id.as_ref() == id)
-            .cloned()
-    }
-
-    fn get_source(&self, id: &str) -> Option<SourceRecord> {
-        self.sources.iter().find(|&o| o.id.as_ref() == id).cloned()
-    }
-
-    fn get_sink(&self, id: &str) -> Option<SinkRecord> {
-        self.sinks.iter().find(|&o| o.id.as_ref() == id).cloned()
-    }
-
     fn add_links(&mut self, links: &[LinkDescriptor]) -> ZFResult<()> {
         for l in links {
+            log::debug!("Adding link: {:?}…", l);
             let from_runtime = match self.find_node_runtime(&l.from.node) {
                 Some(rt) => rt,
                 None => {
+                    log::error!("Could not find runtime for: {:?}", &l.from.node);
                     return Err(ZFError::Uncompleted(format!(
                         "Unable to find runtime for {}",
                         &l.from.node
-                    )))
+                    )));
                 }
             };
 
             let to_runtime = match self.find_node_runtime(&l.to.node) {
                 Some(rt) => rt,
                 None => {
+                    log::error!("Could not find runtime for: {:?}", &l.to.node);
                     return Err(ZFError::Uncompleted(format!(
                         "Unable to find runtime for {}",
                         &l.to.node
-                    )))
+                    )));
                 }
             };
 
@@ -153,6 +139,7 @@ impl DataFlowRecord {
             }
 
             if from_runtime == to_runtime {
+                log::debug!("Adding link: {:?}… OK", l);
                 // link between nodes on the same runtime
                 self.links.push(l.clone())
             } else {
@@ -251,7 +238,7 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
     type Error = ZFError;
 
     fn try_from(d: (DataFlowDescriptor, Uuid)) -> Result<Self, Self::Error> {
-        let (d, id) = d;
+        let (mut d, id) = d;
 
         let deadlines = d
             .deadlines
@@ -261,9 +248,9 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
         let mut dfr = DataFlowRecord {
             uuid: id,
             flow: d.flow.clone(),
-            operators: Vec::new(),
-            sinks: Vec::new(),
-            sources: Vec::new(),
+            operators: HashMap::new(),
+            sinks: HashMap::new(),
+            sources: HashMap::new(),
             connectors: Vec::new(),
             links: Vec::new(),
             end_to_end_deadlines: deadlines,
@@ -280,8 +267,9 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
                         configuration: o.configuration.clone(),
                         runtime: m,
                         deadline: o.deadline.as_ref().map(|period| period.to_duration()),
+                        ciclo: None,
                     };
-                    dfr.operators.push(or)
+                    dfr.operators.insert(o.id.clone(), or);
                 }
                 None => {
                     return Err(ZFError::Uncompleted(format!(
@@ -303,7 +291,7 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
                         configuration: s.configuration.clone(),
                         runtime: m,
                     };
-                    dfr.sources.push(sr)
+                    dfr.sources.insert(s.id.clone(), sr);
                 }
                 None => {
                     return Err(ZFError::Uncompleted(format!(
@@ -319,13 +307,12 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
                 Some(m) => {
                     let sr = SinkRecord {
                         id: s.id.clone(),
-                        // name: s.name.clone(),
                         input: s.input.clone(),
                         uri: s.uri.clone(),
                         configuration: s.configuration.clone(),
                         runtime: m,
                     };
-                    dfr.sinks.push(sr)
+                    dfr.sinks.insert(s.id.clone(), sr);
                 }
                 None => {
                     return Err(ZFError::Uncompleted(format!(
@@ -336,7 +323,55 @@ impl TryFrom<(DataFlowDescriptor, Uuid)> for DataFlowRecord {
             }
         }
 
+        // A Loop between two nodes is, in fact, a backward link.
+        //
+        // To add a link we first need to add an input to the Ingress and an output to the Egress
+        // (as these ports were not declared by the user). We also must perform these additions to
+        // the `validator` as it will check that everything is alright on the link we are about to
+        // create.
+        //
+        // We finally add the loop information to the Ingress and Egress.
+        if let Some(loops) = d.loops {
+            for ciclo in loops {
+                // Update the ingress / egress.
+                let ingress = dfr
+                    .operators
+                    .get_mut(&ciclo.ingress)
+                    .ok_or(ZFError::GenericError)?;
+                ingress.inputs.push(PortDescriptor {
+                    port_id: ciclo.feedback_port.clone(),
+                    port_type: ciclo.port_type.clone(),
+                });
+                ingress.ciclo = Some(ciclo.clone());
+
+                let egress = dfr
+                    .operators
+                    .get_mut(&ciclo.egress)
+                    .ok_or(ZFError::GenericError)?;
+                egress.outputs.push(PortDescriptor {
+                    port_id: ciclo.feedback_port.clone(),
+                    port_type: ciclo.port_type.clone(),
+                });
+                egress.ciclo = Some(ciclo.clone());
+
+                d.links.push(LinkDescriptor {
+                    from: OutputDescriptor {
+                        node: ciclo.egress,
+                        output: ciclo.feedback_port.clone(),
+                    },
+                    to: InputDescriptor {
+                        node: ciclo.ingress,
+                        input: ciclo.feedback_port,
+                    },
+                    size: None,
+                    queueing_policy: None,
+                    priority: None,
+                });
+            }
+        }
+
         dfr.add_links(&d.links)?;
+
         Ok(dfr)
     }
 }

--- a/zenoh-flow/src/model/loops.rs
+++ b/zenoh-flow/src/model/loops.rs
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2017, 2021 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+
+use crate::{NodeId, PortId, PortType};
+use serde::{Deserialize, Serialize};
+
+/// A LoopDescriptor is the internal representation of a Loop in Zenoh Flow.
+///
+/// Zenoh Flow supports two types of loops: infinite loops (such as a control loop in a robotic
+/// context) or finite loop. When the Loop is finite, Zenoh Flow keeps track of the number of
+/// iterations.
+///
+/// The Operator at the "beginning" of a Loop is called the `Ingress`. The Operator at the "end" is
+/// called the `Egress`.
+///
+/// The provided `feedback_port` will be created by Zenoh Flow for both operators. An error will be
+/// raised if an input (resp. output) port with the same name already exists for the Ingress (resp.
+/// Egress).
+///
+/// The Ingress and Egress must respect the following constraints:
+/// - the Ingress only has a single output,
+/// - the Egress only has a single input,
+/// - they both must be an Operator (not Source nor Sink),
+/// - they must be Ingress or Egress for a single Loop,
+/// - the Ingress must be "before" the Egress (i.e. without the Loop, there should be no path
+///   between both).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopDescriptor {
+    pub ingress: NodeId,
+    pub egress: NodeId,
+    pub feedback_port: PortId,
+    pub is_infinite: bool,
+    pub port_type: PortType,
+}

--- a/zenoh-flow/src/model/mod.rs
+++ b/zenoh-flow/src/model/mod.rs
@@ -16,6 +16,7 @@ pub mod connector;
 pub mod dataflow;
 pub mod deadline;
 pub mod link;
+pub mod loops;
 pub mod node;
 
 use crate::model::link::PortDescriptor;

--- a/zenoh-flow/src/model/node.rs
+++ b/zenoh-flow/src/model/node.rs
@@ -131,6 +131,7 @@ pub struct OperatorRecord {
     pub(crate) configuration: Option<Configuration>,
     pub(crate) deadline: Option<Duration>,
     pub(crate) runtime: RuntimeId,
+    // Ciclo is the italian word for "loop" — we cannot use "loop" as it’s a reserved keyword.
     pub(crate) ciclo: Option<LoopDescriptor>,
 }
 

--- a/zenoh-flow/src/model/node.rs
+++ b/zenoh-flow/src/model/node.rs
@@ -13,6 +13,7 @@
 //
 
 use crate::model::link::PortDescriptor;
+use crate::model::loops::LoopDescriptor;
 use crate::types::{Configuration, NodeId, RuntimeId};
 use crate::{DurationDescriptor, PortType};
 use serde::{Deserialize, Serialize};
@@ -130,6 +131,7 @@ pub struct OperatorRecord {
     pub(crate) configuration: Option<Configuration>,
     pub(crate) deadline: Option<Duration>,
     pub(crate) runtime: RuntimeId,
+    pub(crate) ciclo: Option<LoopDescriptor>,
 }
 
 impl std::fmt::Display for OperatorRecord {

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -116,6 +116,7 @@ pub struct OperatorRunner {
     pub(crate) local_deadline: Option<Duration>,
     pub(crate) end_to_end_deadlines: Vec<E2EDeadlineRecord>,
     pub(crate) is_running: Arc<Mutex<bool>>,
+    // Ciclo is the italian word for "loop" — we cannot use "loop" as it’s a reserved keyword.
     pub(crate) ciclo: Option<LoopDescriptor>,
     pub(crate) state: Arc<Mutex<State>>,
     pub(crate) operator: Arc<dyn Operator>,
@@ -435,14 +436,13 @@ impl OperatorRunner {
             log::debug!("Sending on port < {} >…", port_id);
 
             if let Some(link_senders) = io.outputs.get(port_id) {
-                let mut loop_contexts = loop_contexts_to_propagate.clone();
-
                 // Loop management: the node is an Egress, depending on which output the message
                 // is sent, we need to either update the LoopContext or remove it.
                 //
                 // CAVEAT: both options are possible at the same time! A message can be sent on
-                // the feedback link and on another output. We thus need to perform the clone
-                // above.
+                // the feedback link and on another output. We thus need to clone.
+                let mut loop_contexts = loop_contexts_to_propagate.clone();
+
                 if let Some(ciclo) = &self.ciclo {
                     if ciclo.egress == self.id {
                         if *port_id != ciclo.feedback_port {

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -14,11 +14,13 @@
 
 use crate::async_std::sync::{Arc, Mutex};
 use crate::model::deadline::E2EDeadlineRecord;
+use crate::model::loops::LoopDescriptor;
 use crate::model::node::OperatorRecord;
 use crate::runtime::dataflow::instance::link::{LinkReceiver, LinkSender};
 use crate::runtime::dataflow::instance::runners::{Runner, RunnerKind};
 use crate::runtime::dataflow::node::OperatorLoaded;
 use crate::runtime::deadline::E2EDeadline;
+use crate::runtime::loops::LoopContext;
 use crate::runtime::message::Message;
 use crate::runtime::InstanceContext;
 use crate::{
@@ -114,6 +116,7 @@ pub struct OperatorRunner {
     pub(crate) local_deadline: Option<Duration>,
     pub(crate) end_to_end_deadlines: Vec<E2EDeadlineRecord>,
     pub(crate) is_running: Arc<Mutex<bool>>,
+    pub(crate) ciclo: Option<LoopDescriptor>,
     pub(crate) state: Arc<Mutex<State>>,
     pub(crate) operator: Arc<dyn Operator>,
     pub(crate) _library: Option<Arc<Library>>,
@@ -138,6 +141,7 @@ impl OperatorRunner {
             _library: operator.library,
             local_deadline: operator.local_deadline,
             end_to_end_deadlines: operator.end_to_end_deadlines,
+            ciclo: operator.ciclo,
         })
     }
 
@@ -188,11 +192,12 @@ impl OperatorRunner {
                                     .update_with_timestamp(&data_message.timestamp)
                                 {
                                     log::error!(
-                                            "[Operator: {}][HLC] Could not update HLC with timestamp {:?}: {:?}",
-                                            self.id,
-                                            data_message.timestamp,
-                                            error
-                                        );
+                                        "[Operator: {}][HLC] Could not update HLC with \
+                                             timestamp {:?}: {:?}",
+                                        self.id,
+                                        data_message.timestamp,
+                                        error
+                                    );
                                 }
 
                                 // We clone the `data_message` because the end to end deadlines
@@ -281,6 +286,8 @@ impl OperatorRunner {
 
         let mut earliest_source_timestamp = None;
         let mut e2e_deadlines_to_propagate: Vec<E2EDeadline> = vec![];
+        let mut loop_feedback = false;
+        let mut loop_contexts_to_propagate: Vec<LoopContext> = vec![];
 
         for (port_id, token) in tokens.iter_mut() {
             match token {
@@ -307,9 +314,8 @@ impl OperatorRunner {
 
                     // TODO: Refactor this code to:
                     // 1) Avoid considering the source_timestamp of a token that is dropped.
-                    // 2) Avoid code duplication.
                     match data_token.action {
-                        TokenAction::Consume => {
+                        TokenAction::Consume | TokenAction::Keep => {
                             log::debug!("[Operator: {}] Consuming < {} >.", self.id, port_id);
                             e2e_deadlines_to_propagate.extend(
                                 data_token
@@ -319,26 +325,51 @@ impl OperatorRunner {
                                     .filter(|e2e_deadline| e2e_deadline.to.node != self.id)
                                     .cloned(),
                             );
+
+                            loop_contexts_to_propagate
+                                .extend(data_token.data.loop_contexts.iter().cloned());
+
+                            if let Some(ciclo) = &self.ciclo {
+                                if ciclo.ingress == self.id && *port_id == ciclo.feedback_port {
+                                    loop_feedback = true;
+                                }
+                            }
+
                             data.insert(port_id.clone(), data_token.data.clone());
-                            *token = InputToken::Pending;
-                        }
-                        TokenAction::Keep => {
-                            log::debug!("[Operator: {}] Keeping < {} >.", self.id, port_id);
-                            e2e_deadlines_to_propagate.extend(
-                                data_token
-                                    .data
-                                    .end_to_end_deadlines
-                                    .iter()
-                                    .filter(|e2e_deadline| e2e_deadline.to.node != self.id)
-                                    .cloned(),
-                            );
-                            data.insert(port_id.clone(), data_token.data.clone());
+                            if data_token.action == TokenAction::Consume {
+                                *token = InputToken::Pending;
+                            }
                         }
                         TokenAction::Drop => {
                             log::debug!("[Operator: {}] Dropping < {} >.", self.id, port_id);
                             data.remove(port_id);
                             *token = InputToken::Pending;
                         }
+                    }
+                }
+            }
+        }
+
+        // Loop management: Ingress.
+        //
+        // Two, mutually exclusive, cases can happen:
+        // 1. No message coming from the feedback link was processed. This means a new Loop is
+        //    starting and we need to associate a context to this message.
+        // 2. A message from the feedback link was processed: a LoopContext is already
+        //    associated. We need to update it.
+        if let Some(ciclo) = &self.ciclo {
+            if ciclo.ingress == self.id {
+                let now = self.context.runtime.hlc.new_timestamp();
+                if !loop_feedback {
+                    log::debug!("[Operator: {}] Ingress, new loop detected", self.id);
+                    loop_contexts_to_propagate.push(LoopContext::new(ciclo, now));
+                } else {
+                    log::debug!("[Operator: {}] Ingress, updating LoopContext", self.id);
+                    let loop_ctx = loop_contexts_to_propagate
+                        .iter_mut()
+                        .find(|loop_ctx| loop_ctx.ingress == self.id);
+                    if let Some(ctx) = loop_ctx {
+                        ctx.update_ingress(now);
                     }
                 }
             }
@@ -401,12 +432,45 @@ impl OperatorRunner {
                 None => continue,
             };
 
+            log::debug!("Sending on port < {} >…", port_id);
+
             if let Some(link_senders) = io.outputs.get(port_id) {
+                let mut loop_contexts = loop_contexts_to_propagate.clone();
+
+                // Loop management: the node is an Egress, depending on which output the message
+                // is sent, we need to either update the LoopContext or remove it.
+                //
+                // CAVEAT: both options are possible at the same time! A message can be sent on
+                // the feedback link and on another output. We thus need to perform the clone
+                // above.
+                if let Some(ciclo) = &self.ciclo {
+                    if ciclo.egress == self.id {
+                        if *port_id != ciclo.feedback_port {
+                            // Output is not sent on the feedback link, remove the LoopContext.
+                            loop_contexts = loop_contexts
+                                .into_iter()
+                                .filter(|loop_ctx| loop_ctx.egress != self.id)
+                                .collect::<Vec<LoopContext>>();
+                        } else {
+                            // Output is sent on the feedback link, we updade the context before
+                            // sending it.
+                            let loop_context = loop_contexts
+                                .iter_mut()
+                                .find(|loop_ctx| loop_ctx.egress == self.id);
+                            if let Some(loop_ctx) = loop_context {
+                                loop_ctx.update_egress(now);
+                            }
+                        }
+                    }
+                }
+
                 let zf_message = Arc::new(Message::from_node_output(
                     output,
                     timestamp,
                     e2e_deadlines_to_propagate.clone(),
+                    loop_contexts,
                 ));
+
                 for link_sender in link_senders {
                     let res = link_sender.send(zf_message.clone()).await;
 

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -229,17 +229,17 @@ impl Runner for SourceRunner {
     async fn start_recording(&self) -> ZFResult<String> {
         let mut is_recording_guard = self.is_recording.lock().await;
         if !(*is_recording_guard) {
-            let ts_recoding_start = self.context.runtime.hlc.new_timestamp();
+            let ts_recording_start = self.context.runtime.hlc.new_timestamp();
             let resource_name = format!(
                 "{}/{}",
                 self.base_resource_name,
-                ts_recoding_start.get_time().to_string()
+                ts_recording_start.get_time()
             );
 
             *(self.current_recording_resource.lock().await) = Some(resource_name.clone());
 
             let recording_metadata = RecordingMetadata {
-                timestamp: ts_recoding_start,
+                timestamp: ts_recording_start,
                 port_id: self.output.port_id.clone(),
                 node_id: self.id.clone(),
                 flow_id: self.context.flow_id.clone(),
@@ -249,9 +249,9 @@ impl Runner for SourceRunner {
             let message = Message::Control(ControlMessage::RecordingStart(recording_metadata));
             let serialized = message.serialize_bincode()?;
             log::debug!(
-                "ZenohLogger - {} - Started recoding at {:?}",
+                "ZenohLogger - {} - Started recording at {:?}",
                 resource_name,
-                ts_recoding_start
+                ts_recording_start
             );
             self.context
                 .runtime
@@ -274,13 +274,13 @@ impl Runner for SourceRunner {
                 .ok_or(ZFError::Unimplemented)?
                 .clone();
 
-            let ts_recoding_stop = self.context.runtime.hlc.new_timestamp();
-            let message = Message::Control(ControlMessage::RecordingStop(ts_recoding_stop));
+            let ts_recording_stop = self.context.runtime.hlc.new_timestamp();
+            let message = Message::Control(ControlMessage::RecordingStop(ts_recording_stop));
             let serialized = message.serialize_bincode()?;
             log::debug!(
-                "ZenohLogger - {} - Stop recoding at {:?}",
+                "ZenohLogger - {} - Stop recording at {:?}",
                 resource_name,
-                ts_recoding_stop
+                ts_recording_stop
             );
             self.context
                 .runtime
@@ -292,7 +292,7 @@ impl Runner for SourceRunner {
             *resource_name_guard = None;
             return Ok(resource_name);
         }
-        return Err(ZFError::NotRecoding);
+        return Err(ZFError::NotRecording);
     }
 
     async fn is_recording(&self) -> bool {

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -165,7 +165,12 @@ impl SourceRunner {
         // Send to Links
         log::debug!("Sending on {:?} data: {:?}", self.output.port_id, output);
 
-        let zf_message = Arc::new(Message::from_serdedata(output, timestamp, e2e_deadlines));
+        let zf_message = Arc::new(Message::from_serdedata(
+            output,
+            timestamp,
+            e2e_deadlines,
+            vec![],
+        ));
         for link in links.iter() {
             log::debug!("\tSending on: {:?}", link);
             link.send(zf_message.clone()).await?;

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
@@ -256,6 +256,7 @@ fn e2e_deadline() {
         operator: Arc::new(operator),
         _library: None,
         end_to_end_deadlines: vec![operator_deadline.clone()],
+        ciclo: None,
     };
 
     let runner = NodeRunner::new(Arc::new(operator_runner), instance_context);

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
@@ -116,8 +116,8 @@ impl Operator for TestOperatorDeadlineViolated {
         let token_input1 = tokens.get(&self.input1).unwrap();
         match token_input1 {
             InputToken::Pending => panic!("Unexpected `Pending` token"),
-            InputToken::Ready(ready_token) => {
-                assert_eq!(ready_token.get_missed_end_to_end_deadlines().len(), 1);
+            InputToken::Ready(data_token) => {
+                assert_eq!(data_token.get_missed_end_to_end_deadlines().len(), 1);
             }
         }
 

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_e2e_deadline_tests.rs
@@ -22,8 +22,8 @@ use crate::runtime::deadline::E2EDeadline;
 use crate::runtime::{InstanceContext, RuntimeContext};
 use crate::{
     default_output_rule, Configuration, Context, Data, DataMessage, Deserializable, DowncastAny,
-    EmptyState, LocalDeadlineMiss, Message, Node, NodeId, NodeOutput, Operator, PortId, PortType,
-    State, Token, ZFData, ZFError, ZFResult,
+    EmptyState, InputToken, LocalDeadlineMiss, Message, Node, NodeId, NodeOutput, Operator, PortId,
+    PortType, State, ZFData, ZFError, ZFResult,
 };
 use async_std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -111,12 +111,12 @@ impl Operator for TestOperatorDeadlineViolated {
         &self,
         _context: &mut Context,
         _state: &mut State,
-        tokens: &mut HashMap<PortId, Token>,
+        tokens: &mut HashMap<PortId, InputToken>,
     ) -> ZFResult<bool> {
         let token_input1 = tokens.get(&self.input1).unwrap();
         match token_input1 {
-            Token::Pending => panic!("Unexpected `Pending` token"),
-            Token::Ready(ready_token) => {
+            InputToken::Pending => panic!("Unexpected `Pending` token"),
+            InputToken::Ready(ready_token) => {
                 assert_eq!(ready_token.get_missed_end_to_end_deadlines().len(), 1);
             }
         }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
@@ -108,9 +108,9 @@ impl Operator for TestOperator {
                 .ok_or_else(|| ZFError::MissingInput((self.input_1.as_ref()).into()))?;
             if let InputToken::Ready(token) = input_1 {
                 if token.get_action() == &TokenAction::Keep {
-                    token.set_action_consume();
+                    input_1.set_action_consume();
                 } else {
-                    token.set_action_keep();
+                    input_1.set_action_keep();
                 }
             }
         }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
@@ -266,6 +266,7 @@ fn input_rule_keep() {
         operator: Arc::new(operator),
         _library: None,
         end_to_end_deadlines: vec![],
+        ciclo: None,
     };
 
     let runner = NodeRunner::new(Arc::new(operator_runner), instance_context);

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/operator_test.rs
@@ -31,9 +31,9 @@ use crate::{
         },
         InstanceContext, RuntimeContext,
     },
-    Configuration, Context, Data, DataMessage, Deserializable, DowncastAny, EmptyState,
-    LocalDeadlineMiss, Message, Node, NodeOutput, Operator, PortId, PortType, State, Token,
-    TokenAction, ZFData, ZFError, ZFResult,
+    Configuration, Context, Data, DataMessage, Deserializable, DowncastAny, EmptyState, InputToken,
+    LocalDeadlineMiss, Message, Node, NodeOutput, Operator, PortId, PortType, State, TokenAction,
+    ZFData, ZFError, ZFResult,
 };
 
 // ZFUsize implements Data.
@@ -89,13 +89,13 @@ impl Operator for TestOperator {
         &self,
         _context: &mut Context,
         _state: &mut State,
-        tokens: &mut HashMap<PortId, Token>,
+        tokens: &mut HashMap<PortId, InputToken>,
     ) -> ZFResult<bool> {
         let mut run = true;
 
         // 1st part: KPN input rules, we return `false` if a single input is missing.
         tokens.values().for_each(|token| {
-            if let Token::Pending = token {
+            if let InputToken::Pending = token {
                 run = false
             }
         });
@@ -106,7 +106,7 @@ impl Operator for TestOperator {
             let input_1 = tokens
                 .get_mut(&self.input_1)
                 .ok_or_else(|| ZFError::MissingInput((self.input_1.as_ref()).into()))?;
-            if let Token::Ready(token) = input_1 {
+            if let InputToken::Ready(token) = input_1 {
                 if token.get_action() == &TokenAction::Keep {
                     token.set_action_consume();
                 } else {

--- a/zenoh-flow/src/runtime/dataflow/node.rs
+++ b/zenoh-flow/src/runtime/dataflow/node.rs
@@ -14,6 +14,7 @@
 
 use crate::model::deadline::E2EDeadlineRecord;
 use crate::model::link::PortDescriptor;
+use crate::model::loops::LoopDescriptor;
 use crate::model::node::{OperatorRecord, SinkRecord, SourceRecord};
 use crate::{NodeId, Operator, PortId, PortType, Sink, Source, State, ZFResult};
 use async_std::sync::{Arc, Mutex};
@@ -60,6 +61,7 @@ pub struct OperatorLoaded {
     pub(crate) inputs: HashMap<PortId, PortType>,
     pub(crate) outputs: HashMap<PortId, PortType>,
     pub(crate) local_deadline: Option<Duration>,
+    pub(crate) ciclo: Option<LoopDescriptor>,
     pub(crate) state: Arc<Mutex<State>>,
     pub(crate) operator: Arc<dyn Operator>,
     pub(crate) library: Option<Arc<Library>>,
@@ -95,6 +97,7 @@ impl OperatorLoaded {
             operator,
             library: lib,
             end_to_end_deadlines: vec![],
+            ciclo: record.ciclo,
         })
     }
 }

--- a/zenoh-flow/src/runtime/loops.rs
+++ b/zenoh-flow/src/runtime/loops.rs
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2017, 2021 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use uhlc::Timestamp;
+
+use crate::{model::loops::LoopDescriptor, NodeId};
+
+/// A `LoopContext` is associated to each message that goes through a Loop.
+///
+/// It gives the following information:
+/// - the ingress / egress,
+/// - an iteration counter (if the Loop is finite),
+/// - the starting timestamp of the first iteration,
+/// - the starting timestamp of the current iteration,
+/// - the duration of the last iteration (after the first full iteration is performed).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoopContext {
+    pub(crate) ingress: NodeId,
+    pub(crate) egress: NodeId,
+    pub(crate) iteration: LoopIteration,
+    pub(crate) timestamp_start_first_iteration: Timestamp,
+    pub(crate) timestamp_start_current_iteration: Option<Timestamp>,
+    pub(crate) duration_last_iteration: Option<Duration>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum LoopIteration {
+    Finite(usize),
+    Infinite,
+}
+
+impl LoopContext {
+    pub(crate) fn new(descriptor: &LoopDescriptor, start: Timestamp) -> Self {
+        let iteration = match descriptor.is_infinite {
+            true => LoopIteration::Infinite,
+            false => LoopIteration::Finite(0),
+        };
+
+        Self {
+            ingress: descriptor.ingress.clone(),
+            egress: descriptor.egress.clone(),
+            iteration,
+            timestamp_start_first_iteration: start,
+            timestamp_start_current_iteration: Some(start),
+            duration_last_iteration: None,
+        }
+    }
+
+    pub(crate) fn update_ingress(&mut self, now: Timestamp) {
+        self.timestamp_start_current_iteration = Some(now);
+    }
+
+    pub(crate) fn update_egress(&mut self, now: Timestamp) {
+        if let LoopIteration::Finite(counter) = self.iteration {
+            self.iteration = LoopIteration::Finite(counter + 1);
+        }
+
+        self.duration_last_iteration = self
+            .timestamp_start_current_iteration
+            .map(|timestamp| now.get_diff_duration(&timestamp));
+
+        self.timestamp_start_current_iteration = None;
+    }
+
+    pub fn get_ingress(&self) -> &NodeId {
+        &self.ingress
+    }
+
+    pub fn get_egress(&self) -> &NodeId {
+        &self.egress
+    }
+
+    pub fn get_iteration(&self) -> LoopIteration {
+        self.iteration
+    }
+
+    pub fn get_timestamp_start_first_iteration(&self) -> Timestamp {
+        self.timestamp_start_first_iteration
+    }
+
+    pub fn get_timestamp_start_current_iteration(&self) -> Option<Timestamp> {
+        self.timestamp_start_current_iteration
+    }
+
+    pub fn get_duration_last_iteration(&self) -> Option<Duration> {
+        self.duration_last_iteration
+    }
+}

--- a/zenoh-flow/src/runtime/loops.rs
+++ b/zenoh-flow/src/runtime/loops.rs
@@ -38,7 +38,7 @@ pub struct LoopContext {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum LoopIteration {
-    Finite(usize),
+    Finite(u64),
     Infinite,
 }
 
@@ -65,7 +65,11 @@ impl LoopContext {
 
     pub(crate) fn update_egress(&mut self, now: Timestamp) {
         if let LoopIteration::Finite(counter) = self.iteration {
-            self.iteration = LoopIteration::Finite(counter + 1);
+            let (iteration, has_overflowed) = counter.overflowing_add(1);
+            if has_overflowed {
+                log::error!("LoopIteration counter overflowed for Loop: {:?}", self);
+            }
+            self.iteration = LoopIteration::Finite(iteration);
         }
 
         self.duration_last_iteration = self

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -39,6 +39,7 @@ use self::dataflow::loader::LoaderConfig;
 
 pub mod dataflow;
 pub mod deadline;
+pub mod loops;
 pub mod message;
 pub mod resources;
 pub mod token;

--- a/zenoh-flow/src/runtime/token.rs
+++ b/zenoh-flow/src/runtime/token.rs
@@ -13,7 +13,7 @@
 //
 
 use crate::runtime::deadline::E2EDeadlineMiss;
-use crate::{Data, DataMessage, PortId};
+use crate::{Data, DataMessage, LoopContext, PortId};
 use std::collections::HashMap;
 use uhlc::Timestamp;
 
@@ -72,6 +72,10 @@ impl DataToken {
 
     pub fn get_missed_end_to_end_deadlines(&self) -> &[E2EDeadlineMiss] {
         &self.data.missed_end_to_end_deadlines
+    }
+
+    pub fn get_loop_contexts(&self) -> &[LoopContext] {
+        self.data.get_loop_contexts()
     }
 }
 

--- a/zenoh-flow/src/runtime/token.rs
+++ b/zenoh-flow/src/runtime/token.rs
@@ -52,12 +52,12 @@ impl std::fmt::Display for TokenAction {
 }
 
 #[derive(Debug, Clone)]
-pub struct ReadyToken {
+pub struct DataToken {
     pub(crate) data: DataMessage,
     pub(crate) action: TokenAction,
 }
 
-impl ReadyToken {
+impl DataToken {
     /// Tell Zenoh Flow to immediately discard the data.
     ///
     /// The data associated to the `Token` will be immediately discarded, regardless of the result
@@ -105,13 +105,13 @@ impl ReadyToken {
 #[derive(Debug, Clone)]
 pub enum InputToken {
     Pending,
-    Ready(ReadyToken),
+    Ready(DataToken),
 }
 
 impl InputToken {
     pub(crate) fn should_drop(&self) -> bool {
-        if let InputToken::Ready(token_ready) = self {
-            if let TokenAction::Drop = token_ready.action {
+        if let InputToken::Ready(data_token) = self {
+            if let TokenAction::Drop = data_token.action {
                 return true;
             }
         }
@@ -122,7 +122,7 @@ impl InputToken {
 
 impl From<DataMessage> for InputToken {
     fn from(data_message: DataMessage) -> Self {
-        Self::Ready(ReadyToken {
+        Self::Ready(DataToken {
             data: data_message,
             action: TokenAction::Consume,
         })

--- a/zenoh-flow/src/runtime/token.rs
+++ b/zenoh-flow/src/runtime/token.rs
@@ -58,33 +58,6 @@ pub struct DataToken {
 }
 
 impl DataToken {
-    /// Tell Zenoh Flow to immediately discard the data.
-    ///
-    /// The data associated to the `Token` will be immediately discarded, regardless of the result
-    /// of the `Input Rule`. Hence, even if the `Input Rule` return `True` (indicating the `Run`
-    /// method will be called), the data **will not** be transmitted.
-    pub fn set_action_drop(&mut self) {
-        self.action = TokenAction::Drop
-    }
-
-    /// Tell Zenoh Flow to use the data in the "next" run and keep it.
-    ///
-    /// The data associated to the `Token` will be transmitted to the `Run` method of the `Operator`
-    /// the next time `Run` is called, i.e. the next time the `Input Rule` returns `True`.
-    /// Once `Run` is over, the data is kept, _preventing data from being received on that link_.
-    pub fn set_action_keep(&mut self) {
-        self.action = TokenAction::Keep
-    }
-
-    /// (default) Tell Zenoh Flow to use the data in the "next" run and drop it after.
-    ///
-    /// The data associated to the `Token` will be transmitted to the `Run` method of the `Operator`
-    /// the next time `Run` is called, i.e. the next time the `Input Rule` returns `True`.
-    /// Once `Run` is over, the data is dropped, allowing for data to be received on that link.
-    pub fn set_action_consume(&mut self) {
-        self.action = TokenAction::Consume
-    }
-
     pub fn get_action(&self) -> &TokenAction {
         &self.action
     }
@@ -117,6 +90,47 @@ impl InputToken {
         }
 
         false
+    }
+
+    /// Tell Zenoh Flow to immediately discard the data.
+    ///
+    /// The data associated to the `InputToken` will be immediately discarded, regardless of the
+    /// result of the `Input Rule`. Hence, even if the `Input Rule` return `True` (indicating the
+    /// `Run` method will be called), the data **will not** be transmitted.
+    ///
+    /// This method will do nothing if the `InputToken` is a `InputToken::Pending`.
+    pub fn set_action_drop(&mut self) {
+        if let InputToken::Ready(data_token) = self {
+            data_token.action = TokenAction::Drop;
+        }
+    }
+
+    /// Tell Zenoh Flow to use the data in the "next" run and keep it.
+    ///
+    /// The data associated to the `InputToken` will be transmitted to the `Run` method of the
+    /// `Operator` the next time `Run` is called, i.e. the next time the `Input Rule` returns
+    /// `True`. Once `Run` is over, the data is kept, _preventing data from being received on that
+    /// link_.
+    ///
+    /// This method will do nothing if the `InputToken` is a `InputToken::Pending`.
+    pub fn set_action_keep(&mut self) {
+        if let InputToken::Ready(data_token) = self {
+            data_token.action = TokenAction::Keep;
+        }
+    }
+
+    /// (default) Tell Zenoh Flow to use the data in the "next" run and drop it after.
+    ///
+    /// The data associated to the `InputToken` will be transmitted to the `Run` method of the
+    /// `Operator` the next time `Run` is called, i.e. the next time the `Input Rule` returns
+    /// `True`. Once `Run` is over, the data is dropped, allowing for data to be received on that
+    /// link.
+    ///
+    /// This method will do nothing if the `InputToken` is a `InputToken::Pending`.
+    pub fn set_action_consume(&mut self) {
+        if let InputToken::Ready(data_token) = self {
+            data_token.action = TokenAction::Consume;
+        }
     }
 }
 

--- a/zenoh-flow/src/runtime/token.rs
+++ b/zenoh-flow/src/runtime/token.rs
@@ -18,18 +18,18 @@ use std::collections::HashMap;
 use uhlc::Timestamp;
 
 #[derive(Clone)]
-pub struct Tokens {
-    pub(crate) map: HashMap<PortId, Token>,
+pub struct InputTokens {
+    pub(crate) map: HashMap<PortId, InputToken>,
 }
 
-impl Tokens {
+impl InputTokens {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             map: HashMap::with_capacity(capacity),
         }
     }
 
-    pub fn get_mut(&mut self, port_id: &PortId) -> Option<&mut Token> {
+    pub fn get_mut(&mut self, port_id: &PortId) -> Option<&mut InputToken> {
         self.map.get_mut(port_id)
     }
 }
@@ -103,14 +103,14 @@ impl ReadyToken {
 }
 
 #[derive(Debug, Clone)]
-pub enum Token {
+pub enum InputToken {
     Pending,
     Ready(ReadyToken),
 }
 
-impl Token {
+impl InputToken {
     pub(crate) fn should_drop(&self) -> bool {
-        if let Token::Ready(token_ready) = self {
+        if let InputToken::Ready(token_ready) = self {
             if let TokenAction::Drop = token_ready.action {
                 return true;
             }
@@ -120,7 +120,7 @@ impl Token {
     }
 }
 
-impl From<DataMessage> for Token {
+impl From<DataMessage> for InputToken {
     fn from(data_message: DataMessage) -> Self {
         Self::Ready(ReadyToken {
             data: data_message,

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -14,7 +14,8 @@
 
 use crate::runtime::message::DataMessage;
 use crate::{
-    Configuration, Context, Data, LocalDeadlineMiss, NodeOutput, PortId, State, Token, ZFResult,
+    Configuration, Context, Data, InputToken, LocalDeadlineMiss, NodeOutput, PortId, State,
+    ZFResult,
 };
 use async_trait::async_trait;
 use std::any::Any;
@@ -54,7 +55,7 @@ pub trait Operator: Node + Send + Sync {
         &self,
         context: &mut Context,
         state: &mut State,
-        tokens: &mut HashMap<PortId, Token>,
+        tokens: &mut HashMap<PortId, InputToken>,
     ) -> ZFResult<bool>;
 
     fn run(

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -14,7 +14,7 @@
 
 use crate::async_std::sync::Arc;
 use crate::serde::{Deserialize, Serialize};
-use crate::{ControlMessage, DataMessage, Token, ZFData, ZFState};
+use crate::{ControlMessage, DataMessage, InputToken, ZFData, ZFState};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -204,12 +204,12 @@ pub fn default_output_rule(
 
 pub fn default_input_rule(
     _state: &mut State,
-    tokens: &mut HashMap<PortId, Token>,
+    tokens: &mut HashMap<PortId, InputToken>,
 ) -> ZFResult<bool> {
     for token in tokens.values() {
         match token {
-            Token::Ready(_) => continue,
-            Token::Pending => return Ok(false),
+            InputToken::Ready(_) => continue,
+            InputToken::Pending => return Ok(false),
         }
     }
 

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -133,7 +133,7 @@ impl Operator for NoOp {
         &self,
         _context: &mut zenoh_flow::Context,
         state: &mut State,
-        tokens: &mut HashMap<PortId, zenoh_flow::Token>,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
     ) -> zenoh_flow::ZFResult<bool> {
         default_input_rule(state, tokens)
     }

--- a/zenoh-flow/tests/e2e_deadline.rs
+++ b/zenoh-flow/tests/e2e_deadline.rs
@@ -52,7 +52,7 @@ impl Operator for OperatorE2EDeadline {
         &self,
         _context: &mut zenoh_flow::Context,
         state: &mut State,
-        tokens: &mut HashMap<PortId, zenoh_flow::Token>,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
     ) -> zenoh_flow::ZFResult<bool> {
         default_input_rule(state, tokens)
     }

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -113,13 +113,13 @@ impl Operator for DropOdd {
         tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
     ) -> zenoh_flow::ZFResult<bool> {
         let source: PortId = SOURCE.into();
-        let token = tokens
+        let input_token = tokens
             .get_mut(&source)
             .ok_or_else(|| ZFError::InvalidData(SOURCE.to_string()))?;
-        if let InputToken::Ready(data_token) = token {
+        if let InputToken::Ready(data_token) = input_token {
             let data = data_token.get_data_mut();
             if data.try_get::<ZFUsize>()?.0 % 2 != 0 {
-                data_token.set_action_drop();
+                input_token.set_action_drop();
                 return Ok(false);
             }
 

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -25,8 +25,8 @@ use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::{
-    default_output_rule, zf_empty_state, Configuration, Context, Data, LocalDeadlineMiss, Node,
-    NodeOutput, Operator, PortId, Sink, Source, State, Token, ZFError, ZFResult,
+    default_output_rule, zf_empty_state, Configuration, Context, Data, InputToken,
+    LocalDeadlineMiss, Node, NodeOutput, Operator, PortId, Sink, Source, State, ZFError, ZFResult,
 };
 
 static SOURCE: &str = "Source";
@@ -110,13 +110,13 @@ impl Operator for DropOdd {
         &self,
         _context: &mut zenoh_flow::Context,
         _state: &mut State,
-        tokens: &mut HashMap<PortId, zenoh_flow::Token>,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
     ) -> zenoh_flow::ZFResult<bool> {
         let source: PortId = SOURCE.into();
         let token = tokens
             .get_mut(&source)
             .ok_or_else(|| ZFError::InvalidData(SOURCE.to_string()))?;
-        if let Token::Ready(ready_token) = token {
+        if let InputToken::Ready(ready_token) = token {
             let data = ready_token.get_data_mut();
             if data.try_get::<ZFUsize>()?.0 % 2 != 0 {
                 ready_token.set_action_drop();

--- a/zenoh-flow/tests/input_rule_drop.rs
+++ b/zenoh-flow/tests/input_rule_drop.rs
@@ -116,10 +116,10 @@ impl Operator for DropOdd {
         let token = tokens
             .get_mut(&source)
             .ok_or_else(|| ZFError::InvalidData(SOURCE.to_string()))?;
-        if let InputToken::Ready(ready_token) = token {
-            let data = ready_token.get_data_mut();
+        if let InputToken::Ready(data_token) = token {
+            let data = data_token.get_data_mut();
             if data.try_get::<ZFUsize>()?.0 % 2 != 0 {
-                ready_token.set_action_drop();
+                data_token.set_action_drop();
                 return Ok(false);
             }
 

--- a/zenoh-flow/tests/local_deadline.rs
+++ b/zenoh-flow/tests/local_deadline.rs
@@ -50,7 +50,7 @@ impl Operator for OperatorDeadline {
         &self,
         _context: &mut zenoh_flow::Context,
         state: &mut State,
-        tokens: &mut HashMap<PortId, zenoh_flow::Token>,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
     ) -> zenoh_flow::ZFResult<bool> {
         default_input_rule(state, tokens)
     }

--- a/zenoh-flow/tests/loop.rs
+++ b/zenoh-flow/tests/loop.rs
@@ -197,7 +197,7 @@ impl Operator for OperatorIngressInner {
             };
 
             let feedback_data = feedback_input.get_inner_data().try_get::<ZFUsize>()?;
-            data = Data::from::<ZFUsize>(ZFUsize(feedback_data.0 + increment));
+            data = Data::from::<ZFUsize>(ZFUsize(feedback_data.0 + increment as usize));
         }
 
         results.insert(OPERATOR_EGRESS_INNER.into(), data);

--- a/zenoh-flow/tests/loop.rs
+++ b/zenoh-flow/tests/loop.rs
@@ -1,0 +1,638 @@
+//
+// Copyright (c) 2017, 2021 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ADLINK zenoh team, <zenoh@adlink-labs.tech>
+//
+
+mod types;
+
+use async_std::sync::Arc;
+use std::collections::HashMap;
+use std::time::Duration;
+use types::{VecSink, VecSource, ZFUsize};
+use zenoh_flow::model::link::PortDescriptor;
+use zenoh_flow::model::{InputDescriptor, OutputDescriptor};
+use zenoh_flow::runtime::dataflow::instance::DataflowInstance;
+use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
+use zenoh_flow::runtime::loops::LoopIteration;
+use zenoh_flow::runtime::RuntimeContext;
+use zenoh_flow::{
+    default_input_rule, default_output_rule, zf_empty_state, Configuration, Data, InputToken,
+    LocalDeadlineMiss, Node, NodeOutput, Operator, PortId, State, ZFError, ZFResult,
+};
+
+static SOURCE: &str = "Source";
+static OPERATOR_INGRESS_OUTER: &str = "operator-ingress-outer";
+static OPERATOR_INGRESS_INNER: &str = "operator-ingress-inner";
+static OPERATOR_EGRESS_INNER: &str = "operator-egress-inner";
+static OPERATOR_EGRESS_OUTER: &str = "operator-egress-outer";
+static FEEDBACK_OUTER: &str = "feedback-outer";
+static FEEDBACK_INNER: &str = "feedback-inner";
+static SINK: &str = "Sink";
+
+#[derive(Debug)]
+struct OperatorIngressOuter;
+
+impl Node for OperatorIngressOuter {
+    fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+        zf_empty_state!()
+    }
+
+    fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+        Ok(())
+    }
+}
+
+impl Operator for OperatorIngressOuter {
+    fn input_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        _state: &mut State,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
+    ) -> zenoh_flow::ZFResult<bool> {
+        if matches!(tokens.get(SOURCE).unwrap(), InputToken::Ready(_)) {
+            return Ok(true);
+        }
+
+        if let InputToken::Ready(feedback_token) = tokens.get(FEEDBACK_OUTER).unwrap() {
+            let loop_contexts = feedback_token.get_loop_contexts();
+            assert_eq!(loop_contexts.len(), 1);
+            assert!(
+                loop_contexts[0].get_ingress() == &Into::<Arc<str>>::into(OPERATOR_INGRESS_OUTER)
+            );
+
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn run(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        _state: &mut State,
+        inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, Data>> {
+        let mut results: HashMap<PortId, Data> = HashMap::with_capacity(1);
+        let data: Data;
+
+        if let Some(mut source_input) = inputs.remove(SOURCE) {
+            let source_data = source_input.get_inner_data().try_get::<ZFUsize>()?;
+            data = Data::from::<ZFUsize>(ZFUsize(source_data.0));
+        } else {
+            let mut feedback_input = inputs.remove(FEEDBACK_OUTER).unwrap();
+
+            let loop_contexts = feedback_input.get_loop_contexts();
+            assert_eq!(loop_contexts.len(), 1);
+
+            let loop_iteration = loop_contexts
+                .iter()
+                .find(|&ctx| ctx.get_ingress() == &Into::<Arc<str>>::into(OPERATOR_INGRESS_OUTER))
+                .unwrap()
+                .get_iteration();
+            assert!(
+                matches!(loop_iteration, LoopIteration::Infinite),
+                "Expected LoopIteration to be Infinite, found finite"
+            );
+
+            let feedback_data = feedback_input.get_inner_data().try_get::<ZFUsize>()?;
+            data = Data::from::<ZFUsize>(ZFUsize(feedback_data.0 * 2));
+        }
+
+        results.insert(OPERATOR_INGRESS_INNER.into(), data);
+
+        Ok(results)
+    }
+
+    fn output_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        state: &mut State,
+        outputs: HashMap<PortId, Data>,
+        deadline_miss: Option<LocalDeadlineMiss>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`"
+        );
+        default_output_rule(state, outputs)
+    }
+}
+
+#[derive(Debug)]
+struct OperatorIngressInner;
+
+impl Node for OperatorIngressInner {
+    fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+        zf_empty_state!()
+    }
+
+    fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+        Ok(())
+    }
+}
+
+impl Operator for OperatorIngressInner {
+    fn input_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        _state: &mut State,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
+    ) -> zenoh_flow::ZFResult<bool> {
+        if matches!(
+            tokens.get(OPERATOR_INGRESS_OUTER).unwrap(),
+            InputToken::Ready(_)
+        ) {
+            return Ok(true);
+        }
+
+        if let InputToken::Ready(feedback_token) = tokens.get(FEEDBACK_INNER).unwrap() {
+            assert_eq!(feedback_token.get_loop_contexts().len(), 2);
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn run(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        _state: &mut State,
+        inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, Data>> {
+        let mut results: HashMap<PortId, Data> = HashMap::with_capacity(1);
+        let data: Data;
+
+        if let Some(mut operator_ingress_outer_input) = inputs.remove(OPERATOR_INGRESS_OUTER) {
+            let loop_contexts = operator_ingress_outer_input.get_loop_contexts();
+            assert_eq!(loop_contexts.len(), 1);
+
+            let operator_ingress_outer_data = operator_ingress_outer_input
+                .get_inner_data()
+                .try_get::<ZFUsize>()?;
+            data = Data::from::<ZFUsize>(ZFUsize(operator_ingress_outer_data.0));
+        } else {
+            let mut feedback_input = inputs.remove(FEEDBACK_INNER).unwrap();
+
+            let loop_contexts = feedback_input.get_loop_contexts();
+            assert_eq!(loop_contexts.len(), 2);
+
+            let loop_iteration = loop_contexts
+                .iter()
+                .find(|&ctx| ctx.get_ingress() == &Into::<Arc<str>>::into(OPERATOR_INGRESS_INNER))
+                .unwrap()
+                .get_iteration();
+            let increment = if let LoopIteration::Finite(counter) = loop_iteration {
+                counter
+            } else {
+                return Err(ZFError::GenericError);
+            };
+
+            let feedback_data = feedback_input.get_inner_data().try_get::<ZFUsize>()?;
+            data = Data::from::<ZFUsize>(ZFUsize(feedback_data.0 + increment));
+        }
+
+        results.insert(OPERATOR_EGRESS_INNER.into(), data);
+
+        Ok(results)
+    }
+
+    fn output_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        state: &mut State,
+        outputs: HashMap<PortId, Data>,
+        deadline_miss: Option<LocalDeadlineMiss>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`"
+        );
+        default_output_rule(state, outputs)
+    }
+}
+
+#[derive(Debug)]
+struct OperatorEgressInner;
+
+impl Node for OperatorEgressInner {
+    fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+        zf_empty_state!()
+    }
+
+    fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+        Ok(())
+    }
+}
+
+impl Operator for OperatorEgressInner {
+    fn input_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        state: &mut State,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
+    ) -> zenoh_flow::ZFResult<bool> {
+        default_input_rule(state, tokens)
+    }
+
+    fn run(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        _state: &mut State,
+        inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, Data>> {
+        let mut results: HashMap<PortId, Data> = HashMap::with_capacity(1);
+
+        let mut ingress_inner_input = inputs.remove(OPERATOR_INGRESS_INNER).unwrap();
+        let loop_contexts = ingress_inner_input.get_loop_contexts();
+        assert_eq!(loop_contexts.len(), 2);
+
+        let loop_iteration = loop_contexts
+            .iter()
+            .find(|&ctx| ctx.get_egress() == &Into::<Arc<str>>::into(OPERATOR_EGRESS_INNER))
+            .unwrap()
+            .get_iteration();
+        let iteration = if let LoopIteration::Finite(counter) = loop_iteration {
+            counter
+        } else {
+            return Err(ZFError::GenericError);
+        };
+
+        let data = ingress_inner_input.get_inner_data().try_get::<ZFUsize>()?;
+
+        if iteration < 5 {
+            results.insert(
+                FEEDBACK_INNER.into(),
+                Data::from::<ZFUsize>(ZFUsize(data.0)),
+            );
+        } else {
+            results.insert(
+                OPERATOR_EGRESS_OUTER.into(),
+                Data::from::<ZFUsize>(ZFUsize(data.0)),
+            );
+        }
+
+        Ok(results)
+    }
+
+    fn output_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        state: &mut State,
+        outputs: HashMap<PortId, Data>,
+        deadline_miss: Option<LocalDeadlineMiss>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`"
+        );
+        default_output_rule(state, outputs)
+    }
+}
+
+#[derive(Debug)]
+struct OperatorEgressOuter;
+
+impl Node for OperatorEgressOuter {
+    fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+        zf_empty_state!()
+    }
+
+    fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+        Ok(())
+    }
+}
+
+impl Operator for OperatorEgressOuter {
+    fn input_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        state: &mut State,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
+    ) -> zenoh_flow::ZFResult<bool> {
+        default_input_rule(state, tokens)
+    }
+
+    fn run(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        _state: &mut State,
+        inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, Data>> {
+        let mut results: HashMap<PortId, Data> = HashMap::with_capacity(2);
+
+        let mut egress_inner_input = inputs.remove(OPERATOR_EGRESS_INNER).unwrap();
+        let loop_contexts = egress_inner_input.get_loop_contexts();
+        assert_eq!(loop_contexts.len(), 1);
+
+        let loop_iteration = loop_contexts
+            .iter()
+            .find(|&ctx| ctx.get_egress() == &Into::<Arc<str>>::into(OPERATOR_EGRESS_OUTER))
+            .unwrap()
+            .get_iteration();
+
+        assert!(
+            matches!(loop_iteration, LoopIteration::Infinite),
+            "Expected LoopIteration to be Infinite, found finite"
+        );
+
+        results.insert(
+            FEEDBACK_OUTER.into(),
+            egress_inner_input.get_inner_data().clone(),
+        );
+        results.insert(SINK.into(), egress_inner_input.get_inner_data().clone());
+
+        Ok(results)
+    }
+
+    fn output_rule(
+        &self,
+        _context: &mut zenoh_flow::Context,
+        state: &mut State,
+        outputs: HashMap<PortId, Data>,
+        deadline_miss: Option<LocalDeadlineMiss>,
+    ) -> zenoh_flow::ZFResult<HashMap<zenoh_flow::PortId, NodeOutput>> {
+        assert!(
+            deadline_miss.is_none(),
+            "Expected `deadline_miss` to be `None`"
+        );
+        default_output_rule(state, outputs)
+    }
+}
+
+// Run dataflow in single runtime
+async fn single_runtime() {
+    env_logger::init();
+
+    let (tx_sink, rx_sink) = flume::bounded::<()>(1);
+
+    let session = Arc::new(zenoh::open(zenoh::config::Config::default()).await.unwrap());
+    let hlc = async_std::sync::Arc::new(uhlc::HLC::default());
+    let rt_uuid = uuid::Uuid::new_v4();
+    let ctx = RuntimeContext {
+        session,
+        hlc,
+        loader: Arc::new(Loader::new(LoaderConfig { extensions: vec![] })),
+        runtime_name: format!("test-runtime-{}", rt_uuid).into(),
+        runtime_uuid: rt_uuid,
+    };
+
+    let mut dataflow =
+        zenoh_flow::runtime::dataflow::Dataflow::new(ctx.clone(), "test".into(), None);
+
+    let source = Arc::new(VecSource::new(vec![0]));
+    let sink = Arc::new(VecSink::new(tx_sink, vec![45, 15]));
+    let operator_ingress_outer = Arc::new(OperatorIngressOuter {});
+    let operator_ingress_inner = Arc::new(OperatorIngressInner {});
+    let operator_egress_inner = Arc::new(OperatorEgressInner {});
+    let operator_egress_outer = Arc::new(OperatorEgressOuter {});
+
+    dataflow
+        .try_add_static_source(
+            SOURCE.into(),
+            None,
+            PortDescriptor {
+                port_id: SOURCE.into(),
+                port_type: "int".into(),
+            },
+            source.initialize(&None).unwrap(),
+            source,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_static_operator(
+            OPERATOR_INGRESS_OUTER.into(),
+            vec![PortDescriptor {
+                port_id: SOURCE.into(),
+                port_type: "int".into(),
+            }],
+            vec![PortDescriptor {
+                port_id: OPERATOR_INGRESS_INNER.into(),
+                port_type: "int".into(),
+            }],
+            None,
+            operator_ingress_outer.initialize(&None).unwrap(),
+            operator_ingress_outer,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_static_operator(
+            OPERATOR_INGRESS_INNER.into(),
+            vec![PortDescriptor {
+                port_id: OPERATOR_INGRESS_OUTER.into(),
+                port_type: "int".into(),
+            }],
+            vec![PortDescriptor {
+                port_id: OPERATOR_EGRESS_INNER.into(),
+                port_type: "int".into(),
+            }],
+            None,
+            operator_ingress_inner.initialize(&None).unwrap(),
+            operator_ingress_inner,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_static_operator(
+            OPERATOR_EGRESS_INNER.into(),
+            vec![PortDescriptor {
+                port_id: OPERATOR_INGRESS_INNER.into(),
+                port_type: "int".into(),
+            }],
+            vec![PortDescriptor {
+                port_id: OPERATOR_EGRESS_OUTER.into(),
+                port_type: "int".into(),
+            }],
+            None,
+            operator_egress_inner.initialize(&None).unwrap(),
+            operator_egress_inner,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_static_operator(
+            OPERATOR_EGRESS_OUTER.into(),
+            vec![PortDescriptor {
+                port_id: OPERATOR_EGRESS_INNER.into(),
+                port_type: "int".into(),
+            }],
+            vec![PortDescriptor {
+                port_id: SINK.into(),
+                port_type: "int".into(),
+            }],
+            None,
+            operator_egress_outer.initialize(&None).unwrap(),
+            operator_egress_outer,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_static_sink(
+            SINK.into(),
+            PortDescriptor {
+                port_id: OPERATOR_EGRESS_OUTER.into(),
+                port_type: "int".into(),
+            },
+            sink.initialize(&None).unwrap(),
+            sink,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_link(
+            OutputDescriptor {
+                node: SOURCE.into(),
+                output: SOURCE.into(),
+            },
+            InputDescriptor {
+                node: OPERATOR_INGRESS_OUTER.into(),
+                input: SOURCE.into(),
+            },
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_link(
+            OutputDescriptor {
+                node: OPERATOR_INGRESS_OUTER.into(),
+                output: OPERATOR_INGRESS_INNER.into(),
+            },
+            InputDescriptor {
+                node: OPERATOR_INGRESS_INNER.into(),
+                input: OPERATOR_INGRESS_OUTER.into(),
+            },
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_link(
+            OutputDescriptor {
+                node: OPERATOR_INGRESS_INNER.into(),
+                output: OPERATOR_EGRESS_INNER.into(),
+            },
+            InputDescriptor {
+                node: OPERATOR_EGRESS_INNER.into(),
+                input: OPERATOR_INGRESS_INNER.into(),
+            },
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_link(
+            OutputDescriptor {
+                node: OPERATOR_EGRESS_INNER.into(),
+                output: OPERATOR_EGRESS_OUTER.into(),
+            },
+            InputDescriptor {
+                node: OPERATOR_EGRESS_OUTER.into(),
+                input: OPERATOR_EGRESS_INNER.into(),
+            },
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    dataflow
+        .try_add_link(
+            OutputDescriptor {
+                node: OPERATOR_EGRESS_OUTER.into(),
+                output: SINK.into(),
+            },
+            InputDescriptor {
+                node: SINK.into(),
+                input: OPERATOR_EGRESS_OUTER.into(),
+            },
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    // Incorrect loop, egress and ingress were switched.
+    assert!(dataflow
+        .try_add_loop(
+            OPERATOR_EGRESS_OUTER.into(),
+            OPERATOR_INGRESS_OUTER.into(),
+            "feedback".into(),
+            "int".into(),
+            false
+        )
+        .is_err());
+
+    // Correct loops.
+    assert!(dataflow
+        .try_add_loop(
+            OPERATOR_INGRESS_INNER.into(),
+            OPERATOR_EGRESS_INNER.into(),
+            FEEDBACK_INNER.into(),
+            "int".into(),
+            false
+        )
+        .is_ok());
+
+    assert!(dataflow
+        .try_add_loop(
+            OPERATOR_INGRESS_OUTER.into(),
+            OPERATOR_EGRESS_OUTER.into(),
+            FEEDBACK_OUTER.into(),
+            "int".into(),
+            true
+        )
+        .is_ok());
+
+    let mut instance = DataflowInstance::try_instantiate(dataflow).unwrap();
+
+    let ids = instance.get_nodes();
+    for id in &ids {
+        instance.start_node(id).await.unwrap();
+    }
+
+    // Wait for the Sink to finish asserting and then kill all nodes.
+    let _ = rx_sink.recv_async().await.unwrap();
+
+    for id in &instance.get_sources() {
+        instance.stop_node(id).await.unwrap()
+    }
+
+    for id in &instance.get_operators() {
+        instance.stop_node(id).await.unwrap()
+    }
+
+    for id in &instance.get_sinks() {
+        instance.stop_node(id).await.unwrap()
+    }
+}
+
+#[test]
+fn test_loop() {
+    let h1 = async_std::task::spawn(async move { single_runtime().await });
+
+    assert!(
+        async_std::task::block_on(async_std::future::timeout(
+            Duration::from_secs(5),
+            async move { h1.await }
+        ))
+        .is_ok(),
+        "Deadlock detected."
+    );
+}


### PR DESCRIPTION
A Loop is written as following:

```yaml
loops:
  - ingress: A
    egress: B
    feedback_port: feedback
    port_type: int
    is_infinite: false
```

The `ingress` is the starting point of a Loop. The `egress` is where it can
end. Each time a message goes through a Loop, Zenoh Flow either:
- attaches a new `LoopContext` to it,
- updates the already attached `LoopContext`.

For a given message, the `LoopContext` provides:
- the timestamp at which it entered the Loop,
- the timestamp at which the current iteration started,
- the duration of the last iteration,
- the iteration count (if the Loop was declared as finite).

A Loop between Operators can only exist if the following constraints are respected:
- the Ingress (starting point of the Loop) has a single output,
- the Egress (ending point) has a single input,
- no path between both Operators exist (excluding other Loops),
- an Operator can only be Ingress/Egress for a single Loop.

The dataflow validator was updated accordingly. In particular, the internal
structures now take the `NodeKind` into consideration (to be able to enforce the
constraints on Loops) and keeps track of the nodes that are Ingress / Egress.

---

Additional internal modifications include:
- The `DataFlowRecord` now uses `HashMap` to keep track of the nodes. This was
  motivated by the need to modify them when adding the feedback links of Loops.
- The validator checks that, without Loops, the dataflow is a Directed Acyclic
  Graph.