### PR TITLE
Documentation and examples in the documentation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ To build Zenoh-Flow, just type the following command after having followed the p
 $ cargo build --release
 ```
 
+
+-----------
+## How to build the docs
+
+To build Zenoh-Flow documentation, just type the following command after having followed the previous instructions:
+
+```bash
+$ cargo doc
+```
+
+The HTML documentation can then be found under `./target/doc/zenoh_flow/index.html`.
+
+
 -----------
 ## How to run
 

--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -71,6 +71,7 @@ impl Daemon {
 
     /// Creates a new `Daemon` from a configuration file.
     ///
+    /// # Errors
     /// This function can fail if:
     /// - unable to configure zenoh.
     /// - unable to get the machine hostname.
@@ -149,6 +150,9 @@ impl Daemon {
     /// Sets the status to ready and serves all the requests.
     ///
     /// It stops when receives the stop signal.
+    ///
+    /// # Errors
+    /// Returns an error variant if zenoh-rpc fails.
     pub async fn run(&self, stop: async_std::channel::Receiver<()>) -> ZFResult<()> {
         log::info!("Runtime main loop starting");
 
@@ -223,6 +227,8 @@ impl Daemon {
     /// The daemon is started on a separated blocking task.
     /// And the stop sender and task handler are returned to the caller.
     ///
+    /// # Errors
+    /// Returns an error variant if zenoh fails.
     pub async fn start(
         &self,
     ) -> ZFResult<(
@@ -272,6 +278,10 @@ impl Daemon {
     /// Stops the daemon.
     ///
     /// Removes information, configuration and status from Zenoh.
+    ///
+    /// # Errors
+    /// Returns an error variant if zenoh fails, or if the stop
+    /// channels is disconnected.
     pub async fn stop(&self, stop: async_std::channel::Sender<()>) -> ZFResult<()> {
         stop.send(())
             .await
@@ -292,6 +302,9 @@ impl Daemon {
 }
 
 /// Gets the machine Uuid.
+///
+/// # Errors
+/// Returns an error variant if unable to get or parse the Uuid.
 pub fn get_machine_uuid() -> ZFResult<Uuid> {
     let machine_id_raw = machine_uid::get().map_err(|e| ZFError::ParsingError(format!("{}", e)))?;
     let node_str: &str = &machine_id_raw;

--- a/zenoh-flow-daemon/src/main.rs
+++ b/zenoh-flow-daemon/src/main.rs
@@ -43,14 +43,17 @@ struct RuntimeOpt {
 
 /// Helper function to read a file into a string.
 ///
-/// **Note:** it may panic.
+/// # Panics
+/// It may panic when calling filesystem related functions.
 async fn read_file(path: &Path) -> String {
     fs::read_to_string(path).await.unwrap() //FIXME.
 }
 
 /// Helper function to write a file.
 ///
-/// **Note:** it may panic.
+/// # Panics
+///
+/// It may panic when calling filesystem related functions.
 async fn _write_file(path: &Path, content: Vec<u8>) {
     // FIXME.
     let mut file = fs::File::create(path).await.unwrap();

--- a/zenoh-flow-daemon/src/main.rs
+++ b/zenoh-flow-daemon/src/main.rs
@@ -23,10 +23,13 @@ mod daemon;
 use daemon::Daemon;
 use zenoh_flow::runtime::RuntimeConfig;
 
+/// Default path for the runtime configuration file.
 static RUNTIME_CONFIG_FILE: &str = "/etc/zenoh-flow/runtime.yaml";
 
+/// Git version (commit id) for the runtime.
 const GIT_VERSION: &str = git_version::git_version!(prefix = "v", cargo_prefix = "v");
 
+/// The CLI parameters accepted by the runtime.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "dpn")]
 struct RuntimeOpt {
@@ -38,16 +41,29 @@ struct RuntimeOpt {
     node_uuid: bool,
 }
 
+/// Helper function to read a file into a string.
+///
+/// **Note:** it may panic.
 async fn read_file(path: &Path) -> String {
-    fs::read_to_string(path).await.unwrap()
+    fs::read_to_string(path).await.unwrap() //FIXME.
 }
 
+/// Helper function to write a file.
+///
+/// **Note:** it may panic.
 async fn _write_file(path: &Path, content: Vec<u8>) {
+    // FIXME.
     let mut file = fs::File::create(path).await.unwrap();
     file.write_all(&content).await.unwrap();
     file.sync_all().await.unwrap();
 }
 
+/// The runtime main function.
+///
+/// It initializes the `env_logger`, parses the arguments and then creates
+/// a runtime.
+///
+/// It is able to catch SIGINT for graceful termination.
 #[async_std::main]
 async fn main() {
     // Init logging

--- a/zenoh-flow-derive/src/lib.rs
+++ b/zenoh-flow-derive/src/lib.rs
@@ -15,7 +15,14 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
-
+/// The `ZFData` derive macro is provided to help the users
+/// in implementing the `DowncastAny` trait.
+///
+/// Example::
+/// ```no_run
+/// #[derive(Debug, Clone, ZFData)]
+/// pub struct ZFString(pub String);
+/// ```
 #[proc_macro_derive(ZFData)]
 pub fn zf_data_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -35,6 +42,15 @@ pub fn zf_data_derive(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
+/// The `ZFState` derive macros is provided to help the users
+/// in implementing the `ZFState` trait.
+///
+/// Example:
+/// ```no_run
+/// #[derive(Debug, Clone, ZFState)]
+/// pub struct MyState;
+/// ```
+///
 #[proc_macro_derive(ZFState)]
 pub fn zf_state_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/zenoh-flow-derive/src/lib.rs
+++ b/zenoh-flow-derive/src/lib.rs
@@ -19,7 +19,9 @@ use syn::{parse_macro_input, DeriveInput};
 /// in implementing the `DowncastAny` trait.
 ///
 /// Example::
-/// ```no_run
+/// ```no_compile
+/// use zenoh_flow_derive::ZFData;
+///
 /// #[derive(Debug, Clone, ZFData)]
 /// pub struct ZFString(pub String);
 /// ```
@@ -46,7 +48,9 @@ pub fn zf_data_derive(input: TokenStream) -> TokenStream {
 /// in implementing the `ZFState` trait.
 ///
 /// Example:
-/// ```no_run
+/// ```no_compile
+/// use zenoh_flow_derive::ZFState;
+///
 /// #[derive(Debug, Clone, ZFState)]
 /// pub struct MyState;
 /// ```

--- a/zenoh-flow/src/error.rs
+++ b/zenoh-flow/src/error.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 use zrpc::zrpcresult::ZRPCError;
 
 /// The Zenoh Flow error
-/// It contains mapping to most of the error that could happen withing
-/// Zenoh Flow and dependencies.
+/// It contains mapping to most of the errors that could happen within
+/// Zenoh Flow and its dependencies.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum ZFError {
     GenericError,

--- a/zenoh-flow/src/error.rs
+++ b/zenoh-flow/src/error.rs
@@ -17,6 +17,9 @@ use std::convert::From;
 use uuid::Uuid;
 use zrpc::zrpcresult::ZRPCError;
 
+/// The Zenoh Flow error
+/// It contains mapping to most of the error that could happen withing
+/// Zenoh Flow and dependencies.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub enum ZFError {
     GenericError,

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -12,27 +12,27 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 //!
-//! Zenoh-Flow provides a zenoh-based dataflow programming framework for
+//! Zenoh Flow provides a zenoh-based data flow programming framework for
 //! computations that span from the cloud to the device.
 //!
-//! Zenoh-Flow allow users to declare a dataflow graph, via a YAML file,
-//! and use tags to express location affinity and requirements for the
-//! operators that makeup the graph. When deploying the dataflow graph,
-//! Zenoh-Flow automatically deals with distribution by linking
+//! Zenoh Flow allows users to declare a data flow graph, via a YAML file,
+//! and uses tags to express location affinity and requirements for the
+//! operators that makeup the graph. When deploying the data flow graph,
+//! Zenoh Flow automatically deals with distribution by linking
 //! remote operators through zenoh.
 //!
-//! A dataflow is composed of set of nodes: sources — producing data, operators
+//! A data flow is composed of set of nodes: sources — producing data, operators
 //! — computing over the data, and sinks — consuming the resulting data.
 //!  These nodes are dynamically loaded at runtime.
 //!
 //! Remote source, operators, and sinks leverage zenoh to communicate in a
-//! transparent manner. In other terms, the dataflow the dafalow graph retails
+//! transparent manner. In other terms, the data flow the data flow graph retails
 //! location transparency and could be deployed in
 //! different ways depending on specific needs.
 //!
-//! Zenoh-Flow provides several working examples that illustrate how to
+//! Zenoh Flow provides several working examples that illustrate how to
 //! define operators, sources and sinks as well as how to
-//! declaratively define they dataflow graph by means of a YAML file.
+//! declaratively define they data flow graph by means of a YAML file.
 
 use const_format::formatcp;
 

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -11,6 +11,28 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
+//!
+//! Zenoh-Flow provides a zenoh-based dataflow programming framework for
+//! computations that span from the cloud to the device.
+//!
+//! Zenoh-Flow allow users to declare a dataflow graph, via a YAML file,
+//! and use tags to express location affinity and requirements for the
+//! operators that makeup the graph. When deploying the dataflow graph,
+//! Zenoh-Flow automatically deals with distribution by linking
+//! remote operators through zenoh.
+//!
+//! A dataflow is composed of set of nodes: sources — producing data, operators
+//! — computing over the data, and sinks — consuming the resulting data.
+//!  These nodes are dynamically loaded at runtime.
+//!
+//! Remote source, operators, and sinks leverage zenoh to communicate in a
+//! transparent manner. In other terms, the dataflow the dafalow graph retails
+//! location transparency and could be deployed in
+//! different ways depending on specific needs.
+//!
+//! Zenoh-Flow provides several working examples that illustrate how to
+//! define operators, sources and sinks as well as how to
+//! declaratively define they dataflow graph by means of a YAML file.
 
 use const_format::formatcp;
 
@@ -39,6 +61,12 @@ pub use macros::*;
 pub mod error;
 pub use error::*;
 
+/// Commit id of latest commit on Zenoh Flow
 pub const GIT_VERSION: &str = git_version::git_version!(prefix = "v", cargo_prefix = "v");
+
+/// Version of Zenoh Flow Cargo Package
+/// This is used to verify compatibility in nodes dynamic loading.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Complete string with the Zenoh Flow version, including commit id.
 pub const FULL_VERSION: &str = formatcp!("{}-{}", VERSION, GIT_VERSION);

--- a/zenoh-flow/src/macros.rs
+++ b/zenoh-flow/src/macros.rs
@@ -145,7 +145,7 @@ macro_rules! export_source {
 }
 
 /// This macros should be used in order to provide the symbols
-/// for the dynamic load of an Sink. Along with a register function
+/// for the dynamic load of a Sink. Along with a register function
 ///
 /// Example:
 ///
@@ -211,8 +211,8 @@ macro_rules! zf_spin_lock {
     };
 }
 
-/// This macro is an helper if you node does not need any state.
-/// In can be used inside your implementation of `Node::intialize`
+/// This macro is a helper if your node does not need any state.
+/// It can be used inside your implementation of `Node::intialize`
 ///
 /// Example:
 ///

--- a/zenoh-flow/src/macros.rs
+++ b/zenoh-flow/src/macros.rs
@@ -12,6 +12,23 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
+/// This macros should be used in order to provide the symbols
+/// for the dynamic load of an Operator. Along with a register function
+///
+/// Example:
+///
+/// ```no_run
+/// use async_std::sync::Arc;
+/// use zenoh_flow::{ZFResult, Operator, export_operator};
+/// export_operator!(register);
+///
+///
+/// fn register() -> ZFResult<Arc<dyn Operator>> {
+///    Ok(Arc::new(MyOperator) as Arc<dyn Operator>)
+/// }
+///
+/// ```
+///
 #[macro_export]
 macro_rules! export_operator {
     ($register:expr) => {
@@ -26,6 +43,24 @@ macro_rules! export_operator {
     };
 }
 
+/// This macros should be used in order to provide the symbols
+/// for the dynamic load of an Source. Along with a register function
+///
+/// Example:
+///
+/// ```no_run
+/// use async_std::sync::Arc;
+/// use zenoh_flow::{ZFResult, Source, export_source};
+///
+/// export_source!(register);
+///
+///
+/// fn register() -> ZFResult<Arc<dyn Source>> {
+///    Ok(Arc::new(MySource) as Arc<dyn Source>)
+/// }
+///
+/// ```
+///
 #[macro_export]
 macro_rules! export_source {
     ($register:expr) => {
@@ -40,6 +75,24 @@ macro_rules! export_source {
     };
 }
 
+/// This macros should be used in order to provide the symbols
+/// for the dynamic load of an Sink. Along with a register function
+///
+/// Example:
+///
+/// ```no_run
+/// use async_std::sync::Arc;
+/// use zenoh_flow::{ZFResult, Sink, export_sink};
+///
+/// export_sink!(register);
+///
+///
+/// fn register() -> ZFResult<Arc<dyn Sink>> {
+///    Ok(Arc::new(MySink) as Arc<dyn Sink>)
+/// }
+///
+/// ```
+///
 #[macro_export]
 macro_rules! export_sink {
     ($register:expr) => {
@@ -54,6 +107,8 @@ macro_rules! export_sink {
     };
 }
 
+/// Spin lock over an [`async_std::sync::Mutex`](`async_std::sync::Mutex`)
+/// Note: This is intended for internal usage.
 #[macro_export]
 macro_rules! zf_spin_lock {
     ($val : expr) => {
@@ -66,6 +121,26 @@ macro_rules! zf_spin_lock {
     };
 }
 
+/// This macro is an helper if you node does not need any state.
+/// In can be used inside your implementation of `Node::intialize`
+///
+/// Example:
+///
+/// ```no_run
+/// struct MyOp;
+///
+///
+///  impl Node for MyOp {
+///     fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+///         zf_empty_state!()
+///     }
+///
+///     fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+///         Ok(())
+///     }
+///  }
+///
+/// ```
 #[macro_export]
 macro_rules! zf_empty_state {
     () => {

--- a/zenoh-flow/src/macros.rs
+++ b/zenoh-flow/src/macros.rs
@@ -18,9 +18,57 @@
 /// Example:
 ///
 /// ```no_run
+/// use std::collections::HashMap;
 /// use async_std::sync::Arc;
-/// use zenoh_flow::{ZFResult, Operator, export_operator};
+/// use zenoh_flow::{ZFResult, Operator, export_operator, Node, zf_empty_state,
+///     State, Configuration, Context, DataMessage, default_input_rule,
+///     default_output_rule, PortId, InputToken, LocalDeadlineMiss,
+///     NodeOutput, Data};
+///
+/// pub struct MyOperator;
+///
+/// impl Node for MyOperator {
+///     fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+///         zf_empty_state!()
+///     }
+///
+///     fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+///         Ok(())
+///     }
+/// }
+///
+/// impl Operator for MyOperator {
+///     fn input_rule(
+///         &self,
+///         _context: &mut Context,
+///         state: &mut State,
+///         tokens: &mut HashMap<PortId, InputToken>
+///     ) -> ZFResult<bool> {
+///         default_input_rule(state, tokens)
+///     }
+///
+///     fn run(
+///         &self,
+///         context: &mut Context,
+///         state: &mut State,
+///         inputs: &mut HashMap<PortId, DataMessage>,
+///      ) -> ZFResult<HashMap<PortId, Data>> {
+///         panic!("Not implemented...")
+///      }
+///
+///     fn output_rule(
+///        &self,
+///        _context: &mut Context,
+///        state: &mut State,
+///        outputs: HashMap<PortId, Data>,
+///        _deadline_miss: Option<LocalDeadlineMiss>,
+///      ) -> ZFResult<HashMap<PortId, NodeOutput>> {
+///         default_output_rule(state, outputs)
+///      }
+/// }
+///
 /// export_operator!(register);
+///
 ///
 ///
 /// fn register() -> ZFResult<Arc<dyn Operator>> {
@@ -49,8 +97,29 @@ macro_rules! export_operator {
 /// Example:
 ///
 /// ```no_run
+/// use async_trait::async_trait;
 /// use async_std::sync::Arc;
-/// use zenoh_flow::{ZFResult, Source, export_source};
+/// use zenoh_flow::{ZFResult, Source, export_source, Node, zf_empty_state,
+///     State, Configuration, Context, Data};
+///
+/// pub struct MySource;
+///
+/// impl Node for MySource {
+///     fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+///         zf_empty_state!()
+///     }
+///
+///     fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+///         Ok(())
+///     }
+/// }
+///
+/// #[async_trait]
+/// impl Source for MySource {
+///     async fn run(&self, _context: &mut Context, _state: &mut State) -> ZFResult<Data> {
+///         panic!("Not implemented...")
+///     }
+/// }
 ///
 /// export_source!(register);
 ///
@@ -81,8 +150,29 @@ macro_rules! export_source {
 /// Example:
 ///
 /// ```no_run
+/// use async_trait::async_trait;
 /// use async_std::sync::Arc;
-/// use zenoh_flow::{ZFResult, Sink, export_sink};
+/// use zenoh_flow::{ZFResult, Sink, export_sink, Node, zf_empty_state,
+///     State, Configuration, Context, DataMessage};
+///
+/// pub struct MySink;
+///
+/// impl Node for MySink {
+///     fn initialize(&self, _configuration: &Option<Configuration>) -> ZFResult<State> {
+///         zf_empty_state!()
+///     }
+///
+///     fn finalize(&self, _state: &mut State) -> ZFResult<()> {
+///         Ok(())
+///     }
+/// }
+///
+/// #[async_trait]
+/// impl Sink for MySink {
+///     async fn run(&self, _context: &mut Context, _state: &mut State, _input : DataMessage)  -> ZFResult<()> {
+///         Ok(())
+///     }
+/// }
 ///
 /// export_sink!(register);
 ///
@@ -127,6 +217,8 @@ macro_rules! zf_spin_lock {
 /// Example:
 ///
 /// ```no_run
+/// use zenoh_flow::{zf_empty_state, Node, ZFResult, State, Configuration};
+///
 /// struct MyOp;
 ///
 ///

--- a/zenoh-flow/src/model/connector.rs
+++ b/zenoh-flow/src/model/connector.rs
@@ -16,6 +16,7 @@ use crate::model::link::PortDescriptor;
 use crate::serde::{Deserialize, Serialize};
 use crate::{NodeId, RuntimeId};
 
+/// The type of the connector.
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub enum ZFConnectorKind {
     Sender,
@@ -31,6 +32,9 @@ impl std::fmt::Display for ZFConnectorKind {
     }
 }
 
+/// The internal representation of a connector within a
+/// [`DataFlowRecord`](`DataFlowRecord`)
+///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZFConnectorRecord {
     pub kind: ZFConnectorKind,

--- a/zenoh-flow/src/model/dataflow/descriptor.rs
+++ b/zenoh-flow/src/model/dataflow/descriptor.rs
@@ -107,6 +107,9 @@ pub struct DataFlowDescriptor {
 
 impl DataFlowDescriptor {
     /// Creates a new `DataFlowDescriptor` from its YAML representation.
+    ///
+    ///  # Errors
+    /// A variant error is returned if deserialization fails.
     pub fn from_yaml(data: &str) -> ZFResult<Self> {
         let dataflow_descriptor = serde_yaml::from_str::<DataFlowDescriptor>(data)
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))?;
@@ -115,6 +118,9 @@ impl DataFlowDescriptor {
     }
 
     /// Creates a new `DataFlowDescriptor` from its JSON representation.
+    ///
+    ///  # Errors
+    /// A variant error is returned if deserialization fails.
     pub fn from_json(data: &str) -> ZFResult<Self> {
         let dataflow_descriptor = serde_json::from_str::<DataFlowDescriptor>(data)
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))?;
@@ -123,11 +129,17 @@ impl DataFlowDescriptor {
     }
 
     /// Returns the JSON representation of the `DataFlowDescriptor`.
+    ///
+    ///  # Errors
+    /// A variant error is returned if serialization fails.
     pub fn to_json(&self) -> ZFResult<String> {
         serde_json::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
 
     /// Returns the YAML representation of the `DataFlowDescriptor`.
+    ///
+    ///  # Errors
+    /// A variant error is returned if serialization fails.
     pub fn to_yaml(&self) -> ZFResult<String> {
         serde_yaml::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
@@ -176,6 +188,9 @@ impl DataFlowDescriptor {
     /// - the dataflow, without the loops, is a DAG,
     /// - the end-to-end deadlines are correct,
     /// - the loops are valid.
+    ///
+    ///  # Errors
+    /// A variant error is returned if validation fails.
     fn validate(&self) -> ZFResult<()> {
         let mut validator = DataflowValidator::try_from(self)?;
 

--- a/zenoh-flow/src/model/dataflow/record.rs
+++ b/zenoh-flow/src/model/dataflow/record.rs
@@ -26,6 +26,8 @@ use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
+/// The instance of a [`DataFlowDescriptor`](`DataFlowDescriptor`).
+///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DataFlowRecord {
     pub uuid: Uuid,
@@ -39,24 +41,29 @@ pub struct DataFlowRecord {
 }
 
 impl DataFlowRecord {
+    /// Creates a new `DataFlowDescriptor` record from its YAML format.
     pub fn from_yaml(data: &str) -> ZFResult<Self> {
         serde_yaml::from_str::<DataFlowRecord>(data)
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))
     }
 
+    /// Creates a new `DataFlowDescriptor` from its JSON format.
     pub fn from_json(data: &str) -> ZFResult<Self> {
         serde_json::from_str::<DataFlowRecord>(data)
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))
     }
 
+    /// Returns the JSON representation of the `DataFlowDescriptor`.
     pub fn to_json(&self) -> ZFResult<String> {
         serde_json::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
 
+    /// Returns the YAML representation of the `DataFlowDescriptor`.
     pub fn to_yaml(&self) -> ZFResult<String> {
         serde_yaml::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
 
+    /// Returns the runtime mapping for the given node.
     pub fn find_node_runtime(&self, id: &str) -> Option<RuntimeId> {
         match self.operators.get(id) {
             Some(o) => Some(o.runtime.clone()),
@@ -67,6 +74,7 @@ impl DataFlowRecord {
         }
     }
 
+    /// Returns the output type for the given node and port.
     pub fn find_node_output_type(&self, id: &str, output: &str) -> Option<PortType> {
         log::trace!("find_node_output_type({:?},{:?})", id, output);
         match self.operators.get(id) {
@@ -78,6 +86,7 @@ impl DataFlowRecord {
         }
     }
 
+    /// Returns the input type for the given node and port.
     pub fn find_node_input_type(&self, id: &str, input: &str) -> Option<PortType> {
         log::trace!("find_node_input_type({:?},{:?})", id, input);
         match self.operators.get(id) {
@@ -89,6 +98,11 @@ impl DataFlowRecord {
         }
     }
 
+    /// Adds the links.
+    ///
+    /// If the nodes are mapped to different machines it adds the couple of
+    /// connectors in between and creates the unique key expression
+    /// for the data to flow in Zenoh.
     fn add_links(&mut self, links: &[LinkDescriptor]) -> ZFResult<()> {
         for l in links {
             log::debug!("Adding link: {:?}…", l);

--- a/zenoh-flow/src/model/dataflow/record.rs
+++ b/zenoh-flow/src/model/dataflow/record.rs
@@ -42,23 +42,35 @@ pub struct DataFlowRecord {
 
 impl DataFlowRecord {
     /// Creates a new `DataFlowDescriptor` record from its YAML format.
+    ///
+    ///  # Errors
+    /// A variant error is returned if deserialization fails.
     pub fn from_yaml(data: &str) -> ZFResult<Self> {
         serde_yaml::from_str::<DataFlowRecord>(data)
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))
     }
 
     /// Creates a new `DataFlowDescriptor` from its JSON format.
+    ///
+    ///  # Errors
+    /// A variant error is returned if deserialization fails.
     pub fn from_json(data: &str) -> ZFResult<Self> {
         serde_json::from_str::<DataFlowRecord>(data)
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))
     }
 
     /// Returns the JSON representation of the `DataFlowDescriptor`.
+    ///
+    ///  # Errors
+    /// A variant error is returned if serialization fails.
     pub fn to_json(&self) -> ZFResult<String> {
         serde_json::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
 
     /// Returns the YAML representation of the `DataFlowDescriptor`.
+    ///
+    ///  # Errors
+    /// A variant error is returned if serialization fails.
     pub fn to_yaml(&self) -> ZFResult<String> {
         serde_yaml::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
@@ -103,6 +115,9 @@ impl DataFlowRecord {
     /// If the nodes are mapped to different machines it adds the couple of
     /// connectors in between and creates the unique key expression
     /// for the data to flow in Zenoh.
+    ///
+    ///  # Errors
+    /// A variant error is returned if validation fails.
     fn add_links(&mut self, links: &[LinkDescriptor]) -> ZFResult<()> {
         for l in links {
             log::debug!("Adding link: {:?}…", l);

--- a/zenoh-flow/src/model/dataflow/record.rs
+++ b/zenoh-flow/src/model/dataflow/record.rs
@@ -26,7 +26,7 @@ use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
-/// The instance of a [`DataFlowDescriptor`](`DataFlowDescriptor`).
+///A `DataFlowRecord` is an instance of a [`DataFlowDescriptor`](`DataFlowDescriptor`).
 ///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DataFlowRecord {
@@ -41,7 +41,7 @@ pub struct DataFlowRecord {
 }
 
 impl DataFlowRecord {
-    /// Creates a new `DataFlowDescriptor` record from its YAML format.
+    /// Creates a new `DataFlowRecord` record from its YAML format.
     ///
     ///  # Errors
     /// A variant error is returned if deserialization fails.
@@ -50,7 +50,7 @@ impl DataFlowRecord {
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))
     }
 
-    /// Creates a new `DataFlowDescriptor` from its JSON format.
+    /// Creates a new `DataFlowRecord` from its JSON format.
     ///
     ///  # Errors
     /// A variant error is returned if deserialization fails.
@@ -59,7 +59,7 @@ impl DataFlowRecord {
             .map_err(|e| ZFError::ParsingError(format!("{}", e)))
     }
 
-    /// Returns the JSON representation of the `DataFlowDescriptor`.
+    /// Returns the JSON representation of the `DataFlowRecord`.
     ///
     ///  # Errors
     /// A variant error is returned if serialization fails.
@@ -67,7 +67,7 @@ impl DataFlowRecord {
         serde_json::to_string(&self).map_err(|_| ZFError::SerializationError)
     }
 
-    /// Returns the YAML representation of the `DataFlowDescriptor`.
+    /// Returns the YAML representation of the `DataFlowRecord`.
     ///
     ///  # Errors
     /// A variant error is returned if serialization fails.

--- a/zenoh-flow/src/model/dataflow/validator.rs
+++ b/zenoh-flow/src/model/dataflow/validator.rs
@@ -204,7 +204,7 @@ impl DataflowValidator {
     /// Adds a source
     ///
     /// #Errors
-    /// It can fail when calling `try_add_output` or `try_add_it`.
+    /// It can fail when calling `try_add_output` or `try_add_id`.
     pub(crate) fn try_add_source(
         &mut self,
         node_id: NodeId,
@@ -218,7 +218,7 @@ impl DataflowValidator {
     /// Adds a sink
     ///
     /// # Errors
-    /// It can fail when calling `try_add_output` or `try_add_it`.
+    /// It can fail when calling `try_add_output` or `try_add_id`.
     pub(crate) fn try_add_sink(&mut self, node_id: NodeId, input: PortDescriptor) -> ZFResult<()> {
         self.try_add_id(NodeKind::Sink, node_id.clone())?;
         self.try_add_input(node_id, input)
@@ -227,7 +227,7 @@ impl DataflowValidator {
     /// Adds an operator
     ///
     /// # Errors
-    /// It can fail when calling `try_add_output`, `try_add_it`
+    /// It can fail when calling `try_add_output`, `try_add_id`
     /// or `try_add_input`.
     pub(crate) fn try_add_operator(
         &mut self,

--- a/zenoh-flow/src/model/dataflow/validator.rs
+++ b/zenoh-flow/src/model/dataflow/validator.rs
@@ -68,12 +68,14 @@ pub(crate) struct DataflowValidator {
     loops_node_ids: HashSet<NodeId>,
 }
 
+/// Type of a Port, either Input or Output.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum PortKind {
     Input,
     Output,
 }
 
+/// The type of a Node.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum NodeKind {
     Source,
@@ -81,6 +83,7 @@ enum NodeKind {
     Operator,
 }
 
+/// Unique tuple that identifies a port.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 struct PortUniqueId {
     node_id: NodeId,
@@ -114,6 +117,7 @@ impl TryFrom<&DataFlowDescriptor> for DataflowValidator {
 }
 
 impl DataflowValidator {
+    /// Creates an empty `DataflowValidator`/
     pub(crate) fn new() -> Self {
         Self {
             graph_checker: Graph::new(),
@@ -166,6 +170,7 @@ impl DataflowValidator {
         Ok(node_checker_idx)
     }
 
+    /// `try_add_input` can fail when calling `try_add_node`.
     pub(crate) fn try_add_input(&mut self, node_id: NodeId, input: PortDescriptor) -> ZFResult<()> {
         let node_checker_idx = self.try_add_node(node_id, input, PortKind::Input)?;
         self.input_indexes.insert(node_checker_idx);
@@ -183,6 +188,7 @@ impl DataflowValidator {
         Ok(())
     }
 
+    /// Adds a source, can fail when calling `try_add_output` or `try_add_it`.
     pub(crate) fn try_add_source(
         &mut self,
         node_id: NodeId,
@@ -193,11 +199,14 @@ impl DataflowValidator {
         self.try_add_output(node_id, output)
     }
 
+    /// Adds a sink, can fail when calling `try_add_output` or `try_add_it`.
     pub(crate) fn try_add_sink(&mut self, node_id: NodeId, input: PortDescriptor) -> ZFResult<()> {
         self.try_add_id(NodeKind::Sink, node_id.clone())?;
         self.try_add_input(node_id, input)
     }
 
+    /// Adds an operator, can fail when calling `try_add_output`, `try_add_it`
+    /// or `try_add_input`.
     pub(crate) fn try_add_operator(
         &mut self,
         node_id: NodeId,
@@ -215,6 +224,7 @@ impl DataflowValidator {
             .try_for_each(|output| self.try_add_output(node_id.clone(), output.clone()))
     }
 
+    /// Adds a link, can fail if it does not find the ports.
     pub(crate) fn try_add_link(
         &mut self,
         from: &OutputDescriptor,

--- a/zenoh-flow/src/model/deadline.rs
+++ b/zenoh-flow/src/model/deadline.rs
@@ -18,6 +18,25 @@ use crate::DurationDescriptor;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+/// An End to End deadline is a deadline on sub graph.
+///
+/// The descriptor is its representation within the
+/// [`DataFlowDescriptor`](`DataFlowDescriptor`)
+///
+/// Example:
+///
+/// ```yaml
+/// from:
+///    node: AI-Magic-Face-Detection
+///    output: Faces
+/// to:
+///    node: AI-Magic-Face-Recognition
+///    input: Faces
+/// duration:
+///    length: 250
+///     unit: ms
+/// ```
+///
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineDescriptor {
     pub(crate) from: OutputDescriptor,
@@ -25,6 +44,7 @@ pub struct E2EDeadlineDescriptor {
     pub(crate) duration: DurationDescriptor,
 }
 
+/// An instance of [`E2EDeadlineDescriptor`](`E2EDeadlineDescriptor`)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineRecord {
     pub(crate) from: OutputDescriptor,

--- a/zenoh-flow/src/model/deadline.rs
+++ b/zenoh-flow/src/model/deadline.rs
@@ -18,7 +18,7 @@ use crate::DurationDescriptor;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-/// An End to End deadline is a deadline on sub graph.
+/// An End to End deadline is a deadline on a sub graph.
 ///
 /// The descriptor is its representation within the
 /// [`DataFlowDescriptor`](`DataFlowDescriptor`)
@@ -44,7 +44,7 @@ pub struct E2EDeadlineDescriptor {
     pub(crate) duration: DurationDescriptor,
 }
 
-/// An instance of [`E2EDeadlineDescriptor`](`E2EDeadlineDescriptor`)
+/// An `E2EDeadlineRecord` is an instance of an [`E2EDeadlineDescriptor`](`E2EDeadlineDescriptor`)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineRecord {
     pub(crate) from: OutputDescriptor,

--- a/zenoh-flow/src/model/link.rs
+++ b/zenoh-flow/src/model/link.rs
@@ -16,6 +16,20 @@ use crate::model::{InputDescriptor, OutputDescriptor};
 use crate::{PortId, PortType};
 use serde::{Deserialize, Serialize};
 
+/// The description of a link.
+///
+/// Example:
+///
+/// ```yaml
+///
+/// from:
+///   node : Counter
+///   output : Counter
+/// to:
+///   node : SumOperator
+///   input : Number
+///
+/// ```
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LinkDescriptor {
     pub from: OutputDescriptor,
@@ -31,6 +45,14 @@ impl std::fmt::Display for LinkDescriptor {
     }
 }
 
+/// The description of a port.
+///
+/// Example:
+///
+/// ```yaml
+/// id: Counter
+/// type: usize
+/// ```
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PortDescriptor {
     #[serde(alias = "id")]

--- a/zenoh-flow/src/model/mod.rs
+++ b/zenoh-flow/src/model/mod.rs
@@ -25,6 +25,15 @@ use crate::ZFError;
 use crate::{DurationDescriptor, NodeId, PortId};
 use std::fmt;
 
+/// Describes one output
+///
+/// Example:
+///
+/// ```yaml
+/// node : Counter
+/// output : Counter
+/// ```
+///
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OutputDescriptor {
     pub node: NodeId,
@@ -37,6 +46,14 @@ impl fmt::Display for OutputDescriptor {
     }
 }
 
+/// Describes one input
+///
+/// Example:
+///
+/// ```yaml
+/// node : SumOperator
+/// input : Number
+/// ```
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct InputDescriptor {
     pub node: NodeId,
@@ -49,6 +66,8 @@ impl fmt::Display for InputDescriptor {
     }
 }
 
+/// The kind of a node.
+/// This used in tools.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NodeKind {
@@ -89,6 +108,7 @@ impl Default for NodeKind {
 }
 // Registry metadata
 
+/// The metadata for a node stored in the registry.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RegistryNode {
     pub id: NodeId,
@@ -101,6 +121,7 @@ pub struct RegistryNode {
 }
 
 impl RegistryNode {
+    /// Adds a tag for this node.
     pub fn add_tag(&mut self, tag: RegistryNodeTag) {
         let index = self.tags.iter().position(|t| t.name == tag.name);
         match index {
@@ -118,6 +139,8 @@ impl RegistryNode {
     }
 }
 
+/// The tag of a node in the graph.
+/// A tag represents a version/flavor of a node.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RegistryNodeTag {
     pub name: String,
@@ -143,6 +166,7 @@ impl RegistryNodeTag {
     }
 }
 
+/// The information about the architecure/os for a node in the registry.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RegistryNodeArchitecture {
     pub arch: String,

--- a/zenoh-flow/src/model/mod.rs
+++ b/zenoh-flow/src/model/mod.rs
@@ -66,8 +66,11 @@ impl fmt::Display for InputDescriptor {
     }
 }
 
-/// The kind of a node.
-/// This used in tools.
+/// The kind of a graph node.
+/// It is used as discriminant to understand the kind
+/// of a node in the graph. (e.g. it is a source, a sink or an operator?)
+/// It is used internally when all nodes are mixed inside some data structure.
+///
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NodeKind {
@@ -121,7 +124,9 @@ pub struct RegistryNode {
 }
 
 impl RegistryNode {
-    /// Adds a tag for this node.
+    /// Adds a the given [`RegistryNodeTag`](`RegistryNodeTag`) for this node.
+    /// This is like adding a version/flavor of that node, similar to
+    /// Docker's tag.
     pub fn add_tag(&mut self, tag: RegistryNodeTag) {
         let index = self.tags.iter().position(|t| t.name == tag.name);
         match index {

--- a/zenoh-flow/src/model/node.rs
+++ b/zenoh-flow/src/model/node.rs
@@ -82,7 +82,7 @@ impl std::fmt::Display for SourceDescriptor {
     }
 }
 
-/// Describes a operator.
+/// Describes an operator.
 ///
 /// Example:
 ///
@@ -119,7 +119,7 @@ impl std::fmt::Display for OperatorDescriptor {
 
 // Records
 
-/// The instance of a [`SinkDescriptor`](`SinkDescriptor`)
+/// A `SinkRecord` is an instance of a [`SinkDescriptor`](`SinkDescriptor`)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SinkRecord {
     pub id: NodeId,
@@ -146,7 +146,7 @@ impl SinkRecord {
     }
 }
 
-/// The instance of a [`SourceDescriptor`](`SourceDescriptor`)
+/// A `SourceRecord` is an instance of a [`SourceDescriptor`](`SourceDescriptor`)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SourceRecord {
     pub id: NodeId,
@@ -174,7 +174,7 @@ impl SourceRecord {
     }
 }
 
-/// The instance of a [`OperatorDescriptor`](`OperatorDescriptor`)
+/// An `OperatorRecord` is an instance of an [`OperatorDescriptor`](`OperatorDescriptor`)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperatorRecord {
     pub(crate) id: NodeId,

--- a/zenoh-flow/src/model/node.rs
+++ b/zenoh-flow/src/model/node.rs
@@ -21,6 +21,21 @@ use std::time::Duration;
 
 // Descriptors
 
+/// Describes a sink.
+///
+/// Example:
+///
+///
+/// ```yaml
+/// id : PrintSink
+/// uri: file://./target/release/libgeneric_sink.so
+/// configuration:
+///   file: /tmp/generic-sink.txt
+/// input:
+///   id: Data
+///   type: usize
+/// ```
+///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SinkDescriptor {
     pub id: NodeId,
@@ -36,6 +51,21 @@ impl std::fmt::Display for SinkDescriptor {
     }
 }
 
+/// Describes a source.
+///
+/// Example:
+///
+///
+/// ```yaml
+/// id : PrintSink
+/// uri: file://./target/release/libcounter_source.so
+/// configuration:
+///   start: 10
+/// output:
+///   id: Counter
+///   type: usize
+/// ```
+///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SourceDescriptor {
     pub id: NodeId,
@@ -52,6 +82,24 @@ impl std::fmt::Display for SourceDescriptor {
     }
 }
 
+/// Describes a operator.
+///
+/// Example:
+///
+///
+/// ```yaml
+/// id : PrintSink
+/// uri: file://./target/release/libmy_op.so
+/// configuration:
+///   by: 10
+/// inputs:
+///     - id: Number
+///       type: usize
+/// outputs:
+///   - id: Multiplied
+///     type: usize
+/// ```
+///
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperatorDescriptor {
     pub id: NodeId,
@@ -71,6 +119,7 @@ impl std::fmt::Display for OperatorDescriptor {
 
 // Records
 
+/// The instance of a [`SinkDescriptor`](`SinkDescriptor`)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SinkRecord {
     pub id: NodeId,
@@ -87,6 +136,7 @@ impl std::fmt::Display for SinkRecord {
 }
 
 impl SinkRecord {
+    /// Returns the `PortType` for the input.
     pub fn get_input_type(&self, id: &str) -> Option<PortType> {
         if self.input.port_id.as_ref() == id {
             Some(self.input.port_type.clone())
@@ -96,6 +146,7 @@ impl SinkRecord {
     }
 }
 
+/// The instance of a [`SourceDescriptor`](`SourceDescriptor`)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SourceRecord {
     pub id: NodeId,
@@ -113,6 +164,7 @@ impl std::fmt::Display for SourceRecord {
 }
 
 impl SourceRecord {
+    /// Returns the `PortType` for the output.
     pub fn get_output_type(&self, id: &str) -> Option<PortType> {
         if self.output.port_id.as_ref() == id {
             Some(self.output.port_type.clone())
@@ -122,6 +174,7 @@ impl SourceRecord {
     }
 }
 
+/// The instance of a [`OperatorDescriptor`](`OperatorDescriptor`)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperatorRecord {
     pub(crate) id: NodeId,
@@ -142,6 +195,7 @@ impl std::fmt::Display for OperatorRecord {
 }
 
 impl OperatorRecord {
+    /// Returns the `PortType` for the given output.
     pub fn get_output_type(&self, id: &str) -> Option<PortType> {
         self.outputs
             .iter()
@@ -149,6 +203,7 @@ impl OperatorRecord {
             .map(|lid| lid.port_type.clone())
     }
 
+    /// Return the `PortType` for the given input.
     pub fn get_input_type(&self, id: &str) -> Option<PortType> {
         self.inputs
             .iter()

--- a/zenoh-flow/src/runtime/dataflow/instance/link.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/link.rs
@@ -25,7 +25,7 @@ pub struct LinkSender<T> {
 }
 
 /// The Zenoh Flow link receiver.
-/// A wrapper over a flume recver, that receiver `Arc<T>` and the associated
+/// A wrapper over a flume Receiver, that receives `Arc<T>` and the associated
 /// `PortId`
 #[derive(Clone, Debug)]
 pub struct LinkReceiver<T> {
@@ -33,8 +33,8 @@ pub struct LinkReceiver<T> {
     pub receiver: flume::Receiver<Arc<T>>,
 }
 
-/// The output of the [`LinkReceiver<T>`](`LinkReceiver<T>`) a tuple
-/// containg the `PortId` and `Arc<T>`.
+/// The output of the [`LinkReceiver<T>`](`LinkReceiver<T>`), a tuple
+/// containing the `PortId` and `Arc<T>`.
 ///
 /// In Zenoh Flow `T = Data`.
 ///

--- a/zenoh-flow/src/runtime/dataflow/instance/link.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/link.rs
@@ -15,21 +15,35 @@
 use crate::{PortId, ZFResult};
 use async_std::sync::Arc;
 
+/// The Zenoh Flow link sender.
+/// A wrapper over a flume Sender, that sends `Arc<T>` and is associated
+/// with a `PortId`
 #[derive(Clone, Debug)]
 pub struct LinkSender<T> {
     pub id: PortId,
     pub sender: flume::Sender<Arc<T>>,
 }
 
+/// The Zenoh Flow link receiver.
+/// A wrapper over a flume recver, that receiver `Arc<T>` and the associated
+/// `PortId`
 #[derive(Clone, Debug)]
 pub struct LinkReceiver<T> {
     pub id: PortId,
     pub receiver: flume::Receiver<Arc<T>>,
 }
 
+/// The output of the [`LinkReceiver<T>`](`LinkReceiver<T>`) a tuple
+/// containg the `PortId` and `Arc<T>`.
+///
+/// In Zenoh Flow `T = Data`.
+///
 pub type ZFLinkOutput<T> = ZFResult<(PortId, Arc<T>)>;
 
 impl<T: std::marker::Send + std::marker::Sync> LinkReceiver<T> {
+    /// Wrapper over flume::Receiver::recv_async(),
+    /// it returns [`ZFLinkOutput<T>`](`ZFLinkOutput<T>`)
+    ///
     pub fn recv(
         &self,
     ) -> ::core::pin::Pin<Box<dyn std::future::Future<Output = ZFLinkOutput<T>> + '_ + Send + Sync>>
@@ -41,45 +55,59 @@ impl<T: std::marker::Send + std::marker::Sync> LinkReceiver<T> {
         Box::pin(__recv(self))
     }
 
+    /// Discards the message
+    ///
+    /// *Note:* Not implemented.
     pub async fn discard(&self) -> ZFResult<()> {
         Ok(())
     }
 
+    /// Returns the `PortId` associated with the receiver.
     pub fn id(&self) -> PortId {
         self.id.clone()
     }
 
+    /// Checks if the receiver is disconnected.
     pub fn is_disconnected(&self) -> bool {
         self.receiver.is_disconnected()
     }
 }
 
 impl<T> LinkSender<T> {
+    /// Wrapper over flume::Sender::send_async(),
+    /// it sends `Arc<T>`.
+    ///
     pub async fn send(&self, data: Arc<T>) -> ZFResult<()> {
         Ok(self.sender.send_async(data).await?)
     }
 
+    /// Returns the sender occupation.
     pub fn len(&self) -> usize {
         self.sender.len()
     }
 
+    /// Checks if the sender is empty.
     pub fn is_empty(&self) -> bool {
         self.sender.is_empty()
     }
 
+    /// Returns the sender capacity if any.
     pub fn capacity(&self) -> Option<usize> {
         self.sender.capacity()
     }
 
+    /// Returns the sender `PortId`.
     pub fn id(&self) -> PortId {
         self.id.clone()
     }
 
+    /// Checks is the sender is disconnected.
     pub fn is_disconnected(&self) -> bool {
         self.sender.is_disconnected()
     }
 }
 
+/// Creates the `Link` with the given capacity and `PortId`s.
 pub fn link<T>(
     capacity: Option<usize>,
     send_id: PortId,

--- a/zenoh-flow/src/runtime/dataflow/instance/link.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/link.rs
@@ -38,12 +38,15 @@ pub struct LinkReceiver<T> {
 ///
 /// In Zenoh Flow `T = Data`.
 ///
+///
 pub type ZFLinkOutput<T> = ZFResult<(PortId, Arc<T>)>;
 
 impl<T: std::marker::Send + std::marker::Sync> LinkReceiver<T> {
     /// Wrapper over flume::Receiver::recv_async(),
     /// it returns [`ZFLinkOutput<T>`](`ZFLinkOutput<T>`)
     ///
+    /// # Errors
+    /// If fails if the link is disconnected
     pub fn recv(
         &self,
     ) -> ::core::pin::Pin<Box<dyn std::future::Future<Output = ZFLinkOutput<T>> + '_ + Send + Sync>>
@@ -58,6 +61,9 @@ impl<T: std::marker::Send + std::marker::Sync> LinkReceiver<T> {
     /// Discards the message
     ///
     /// *Note:* Not implemented.
+    ///
+    /// # Errors
+    /// It fails if the link is disconnected
     pub async fn discard(&self) -> ZFResult<()> {
         Ok(())
     }
@@ -77,6 +83,8 @@ impl<T> LinkSender<T> {
     /// Wrapper over flume::Sender::send_async(),
     /// it sends `Arc<T>`.
     ///
+    /// # Errors
+    /// It fails if the link is disconnected
     pub async fn send(&self, data: Arc<T>) -> ZFResult<()> {
         Ok(self.sender.send_async(data).await?)
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/mod.rs
@@ -354,7 +354,7 @@ impl DataflowInstance {
         Ok(manager.await?)
     }
 
-    /// Starts the recoding for the given source.
+    /// Starts the recording for the given source.
     ///
     /// It returns the key expression where the recording is stored.
     ///
@@ -368,7 +368,7 @@ impl DataflowInstance {
         manager.start_recording().await
     }
 
-    /// Stops the recoding for the given source.
+    /// Stops the recording for the given source.
     ///
     /// It returns the key expression where the recording is stored.
     ///
@@ -439,7 +439,7 @@ impl DataflowInstance {
         Ok(replay_id)
     }
 
-    /// Stops the recoding for the given source.
+    /// Stops the recording for the given source.
     ///
     /// # Errors
     /// If fails if the node is not found.

--- a/zenoh-flow/src/runtime/dataflow/instance/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/mod.rs
@@ -43,6 +43,10 @@ pub struct DataflowInstance {
 }
 
 /// Creates the [`Link`](`Link`) between the `nodes` using `links`.
+///
+/// # Errors
+/// An error variant is returned in case of:
+/// -  port id is duplicated.
 fn create_links(
     nodes: &[NodeId],
     links: &[LinkDescriptor],
@@ -92,6 +96,11 @@ impl DataflowInstance {
     ///
     /// This function is called by the runtime once the `Dataflow` object was
     /// created and validated.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
+    /// - connectors cannot be created
     pub fn try_instantiate(dataflow: Dataflow) -> ZFResult<Self> {
         // Gather all node ids to be able to generate (i) the links and (ii) the hash map containing
         // the runners.
@@ -260,34 +269,52 @@ impl DataflowInstance {
 
     /// Starts all the sources in this instance.
     ///
-    /// *Note:* Not implemented.
+    ///
+    /// **Note:** Not implemented.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  sources already started.
     pub async fn start_sources(&mut self) -> ZFResult<()> {
         Err(ZFError::Unimplemented)
     }
 
     /// Starts all the nodes in this instance.
     ///
-    /// *Note:* Not implemented.
+    /// **Note:** Not implemented.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  nodes already started.
     pub async fn start_nodes(&mut self) -> ZFResult<()> {
         Err(ZFError::Unimplemented)
     }
 
     /// Stops all the sources in this instance.
     ///
-    /// *Note:* Not implemented.
+    /// **Note:** Not implemented.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  sources already stopped.
     pub async fn stop_sources(&mut self) -> ZFResult<()> {
         Err(ZFError::Unimplemented)
     }
 
     /// Stops all the sources in this instance.
     ///
-    /// *Note:* Not implemented.
+    /// **Note:** Not implemented.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  nodes already stopped.
     pub async fn stop_nodes(&mut self) -> ZFResult<()> {
         Err(ZFError::Unimplemented)
     }
 
     /// Checks if the given node is running.
     ///
+    /// # Errors
     /// If fails if the node is not found.
     pub async fn is_node_running(&self, node_id: &NodeId) -> ZFResult<bool> {
         self.runners
@@ -302,6 +329,7 @@ impl DataflowInstance {
 
     /// Starts the given node.
     ///
+    /// # Errors
     /// If fails if the node is not found.
     pub async fn start_node(&mut self, node_id: &NodeId) -> ZFResult<()> {
         let runner = self
@@ -315,6 +343,7 @@ impl DataflowInstance {
 
     /// Stops the given node.
     ///
+    /// # Errors
     /// If fails if the node is not found or it is not running.
     pub async fn stop_node(&mut self, node_id: &NodeId) -> ZFResult<()> {
         let manager = self
@@ -329,6 +358,7 @@ impl DataflowInstance {
     ///
     /// It returns the key expression where the recording is stored.
     ///
+    /// # Errors
     /// If fails if the node is not found.
     pub async fn start_recording(&self, node_id: &NodeId) -> ZFResult<String> {
         let manager = self
@@ -342,6 +372,7 @@ impl DataflowInstance {
     ///
     /// It returns the key expression where the recording is stored.
     ///
+    /// # Errors
     /// If fails if the node is not found.
     pub async fn stop_recording(&self, node_id: &NodeId) -> ZFResult<String> {
         let manager = self
@@ -356,6 +387,12 @@ impl DataflowInstance {
     /// is not running prior to call this function.
     /// If someone is using directly the DataflowInstance need to stop and check
     /// if the node is running before calling this function.
+    ///
+    /// # Errors
+    /// It fails if:
+    /// - the source is not stopped
+    /// - the node is not a source
+    /// - the key expression is not point to a recording
     pub async fn start_replay(&mut self, source_id: &NodeId, resource: String) -> ZFResult<NodeId> {
         let runner = self
             .runners
@@ -404,6 +441,7 @@ impl DataflowInstance {
 
     /// Stops the recoding for the given source.
     ///
+    /// # Errors
     /// If fails if the node is not found.
     pub async fn stop_replay(&mut self, replay_id: &NodeId) -> ZFResult<()> {
         self.stop_node(replay_id).await?;

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use futures::prelude::*;
 use zenoh::publication::CongestionControl;
 
-/// The `ZenohSender` is the connector that send the data to Zenoh
+/// The `ZenohSender` is the connector that sends the data to Zenoh
 /// when nodes are running on different runtimes.
 #[derive(Clone)]
 pub struct ZenohSender {
@@ -41,7 +41,8 @@ impl ZenohSender {
     /// Creates a new `ZenohSender` with the given parameters.
     ///
     /// # Errors
-    /// An error variant is returned if the link is wrong.
+    /// An error variant is returned if the link is not supposed to be
+    /// connected to this node.
     pub fn try_new(
         context: InstanceContext,
         record: ZFConnectorRecord,
@@ -209,7 +210,8 @@ impl ZenohReceiver {
     /// Creates a new `ZenohReceiver` with the given parametes.
     ///
     /// # Errors
-    /// An error variant is returned if the link is wrong.
+    /// An error variant is returned if the link is not supposed to be
+    /// connected to this node.
     pub fn try_new(
         context: InstanceContext,
         record: ZFConnectorRecord,

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -26,6 +26,8 @@ use async_trait::async_trait;
 use futures::prelude::*;
 use zenoh::publication::CongestionControl;
 
+/// The `ZenohSender` is the connector that send the data to Zenoh
+/// when nodes are running on different runtimes.
 #[derive(Clone)]
 pub struct ZenohSender {
     pub(crate) id: NodeId,
@@ -36,6 +38,8 @@ pub struct ZenohSender {
 }
 
 impl ZenohSender {
+    /// Creates a new `ZenohSender` with the given parameters.
+    ///
     pub fn try_new(
         context: InstanceContext,
         record: ZFConnectorRecord,
@@ -59,10 +63,12 @@ impl ZenohSender {
         })
     }
 
+    /// Starts the the sender.
     async fn start(&self) {
         *self.is_running.lock().await = true;
     }
 
+    /// A single sender iteration
     async fn iteration(&self) -> ZFResult<()> {
         log::debug!("ZenohSender - {} - Started", self.record.resource);
         if let Some(link) = &*self.link.lock().await {
@@ -180,6 +186,8 @@ impl Runner for ZenohSender {
     }
 }
 
+/// A `ZenohReceiver` receives the messages from Zenoh when nodes are running
+/// on different runtimes.
 #[derive(Clone)]
 pub struct ZenohReceiver {
     pub(crate) id: NodeId,
@@ -190,6 +198,7 @@ pub struct ZenohReceiver {
 }
 
 impl ZenohReceiver {
+    /// Creates a new `ZenohReceiver` with the given parametes.
     pub fn try_new(
         context: InstanceContext,
         record: ZFConnectorRecord,
@@ -224,6 +233,7 @@ impl ZenohReceiver {
         })
     }
 
+    /// Starts the receiver.
     async fn start(&self) {
         *self.is_running.lock().await = true;
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -40,6 +40,8 @@ pub struct ZenohSender {
 impl ZenohSender {
     /// Creates a new `ZenohSender` with the given parameters.
     ///
+    /// # Errors
+    /// An error variant is returned if the link is wrong.
     pub fn try_new(
         context: InstanceContext,
         record: ZFConnectorRecord,
@@ -69,6 +71,12 @@ impl ZenohSender {
     }
 
     /// A single sender iteration
+    ///
+    /// # Errors
+    /// An error variant is returned if:
+    /// - serialization fails
+    /// - zenoh put fails
+    /// - link recv fails
     async fn iteration(&self) -> ZFResult<()> {
         log::debug!("ZenohSender - {} - Started", self.record.resource);
         if let Some(link) = &*self.link.lock().await {
@@ -199,6 +207,9 @@ pub struct ZenohReceiver {
 
 impl ZenohReceiver {
     /// Creates a new `ZenohReceiver` with the given parametes.
+    ///
+    /// # Errors
+    /// An error variant is returned if the link is wrong.
     pub fn try_new(
         context: InstanceContext,
         record: ZFConnectorRecord,

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -78,6 +78,7 @@ impl OperatorIO {
 
     /// Tries to add the given `LinkReceiver<Message>`
     ///
+    /// # Errors
     /// It fails if the `PortId` is duplicated.
     pub fn try_add_input(&mut self, rx: LinkReceiver<Message>) -> ZFResult<()> {
         if self.inputs.contains_key(&rx.id()) {
@@ -144,6 +145,7 @@ impl OperatorRunner {
     /// [`InstanceContext`](`InstanceContext`), [`OperatorLoaded`](`OperatorLoaded`)
     /// and [`OperatorIO`](`OperatorIO`).
     ///
+    /// # Errors
     /// If fails if the output is not connected.
     pub fn try_new(
         context: InstanceContext,
@@ -173,6 +175,13 @@ impl OperatorRunner {
     }
 
     /// A single iteration of the run loop.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  user returns an error
+    /// - link recv fails
+    /// - link send fails
+    ///
     async fn iteration(
         &self,
         mut context: Context,

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/operator.rs
@@ -37,12 +37,15 @@ use libloading::os::unix::Library;
 #[cfg(target_family = "windows")]
 use libloading::Library;
 
+/// A struct that wraps the inputs and outputs
+/// of a node.
 #[derive(Default)]
 pub struct OperatorIO {
     inputs: HashMap<PortId, LinkReceiver<Message>>,
     outputs: HashMap<PortId, Vec<LinkSender<Message>>>,
 }
 
+/// Future of the `Receiver`
 type LinkRecvFut<'a> = std::pin::Pin<
     Box<dyn Future<Output = Result<(Arc<str>, Arc<Message>), ZFError>> + Send + Sync + 'a>,
 >;
@@ -59,10 +62,13 @@ impl OperatorIO {
     }
 }
 
+/// Type of Inputs
 pub type InputsLink = HashMap<PortId, LinkReceiver<Message>>;
+/// Type of Outputs
 pub type OutputsLinks = HashMap<PortId, Vec<LinkSender<Message>>>;
 
 impl OperatorIO {
+    /// Creates the `OperatorIO` from an [`OperatorRecord`](`OperatorRecord`)
     pub fn new(record: &OperatorRecord) -> Self {
         Self {
             inputs: HashMap::with_capacity(record.inputs.len()),
@@ -70,6 +76,9 @@ impl OperatorIO {
         }
     }
 
+    /// Tries to add the given `LinkReceiver<Message>`
+    ///
+    /// It fails if the `PortId` is duplicated.
     pub fn try_add_input(&mut self, rx: LinkReceiver<Message>) -> ZFResult<()> {
         if self.inputs.contains_key(&rx.id()) {
             return Err(ZFError::DuplicatedPort((rx.id(), rx.id())));
@@ -80,6 +89,7 @@ impl OperatorIO {
         Ok(())
     }
 
+    /// Adds the given `LinkSender<Message>`
     pub fn add_output(&mut self, tx: LinkSender<Message>) {
         if let Some(vec_senders) = self.outputs.get_mut(&tx.id()) {
             vec_senders.push(tx);
@@ -88,24 +98,30 @@ impl OperatorIO {
         }
     }
 
+    /// Destroys and returns a tuple with the internal inputs and outputs.
     pub fn take(self) -> (InputsLink, OutputsLinks) {
         (self.inputs, self.outputs)
     }
 
+    /// Returns a copy of the inputs.
     pub fn get_inputs(&self) -> InputsLink {
         self.inputs.clone()
     }
 
+    /// Returns a copy of the outputs.
     pub fn get_outputs(&self) -> OutputsLinks {
         self.outputs.clone()
     }
 }
 
-// Do not reorder the fields in this struct.
-// Rust drops fields in a struct in the same order they are declared.
-// Ref: https://doc.rust-lang.org/reference/destructors.html
-// We need the state to be dropped before the operator/lib, otherwise we
-// will have a SIGSEV.
+/// The `OperatorRunner` is the component in charge of executing the operator.
+/// It contains all the runtime information for the operator, the graph instance.
+///
+/// Do not reorder the fields in this struct.
+/// Rust drops fields in a struct in the same order they are declared.
+/// Ref: <https://doc.rust-lang.org/reference/destructors.html>
+/// We need the state to be dropped before the operator/lib, otherwise we
+/// will have a SIGSEV.
 #[derive(Clone)]
 pub struct OperatorRunner {
     pub(crate) id: NodeId,
@@ -124,6 +140,11 @@ pub struct OperatorRunner {
 }
 
 impl OperatorRunner {
+    /// Tries to create a new `OperatorRunner` using the given
+    /// [`InstanceContext`](`InstanceContext`), [`OperatorLoaded`](`OperatorLoaded`)
+    /// and [`OperatorIO`](`OperatorIO`).
+    ///
+    /// If fails if the output is not connected.
     pub fn try_new(
         context: InstanceContext,
         operator: OperatorLoaded,
@@ -146,10 +167,12 @@ impl OperatorRunner {
         })
     }
 
+    /// Starts the operator.
     async fn start(&self) {
         *self.is_running.lock().await = true;
     }
 
+    /// A single iteration of the run loop.
     async fn iteration(
         &self,
         mut context: Context,

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/replay.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/replay.rs
@@ -25,6 +25,7 @@ use std::collections::HashMap;
 use zenoh::query::*;
 use zenoh::*;
 
+/// The Replay node.
 #[derive(Clone)]
 pub struct ZenohReplay {
     pub(crate) id: NodeId,
@@ -38,6 +39,10 @@ pub struct ZenohReplay {
 }
 
 impl ZenohReplay {
+    /// Tries to create a replay node, that will replay from the given
+    /// `resource_name`.
+    ///
+    /// It fails if the ports are not connected correctly.
     pub fn try_new(
         id: NodeId,
         context: InstanceContext,
@@ -68,6 +73,9 @@ impl ZenohReplay {
         })
     }
 
+    /// Sends a data to the link.
+    ///
+    /// This is the replay.
     async fn send_data(&self, msg: Message) -> ZFResult<()> {
         log::trace!("ZenohReplay {} - {} - SendData ", self.id, self.node_id);
         let links = self.links.lock().await;
@@ -78,6 +86,8 @@ impl ZenohReplay {
         }
         Ok(())
     }
+
+    /// Starts the replay.
     async fn start(&self) {
         *self.is_running.lock().await = true;
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/replay.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/replay.rs
@@ -42,6 +42,7 @@ impl ZenohReplay {
     /// Tries to create a replay node, that will replay from the given
     /// `resource_name`.
     ///
+    /// # Errors
     /// It fails if the ports are not connected correctly.
     pub fn try_new(
         id: NodeId,
@@ -76,6 +77,10 @@ impl ZenohReplay {
     /// Sends a data to the link.
     ///
     /// This is the replay.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  link send fails
     async fn send_data(&self, msg: Message) -> ZFResult<()> {
         log::trace!("ZenohReplay {} - {} - SendData ", self.id, self.node_id);
         let links = self.links.lock().await;

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/sink.rs
@@ -58,6 +58,7 @@ impl SinkRunner {
     /// [`InstanceContext`](`InstanceContext`), [`SinkLoaded`](`SinkLoaded`)
     /// and [`OperatorIO`](`OperatorIO`).
     ///
+    /// # Errors
     /// If fails if the input is not connected.
     pub fn try_new(context: InstanceContext, sink: SinkLoaded, io: OperatorIO) -> ZFResult<Self> {
         let (mut inputs, _) = io.take();
@@ -88,6 +89,12 @@ impl SinkRunner {
     }
 
     /// A single iteration of the run loop.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  user returns an error
+    /// - link recv fails
+    ///
     async fn iteration(&self, mut context: Context) -> ZFResult<Context> {
         // Guards are taken at the beginning of each iteration to allow interleaving.
         if let Some(link) = &*self.link.lock().await {

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -66,6 +66,7 @@ impl SourceRunner {
     /// [`InstanceContext`](`InstanceContext`), [`SourceLoaded`](`SourceLoaded`)
     /// and [`OperatorIO`](`OperatorIO`).
     ///
+    /// # Errors
     /// If fails if the output is not connected.
     pub fn try_new(
         context: InstanceContext,
@@ -104,6 +105,11 @@ impl SourceRunner {
     }
 
     /// Records the given `message`.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - unable to put on zenoh
+    /// - serialization fails
     async fn record(&self, message: Arc<Message>) -> ZFResult<()> {
         log::debug!("ZenohLogger IN <= {:?} ", message);
         let recording = self.is_recording.lock().await;
@@ -132,6 +138,12 @@ impl SourceRunner {
     }
 
     /// A single iteration of the run loop.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - user returns an error
+    /// - record fails
+    /// - link send fails
     async fn iteration(&self, mut context: Context) -> ZFResult<Context> {
         let links = self.links.lock().await;
         let mut state = self.state.lock().await;

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/source.rs
@@ -36,11 +36,14 @@ use libloading::os::unix::Library;
 #[cfg(target_family = "windows")]
 use libloading::Library;
 
-// Do not reorder the fields in this struct.
-// Rust drops fields in a struct in the same order they are declared.
-// Ref: https://doc.rust-lang.org/reference/destructors.html
-// We need the state to be dropped before the source/lib, otherwise we
-// will have a SIGSEV.
+/// The `SourceRunner` is the component in charge of executing the source.
+/// It contains all the runtime information for the source, the graph instance.
+///
+/// Do not reorder the fields in this struct.
+/// Rust drops fields in a struct in the same order they are declared.
+/// Ref: <https://doc.rust-lang.org/reference/destructors.html>
+/// We need the state to be dropped before the source/lib, otherwise we
+/// will have a SIGSEV.
 #[derive(Clone)]
 pub struct SourceRunner {
     pub(crate) id: NodeId,
@@ -59,6 +62,11 @@ pub struct SourceRunner {
 }
 
 impl SourceRunner {
+    /// Tries to create a new `SourceRunner` using the given
+    /// [`InstanceContext`](`InstanceContext`), [`SourceLoaded`](`SourceLoaded`)
+    /// and [`OperatorIO`](`OperatorIO`).
+    ///
+    /// If fails if the output is not connected.
     pub fn try_new(
         context: InstanceContext,
         source: SourceLoaded,
@@ -95,6 +103,7 @@ impl SourceRunner {
         })
     }
 
+    /// Records the given `message`.
     async fn record(&self, message: Arc<Message>) -> ZFResult<()> {
         log::debug!("ZenohLogger IN <= {:?} ", message);
         let recording = self.is_recording.lock().await;
@@ -122,6 +131,7 @@ impl SourceRunner {
         Ok(())
     }
 
+    /// A single iteration of the run loop.
     async fn iteration(&self, mut context: Context) -> ZFResult<Context> {
         let links = self.links.lock().await;
         let mut state = self.state.lock().await;
@@ -154,6 +164,7 @@ impl SourceRunner {
         Ok(context)
     }
 
+    /// Starts the source.
     async fn start(&self) {
         *self.is_running.lock().await = true;
     }

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/tests/source_periodic_test.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/tests/source_periodic_test.rs
@@ -29,8 +29,8 @@ use async_trait::async_trait;
 use std::time::{Duration, Instant};
 use zenoh::prelude::*;
 
-// Using 5ms as default delta, this has proven to be effective on my MacBook.
-static DEFAULT_DELTA_MS: u64 = 5;
+// Using 10ms as default delta, this has proven to be effective on my MacBook.
+static DEFAULT_DELTA_MS: u64 = 10;
 
 // Using 1s as default period.
 static DEFAULT_PERIOD_S: u64 = 1;

--- a/zenoh-flow/src/runtime/dataflow/loader.rs
+++ b/zenoh-flow/src/runtime/dataflow/loader.rs
@@ -30,11 +30,15 @@ use url::Url;
 static LOAD_FLAGS: std::os::raw::c_int =
     libloading::os::unix::RTLD_NOW | libloading::os::unix::RTLD_LOCAL;
 
-/// Constant used to for version check when loading nodes, Zenoh Flow version,
-/// as API changes across versions.
+/// Constant used to check if a node is compatible with the currently
+/// running Zenoh Flow daemon.
+/// As nodes are dynamically loaded, this is to prevent (possibly cryptic)
+///  runtime error due to incompatible API.
 pub static CORE_VERSION: &str = env!("CARGO_PKG_VERSION");
-/// Constant used to for version check when loading nodes,
-/// rust compiler version, as ABI is not stable.
+/// Constant used to check if a node was compiled with the same version of
+/// the Rust compiler than the currently running Zenoh Flow daemon.
+/// As Rust is not ABI stable,
+/// this is to prevent (possibly cryptic) runtime errors.
 pub static RUSTC_VERSION: &str = env!("RUSTC_VERSION");
 
 // OPERATOR
@@ -85,7 +89,7 @@ pub struct SinkDeclaration {
 }
 
 /// Extensible support for different implementations
-/// This represent the configuration for an extention.
+/// This represents the configuration for an extension.
 ///
 ///
 /// Example:
@@ -108,7 +112,7 @@ pub struct ExtensibleImplementation {
     pub(crate) config_lib_key: String,
 }
 
-/// Loader configuration files, it includes the extentions.
+/// Loader configuration files, it includes the extensions.
 ///
 /// Example:
 ///
@@ -128,8 +132,8 @@ pub struct LoaderConfig {
 }
 
 /// The dynamic library loader.
-/// Before loading it verifies if the version are compatible and if the symbols
-/// are presents.
+/// Before loading it verifies if the versions are compatible
+/// and if the symbols are presents.
 /// It loads the files in different way depending on the operating system.
 /// In particular the scope of the symbols is different between Unix and
 /// Windows.
@@ -144,7 +148,7 @@ pub struct Loader {
 }
 
 impl Loader {
-    /// Creates a new `Loaded` with the given `config`.
+    /// Creates a new `Loader` with the given `config`.
     pub fn new(config: LoaderConfig) -> Self {
         Self { config }
     }
@@ -154,8 +158,8 @@ impl Loader {
     ///
     /// # Errors
     /// It can fail because of:
-    /// - different version of zenoh flow used to build the operator
-    /// - different verion of rust compiler used to build the operator
+    /// - different versions of zenoh flow used to build the operator
+    /// - different versions of rust compiler used to build the operator
     /// - the library does not contain the symbols.
     /// - the URI is missing
     /// - the URI scheme is not known ( so far only `file://` is known).
@@ -198,8 +202,8 @@ impl Loader {
     ///
     /// # Errors
     /// It can fail because of:
-    /// - different version of zenoh flow used to build the source
-    /// - different verion of rust compiler used to build the source
+    /// - different versions of zenoh flow used to build the source
+    /// - different versions of rust compiler used to build the source
     /// - the library does not contain the symbols.
     /// - the URI is missing
     /// - the URI scheme is not known ( so far only `file://` is known).
@@ -241,8 +245,8 @@ impl Loader {
     ///
     /// # Errors
     /// It can fail because of:
-    /// - different version of zenoh flow used to build the sink
-    /// - different verion of rust compiler used to build the sink
+    /// - different versions of zenoh flow used to build the sink
+    /// - different versions of rust compiler used to build the sink
     /// - the library does not contain the symbols.
     /// - the URI is missing
     /// - the URI scheme is not known ( so far only `file://` is known).
@@ -403,8 +407,8 @@ impl Loader {
     /// # Errors
     /// This function can fail:
     /// - the extension is not known
-    /// - different version of zenoh flow used to build the extension
-    /// - different verion of rust compiler used to build the extension
+    /// - different versions of zenoh flow used to build the extension
+    /// - different versions of rust compiler used to build the extension
     /// - the extension library does not contain the symbols.
     /// - the URI is missing
     /// - the URI scheme is not known ( so far only `file://` is known).
@@ -443,14 +447,14 @@ impl Loader {
         }
     }
 
-    /// Loads an source that is not a dynamic library.
+    /// Loads a source that is not a dynamic library.
     /// Using one of the extension configured within the loader.
     ///
     /// # Errors
     /// This function can fail:
     /// - the extension is not known
-    /// - different version of zenoh flow used to build the extension
-    /// - different verion of rust compiler used to build the extension
+    /// - different versions of zenoh flow used to build the extension
+    /// - different versions of rust compiler used to build the extension
     /// - the extension library does not contain the symbols.
     /// - the URI is missing
     /// - the URI scheme is not known ( so far only `file://` is known).
@@ -489,14 +493,14 @@ impl Loader {
         }
     }
 
-    /// Loads an sink that is not a dynamic library.
+    /// Loads a sink that is not a dynamic library.
     /// Using one of the extension configured within the loader.
     ///
     /// # Errors
     /// This function can fail:
     /// - the extension is not known
-    /// - different version of zenoh flow used to build the extension
-    /// - different verion of rust compiler used to build the extension
+    /// - different versions of zenoh flow used to build the extension
+    /// - different versions of rust compiler used to build the extension
     /// - the extension library does not contain the symbols.
     /// - the URI is missing
     /// - the URI scheme is not known ( so far only `file://` is known).

--- a/zenoh-flow/src/runtime/dataflow/loader.rs
+++ b/zenoh-flow/src/runtime/dataflow/loader.rs
@@ -39,6 +39,10 @@ pub static RUSTC_VERSION: &str = env!("RUSTC_VERSION");
 
 // OPERATOR
 /// Operator register function signature
+///
+/// # Errors
+/// An error variant is returned in case of:
+/// -  user wants to return an error.
 pub type OperatorRegisterFn = fn() -> ZFResult<Arc<dyn Operator>>;
 
 /// Operator declaration expected in the library that will be loaded.
@@ -51,6 +55,10 @@ pub struct OperatorDeclaration {
 // SOURCE
 
 /// Source register function signature.
+///
+/// # Errors
+/// An error variant is returned in case of:
+/// -  user wants to return an error.
 pub type SourceRegisterFn = fn() -> ZFResult<Arc<dyn Source>>;
 
 /// Source declaration expected in the library that will be loaded.
@@ -63,6 +71,10 @@ pub struct SourceDeclaration {
 // SINK
 
 /// Sink register function signature.
+///
+/// # Errors
+/// An error variant is returned in case of:
+/// -  user wants to return an error.
 pub type SinkRegisterFn = fn() -> ZFResult<Arc<dyn Sink>>;
 
 /// Sink declaration expected in the library that will be loaded.
@@ -140,8 +152,8 @@ impl Loader {
     /// Tries to load an operator from the information passed within
     /// the [`OperatorRecord`](`OperatorRecord`).
     ///
+    /// # Errors
     /// It can fail because of:
-    ///
     /// - different version of zenoh flow used to build the operator
     /// - different verion of rust compiler used to build the operator
     /// - the library does not contain the symbols.
@@ -183,8 +195,9 @@ impl Loader {
     /// Tries to load a source from the information passed within
     /// the [`SourceRecord`](`SourceRecord`).
     ///
-    /// It can fail because of:
     ///
+    /// # Errors
+    /// It can fail because of:
     /// - different version of zenoh flow used to build the source
     /// - different verion of rust compiler used to build the source
     /// - the library does not contain the symbols.
@@ -226,8 +239,8 @@ impl Loader {
     /// Tries to load a sink from the information passed within
     /// the [`SinkRecord`](`SinkRecord`).
     ///
+    /// # Errors
     /// It can fail because of:
-    ///
     /// - different version of zenoh flow used to build the sink
     /// - different verion of rust compiler used to build the sink
     /// - the library does not contain the symbols.
@@ -269,10 +282,11 @@ impl Loader {
     /// Load the library of the operator.
     ///
     /// # Safety
+    /// - dynamic loading of library and lookup of symbols.
     ///
+    /// # Errors
     /// This function dynamically loads an external library, things can go wrong:
     /// - it fails if the symbol `zfoperator_declaration` is not found,
-    /// - be sure to *trust* the code you are loading.
     unsafe fn load_lib_operator(path: PathBuf) -> ZFResult<(Library, Arc<dyn Operator>)> {
         log::debug!("Operator Loading {:#?}", path);
 
@@ -297,10 +311,11 @@ impl Loader {
     /// Load the library of a source.
     ///
     /// # Safety
+    /// - dynamic loading of library, and lookup of symbols.
     ///
+    /// # Errors
     /// This function dynamically loads an external library, things can go wrong:
     /// - it fails if the symbol `zfsource_declaration` is not found,
-    /// - be sure to *trust* the code you are loading.
     unsafe fn load_lib_source(path: PathBuf) -> ZFResult<(Library, Arc<dyn Source>)> {
         log::debug!("Source Loading {:#?}", path);
 
@@ -325,10 +340,12 @@ impl Loader {
     /// Load the library of a sink.
     ///
     /// # Safety
+    /// - dynamic loading of library, and lookup of symbols.
     ///
+    /// # Errors
     /// This function dynamically loads an external library, things can go wrong:
     /// - it fails if the symbol `zfsink_declaration` is not found,
-    /// - be sure to *trust* the code you are loading.
+    ///
     unsafe fn load_lib_sink(path: PathBuf) -> ZFResult<(Library, Arc<dyn Sink>)> {
         log::debug!("Sink Loading {:#?}", path);
 
@@ -370,7 +387,7 @@ impl Loader {
         false
     }
 
-    /// Returns the file extension.
+    /// Returns the file extension, if any.
     fn get_file_extension(file: &Path) -> Option<String> {
         if let Some(ext) = file.extension() {
             if let Some(ext) = ext.to_str() {
@@ -383,6 +400,7 @@ impl Loader {
     /// Loads an operator that is not a dynamic library.
     /// Using one of the extension configured within the loader.
     ///
+    /// # Errors
     /// This function can fail:
     /// - the extension is not known
     /// - different version of zenoh flow used to build the extension
@@ -428,6 +446,7 @@ impl Loader {
     /// Loads an source that is not a dynamic library.
     /// Using one of the extension configured within the loader.
     ///
+    /// # Errors
     /// This function can fail:
     /// - the extension is not known
     /// - different version of zenoh flow used to build the extension
@@ -473,6 +492,7 @@ impl Loader {
     /// Loads an sink that is not a dynamic library.
     /// Using one of the extension configured within the loader.
     ///
+    /// # Errors
     /// This function can fail:
     /// - the extension is not known
     /// - different version of zenoh flow used to build the extension
@@ -516,6 +536,10 @@ impl Loader {
     }
 
     /// Wraps the configuration in case of an extension.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// -  unable to parse the file path
     fn generate_wrapper_config(
         configuration: Option<Configuration>,
         config_key: String,

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -35,6 +35,12 @@ use crate::{
     ZFResult,
 };
 
+/// The data flow struct.
+/// This struct contains all the information needed to instantiate a data flow.
+/// running withing a Zenoh Flow runtime.
+/// It stores a `RuntimeContext` all the loaded nodes, the connectors.
+/// It also contains a `DataflowValidator` that is used to verify that the
+/// data flow can be instantiated.
 pub struct Dataflow {
     pub(crate) uuid: Uuid,
     pub(crate) flow_id: FlowId,
@@ -74,6 +80,13 @@ impl Dataflow {
         }
     }
 
+    /// Creates a new `Dataflow` departing from
+    /// an existing [`DataFlowRecord`](`DataFlowRecord`)
+    ///
+    /// This function is called by the runtime when instantiating
+    /// a dynamically loaded graph.
+    /// It loads the nodes using the loader stored in
+    /// the [`RuntimeContext`](`RuntimeContext`).
     pub fn try_new(context: RuntimeContext, record: DataFlowRecord) -> ZFResult<Self> {
         let loaded_sources = record
             .sources
@@ -136,6 +149,11 @@ impl Dataflow {
         Ok(dataflow)
     }
 
+    /// Tries to add a static source to the data flow.
+    ///
+    /// If the validation fails the source cannot be added.
+    /// This is mean to be used when creating an empty dataflow using
+    /// `Dataflow::new(..)` function.
     pub fn try_add_static_source(
         &mut self,
         id: NodeId,
@@ -162,6 +180,11 @@ impl Dataflow {
         Ok(())
     }
 
+    /// Tries to add a static operator to the data flow.
+    ///
+    /// If the validation fails the operator cannot be added.
+    /// This is mean to be used when creating an empty dataflow using
+    /// `Dataflow::new(..)` function.
     pub fn try_add_static_operator(
         &mut self,
         id: NodeId,
@@ -201,6 +224,11 @@ impl Dataflow {
         Ok(())
     }
 
+    /// Tries to add a static sink to the data flow.
+    ///
+    /// If the validation fails the sink cannot be added.
+    /// This is mean to be used when creating an empty dataflow using
+    /// `Dataflow::new(..)` function.
     pub fn try_add_static_sink(
         &mut self,
         id: NodeId,
@@ -253,6 +281,9 @@ impl Dataflow {
         Ok(())
     }
 
+    /// Tries to add a deadline within the dataflow
+    ///
+    /// If the validation fails the deadline cannot be added.
     pub fn try_add_deadline(
         &mut self,
         from: OutputDescriptor,
@@ -266,6 +297,7 @@ impl Dataflow {
         Ok(())
     }
 
+    /// Adds a deadline within the dataflow.
     fn add_end_to_end_deadline(&mut self, deadline: E2EDeadlineRecord) {
         // Look for the "from" node in either Sources and Operators.
         if let Some(source) = self.sources.get_mut(&deadline.from.node) {
@@ -286,6 +318,9 @@ impl Dataflow {
         }
     }
 
+    /// Tries to add a loop within the dataflow
+    ///
+    /// If the validation fails the loop cannot be added.
     pub fn try_add_loop(
         &mut self,
         ingress: NodeId,

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -37,8 +37,8 @@ use crate::{
 
 /// The data flow struct.
 /// This struct contains all the information needed to instantiate a data flow.
-/// running withing a Zenoh Flow runtime.
-/// It stores a `RuntimeContext` all the loaded nodes, the connectors.
+/// running within a Zenoh Flow runtime.
+/// It stores in a `RuntimeContext` all the loaded nodes and the connectors.
 /// It also contains a `DataflowValidator` that is used to verify that the
 /// data flow can be instantiated.
 pub struct Dataflow {
@@ -156,7 +156,7 @@ impl Dataflow {
     /// Tries to add a static source to the data flow.
     ///
     /// If the validation fails the source cannot be added.
-    /// This is mean to be used when creating an empty dataflow using
+    /// This is meant to be used when creating an empty data flow using
     /// `Dataflow::new(..)` function.
     ///
     /// # Errors
@@ -191,7 +191,7 @@ impl Dataflow {
     /// Tries to add a static operator to the data flow.
     ///
     /// If the validation fails the operator cannot be added.
-    /// This is mean to be used when creating an empty dataflow using
+    /// This is meant to be used when creating an empty data flow using
     /// `Dataflow::new(..)` function.
     ///
     /// # Errors
@@ -239,7 +239,7 @@ impl Dataflow {
     /// Tries to add a static sink to the data flow.
     ///
     /// If the validation fails the sink cannot be added.
-    /// This is mean to be used when creating an empty dataflow using
+    /// This is meant to be used when creating an empty data flow using
     /// `Dataflow::new(..)` function.
     ///
     /// # Errors

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -87,6 +87,10 @@ impl Dataflow {
     /// a dynamically loaded graph.
     /// It loads the nodes using the loader stored in
     /// the [`RuntimeContext`](`RuntimeContext`).
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - fails to load nodes
     pub fn try_new(context: RuntimeContext, record: DataFlowRecord) -> ZFResult<Self> {
         let loaded_sources = record
             .sources
@@ -154,6 +158,10 @@ impl Dataflow {
     /// If the validation fails the source cannot be added.
     /// This is mean to be used when creating an empty dataflow using
     /// `Dataflow::new(..)` function.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
     pub fn try_add_static_source(
         &mut self,
         id: NodeId,
@@ -185,6 +193,10 @@ impl Dataflow {
     /// If the validation fails the operator cannot be added.
     /// This is mean to be used when creating an empty dataflow using
     /// `Dataflow::new(..)` function.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
     pub fn try_add_static_operator(
         &mut self,
         id: NodeId,
@@ -229,6 +241,10 @@ impl Dataflow {
     /// If the validation fails the sink cannot be added.
     /// This is mean to be used when creating an empty dataflow using
     /// `Dataflow::new(..)` function.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
     pub fn try_add_static_sink(
         &mut self,
         id: NodeId,
@@ -260,6 +276,10 @@ impl Dataflow {
     /// This function will return error if the nodes that are to be linked where not previously
     /// added to the Dataflow **or** if the types of the ports (declared in the nodes) are not
     /// identical.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
     pub fn try_add_link(
         &mut self,
         from: OutputDescriptor,
@@ -284,6 +304,10 @@ impl Dataflow {
     /// Tries to add a deadline within the dataflow
     ///
     /// If the validation fails the deadline cannot be added.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
     pub fn try_add_deadline(
         &mut self,
         from: OutputDescriptor,
@@ -321,6 +345,10 @@ impl Dataflow {
     /// Tries to add a loop within the dataflow
     ///
     /// If the validation fails the loop cannot be added.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - validation fails
     pub fn try_add_loop(
         &mut self,
         ingress: NodeId,

--- a/zenoh-flow/src/runtime/dataflow/node.rs
+++ b/zenoh-flow/src/runtime/dataflow/node.rs
@@ -43,6 +43,10 @@ impl SourceLoaded {
     /// Creates and initialzes a `Source`.
     /// The state is stored within the `SourceLoaded` in order to be used
     /// when calling the Source's callbacks.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - fails to initialize
     pub fn try_new(
         record: SourceRecord,
         lib: Option<Arc<Library>>,
@@ -81,6 +85,10 @@ impl OperatorLoaded {
     /// Creates and initialzes an `Operator`.
     /// The state is stored within the `OperatorLoaded` in order to be used
     /// when calling the Operators's callbacks.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - fails to initialize
     pub fn try_new(
         record: OperatorRecord,
         lib: Option<Arc<Library>>,
@@ -130,6 +138,10 @@ impl SinkLoaded {
     /// Creates and initialzes a `Sink`.
     /// The state is stored within the `SinkLoaded` in order to be used
     /// when calling the Sink's callbacks.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - fails to initialize
     pub fn try_new(
         record: SinkRecord,
         lib: Option<Arc<Library>>,

--- a/zenoh-flow/src/runtime/dataflow/node.rs
+++ b/zenoh-flow/src/runtime/dataflow/node.rs
@@ -26,6 +26,9 @@ use libloading::os::unix::Library;
 #[cfg(target_family = "windows")]
 use libloading::Library;
 
+/// A Source that was loaded, either dynamically or statically.
+/// When a source is loaded it is first initialized and then can be ran.
+/// This struct is then used within a `Runner` to actually run the source.
 pub struct SourceLoaded {
     pub(crate) id: NodeId,
     pub(crate) output: PortDescriptor,
@@ -37,6 +40,9 @@ pub struct SourceLoaded {
 }
 
 impl SourceLoaded {
+    /// Creates and initialzes a `Source`.
+    /// The state is stored within the `SourceLoaded` in order to be used
+    /// when calling the Source's callbacks.
     pub fn try_new(
         record: SourceRecord,
         lib: Option<Arc<Library>>,
@@ -56,6 +62,9 @@ impl SourceLoaded {
     }
 }
 
+/// An Operator that was loaded, either dynamically or statically.
+/// When a operator is loaded it is first initialized and then can be ran.
+/// This struct is then used within a `Runner` to actually run the operator.
 pub struct OperatorLoaded {
     pub(crate) id: NodeId,
     pub(crate) inputs: HashMap<PortId, PortType>,
@@ -69,6 +78,9 @@ pub struct OperatorLoaded {
 }
 
 impl OperatorLoaded {
+    /// Creates and initialzes an `Operator`.
+    /// The state is stored within the `OperatorLoaded` in order to be used
+    /// when calling the Operators's callbacks.
     pub fn try_new(
         record: OperatorRecord,
         lib: Option<Arc<Library>>,
@@ -102,6 +114,9 @@ impl OperatorLoaded {
     }
 }
 
+/// A Sink that was loaded, either dynamically or statically.
+/// When a sink is loaded it is first initialized and then can be ran.
+/// This struct is then used within a `Runner` to actually run the sink.
 pub struct SinkLoaded {
     pub(crate) id: NodeId,
     pub(crate) input: PortDescriptor,
@@ -112,6 +127,9 @@ pub struct SinkLoaded {
 }
 
 impl SinkLoaded {
+    /// Creates and initialzes a `Sink`.
+    /// The state is stored within the `SinkLoaded` in order to be used
+    /// when calling the Sink's callbacks.
     pub fn try_new(
         record: SinkRecord,
         lib: Option<Arc<Library>>,

--- a/zenoh-flow/src/runtime/deadline.rs
+++ b/zenoh-flow/src/runtime/deadline.rs
@@ -31,6 +31,8 @@ pub struct LocalDeadlineMiss {
     pub elapsed: Duration,
 }
 
+/// A End to End Deadline.
+/// A deadline can apply for a whole graph or for a subpart of it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct E2EDeadlineMiss {
     pub duration: Duration,
@@ -41,6 +43,9 @@ pub struct E2EDeadlineMiss {
 }
 
 impl E2EDeadlineMiss {
+    /// Creates a new `E2EDeadlineMiss` from an [`E2EDeadline`](`E2EDeadline`)
+    /// and a [`Timestamp`](`Timestamp`).
+    ///
     pub fn new(deadline: &E2EDeadline, end: &Timestamp) -> Self {
         Self {
             duration: deadline.duration,

--- a/zenoh-flow/src/runtime/loops.rs
+++ b/zenoh-flow/src/runtime/loops.rs
@@ -36,6 +36,7 @@ pub struct LoopContext {
     pub(crate) duration_last_iteration: Option<Duration>,
 }
 
+/// The LoopIteration specifies if the loop is finite or infinite.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum LoopIteration {
     Finite(u64),
@@ -43,6 +44,9 @@ pub enum LoopIteration {
 }
 
 impl LoopContext {
+    /// Creates a new `LoopContext` from a [`LoopDescriptor`](`LoopDescriptor`)
+    /// and a `Timestamp`.
+    ///
     pub(crate) fn new(descriptor: &LoopDescriptor, start: Timestamp) -> Self {
         let iteration = match descriptor.is_infinite {
             true => LoopIteration::Infinite,
@@ -59,10 +63,14 @@ impl LoopContext {
         }
     }
 
+    /// Updates the start timestamp for the current iteration.
+    /// This is called when the iteration begins.
     pub(crate) fn update_ingress(&mut self, now: Timestamp) {
         self.timestamp_start_current_iteration = Some(now);
     }
 
+    /// Updates the end timestamp for the current iteration.
+    /// This is called when the iteration ends.
     pub(crate) fn update_egress(&mut self, now: Timestamp) {
         if let LoopIteration::Finite(counter) = self.iteration {
             let (iteration, has_overflowed) = counter.overflowing_add(1);
@@ -79,26 +87,32 @@ impl LoopContext {
         self.timestamp_start_current_iteration = None;
     }
 
+    /// Returns the ingress node for the loop.
     pub fn get_ingress(&self) -> &NodeId {
         &self.ingress
     }
 
+    /// Returns the egress node for the loop.
     pub fn get_egress(&self) -> &NodeId {
         &self.egress
     }
 
+    /// Returns the [`LoopIteration`](`LoopIteration`).
     pub fn get_iteration(&self) -> LoopIteration {
         self.iteration
     }
 
+    /// Returns the timestamp for the first iteration.
     pub fn get_timestamp_start_first_iteration(&self) -> Timestamp {
         self.timestamp_start_first_iteration
     }
 
+    /// Returns the initial timestamp for the current iteration.
     pub fn get_timestamp_start_current_iteration(&self) -> Option<Timestamp> {
         self.timestamp_start_current_iteration
     }
 
+    /// Returns the duration of the previous iteration.
     pub fn get_duration_last_iteration(&self) -> Option<Duration> {
         self.duration_last_iteration
     }

--- a/zenoh-flow/src/runtime/message.rs
+++ b/zenoh-flow/src/runtime/message.rs
@@ -192,6 +192,10 @@ impl Message {
     }
 
     /// Serialized the `Message` using bincode.
+    ///
+    /// # Errors
+    /// An error variant is returned in case of:
+    /// - fails to serialize
     pub fn serialize_bincode(&self) -> ZFResult<Vec<u8>> {
         match &self {
             Message::Control(_) => {

--- a/zenoh-flow/src/runtime/message.rs
+++ b/zenoh-flow/src/runtime/message.rs
@@ -97,7 +97,7 @@ impl DataMessage {
     }
 
     /// Creates a messages from `Typed` data.
-    /// This is used when the data is generated from rust source.
+    /// This is used when the data is generated from rust nodes.
     pub fn new_deserialized(
         data: Arc<dyn ZFData>,
         timestamp: Timestamp,
@@ -115,9 +115,9 @@ impl DataMessage {
 }
 
 /// Metadata stored in Zenoh's time series storages.
-/// It contains information about the recoding.
+/// It contains information about the recording.
 /// Multiple [`RecordingMetadata`](`RecordingMetadata`) can be used
-/// to syncronize the recoding from different Ports.
+/// to synchronize the recording from different Ports.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RecordingMetadata {
     pub(crate) timestamp: Timestamp,
@@ -129,7 +129,7 @@ pub struct RecordingMetadata {
 
 /// Zenoh Flow control messages.
 /// It contains the control messages used within Zenoh Flow.
-/// For the time being only the `RecodingStart` and `RecodingStop` messages
+/// For the time being only the `RecordingStart` and `RecordingStop` messages
 /// have been defined,
 /// *Note*: Most of messages are not yet defined.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -191,7 +191,7 @@ impl Message {
         }
     }
 
-    /// Serialized the `Message` using bincode.
+    /// Serializes the `Message` using bincode.
     ///
     /// # Errors
     /// An error variant is returned in case of:

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -44,6 +44,10 @@ pub mod message;
 pub mod resources;
 pub mod token;
 
+/// The context of a Zenoh Flow runtime.
+/// This is shared across all the instances in a runtime.
+/// It allows sharing the `zenoh::Session`, the `Loader`,
+/// the `HLC` and other relevant singletons.
 #[derive(Clone)]
 pub struct RuntimeContext {
     pub session: Arc<Session>,
@@ -53,6 +57,7 @@ pub struct RuntimeContext {
     pub runtime_uuid: Uuid,
 }
 
+/// The context of a Zenoh Flow graph instance.
 #[derive(Clone)]
 pub struct InstanceContext {
     pub flow_id: FlowId,
@@ -60,6 +65,10 @@ pub struct InstanceContext {
     pub runtime: RuntimeContext,
 }
 
+/// This function maps a [`DataFlowDescriptor`](`DataFlowDescriptor`) into
+/// the infrastructure.
+/// The initial implementation simply maps all missing mapping
+/// to the given runtime `runtime`.
 pub async fn map_to_infrastructure(
     mut descriptor: DataFlowDescriptor,
     runtime: &str,
@@ -120,6 +129,9 @@ pub async fn map_to_infrastructure(
 }
 
 // Runtime related types, maybe can be moved.
+
+/// Runtime Status, either Ready or Not Ready.
+/// When Ready it is able to accept commands and instantiate graphs.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum RuntimeStatusKind {
@@ -127,6 +139,7 @@ pub enum RuntimeStatusKind {
     NotReady,
 }
 
+/// The Runtime information.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuntimeInfo {
     pub id: Uuid,
@@ -136,6 +149,7 @@ pub struct RuntimeInfo {
     // Do we need/want also RAM usage?
 }
 
+/// The detailed runtime status.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuntimeStatus {
     pub id: Uuid,
@@ -147,6 +161,7 @@ pub struct RuntimeStatus {
     pub running_connectors: usize,
 }
 
+/// Wrapper for Zenoh kind.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum ZenohConfigKind {
@@ -184,6 +199,7 @@ impl Into<zenoh::config::whatami::WhatAmI> for ZenohConfigKind {
     }
 }
 
+/// Wrapper for Zenoh config in the runtime configuration file.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ZenohConfig {
     pub kind: ZenohConfigKind, // whether the runtime is a peer or a client
@@ -191,6 +207,7 @@ pub struct ZenohConfig {
     pub locators: Vec<String>, // where to connect (eg. a router if the runtime is a client, or other peers/routers if the runtime is a peer)
 }
 
+/// The runtime configuration file struct.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RuntimeConfig {
     pub pid_file: String, //Where the PID file resides
@@ -203,6 +220,8 @@ pub struct RuntimeConfig {
 
 /// The interface the Runtime expose to a client
 /// (eg. another runtime, the cli, the mgmt API)
+/// The service is exposed using zenoh-rpc, the server and client
+/// are generated automatically.
 #[znservice(
     timeout_s = 60,
     prefix = "/zf/runtime",

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -68,7 +68,7 @@ pub struct InstanceContext {
 /// This function maps a [`DataFlowDescriptor`](`DataFlowDescriptor`) into
 /// the infrastructure.
 /// The initial implementation simply maps all missing mapping
-/// to the given runtime `runtime`.
+/// to the provided runtime.
 ///
 /// # Errors
 /// An error variant is returned in case of:

--- a/zenoh-flow/src/runtime/resources.rs
+++ b/zenoh-flow/src/runtime/resources.rs
@@ -334,7 +334,7 @@ impl DataStore {
         Self { z }
     }
 
-    /// Gets the [`RuntimeInfo`](`RuntimeInfo`) for the given `rtid.
+    /// Gets the [`RuntimeInfo`](`RuntimeInfo`) for the given `rtid`.
     ///
     /// # Errors
     /// An error variant is returned in case of:
@@ -346,7 +346,7 @@ impl DataStore {
         self.get_from_zenoh::<RuntimeInfo>(&selector).await
     }
 
-    /// Gets the  [`RuntimeInfo`](`RuntimeInfo`) for all the runtime in the
+    /// Gets the  [`RuntimeInfo`](`RuntimeInfo`) for all the runtimes in the
     /// infrastructure
     ///
     /// # Errors
@@ -407,7 +407,7 @@ impl DataStore {
         self.get_from_zenoh::<RuntimeConfig>(&selector).await
     }
 
-    /// Subscribers to configuration changes for the given `rtid`
+    /// Subscribes to configuration changes for the given `rtid`
     /// **NOTE:** not implemented.
     ///
     /// # Errors
@@ -448,7 +448,7 @@ impl DataStore {
         Ok(self.z.put(&path, encoded_info).await?)
     }
 
-    /// Gets the `RuntimeStatus` for the given runtinme `rtid.
+    /// Gets the `RuntimeStatus` for the given runtime `rtid`.
     ///
     /// # Errors
     /// An error variant is returned in case of:
@@ -484,7 +484,7 @@ impl DataStore {
         Ok(self.z.put(&path, encoded_info).await?)
     }
 
-    /// Gets the [`DataFlowRecord`](`DataFlowRecord`) running on the give
+    /// Gets the [`DataFlowRecord`](`DataFlowRecord`) running on the given
     /// runtime `rtid` for the given instance `iid`.
     ///
     /// # Errors
@@ -501,7 +501,7 @@ impl DataStore {
         self.get_from_zenoh::<DataFlowRecord>(&selector).await
     }
 
-    /// Getsthe [`DataFlowRecord`](`DataFlowRecord`) running across the
+    /// Gets the [`DataFlowRecord`](`DataFlowRecord`) running across the
     /// infrastructure for the instance `iid`.
     ///
     /// # Errors

--- a/zenoh-flow/src/runtime/token.rs
+++ b/zenoh-flow/src/runtime/token.rs
@@ -50,7 +50,6 @@ impl InputTokens {
 /// - Drop the data will be dropped
 /// - Keep the data will be kept for the current and the next
 /// time the run is triggered, if can be set back to `Consume` by the user.
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenAction {
     Consume,

--- a/zenoh-flow/src/runtime/token.rs
+++ b/zenoh-flow/src/runtime/token.rs
@@ -49,7 +49,7 @@ impl InputTokens {
 /// - Consume (default) the data will be consumed when run is triggered
 /// - Drop the data will be dropped
 /// - Keep the data will be kept for the current and the next
-/// time the run is triggered, if can be set back to `Consume` by the user.
+/// time the run is triggered, it has to be explicitly set back to `Consume`
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenAction {
     Consume,

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -22,35 +22,124 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-// NOTE: This trait is separate from `ZFDataTrait` so that we can provide a `#derive` macro to
-// automatically implement it for the users.
+/// This trait is used to ensure the data can donwcast to [`Any`](`Any`)
+/// NOTE: This trait is separate from `ZFDataTrait` so that we can provide
+/// a `#derive` macro to automatically implement it for the users.
+///
+/// This can be derived using the `#derive(ZFData)
+///
+/// Example::
+/// ```no_run
+/// #[derive(Debug, Clone, ZFData)]
+/// pub struct MyString(pub String);
+/// ```
 pub trait DowncastAny {
+    /// Donwcast as reference to [`Any`](`Any`)
     fn as_any(&self) -> &dyn Any;
+
+    /// Donwcast as mutable reference to [`Any`](`Any`)
     fn as_mut_any(&mut self) -> &mut dyn Any;
 }
 
+/// This trait abstracts the user's data type inside Zenoh Flow.
+///
+/// User types should implement this trait otherwise Zenoh Flow will
+/// not be able to handle the data, and serialize them when needed.
+///
+/// Example:
+/// ```no_run
+/// impl ZFData for MyString {
+///     fn try_serialize(&self) -> zenoh_flow::ZFResult<Vec<u8>> {
+///         Ok(self.0.as_bytes().to_vec())
+///     }
+/// }
+/// ```
 pub trait ZFData: DowncastAny + Debug + Send + Sync {
+    /// Tries to serialize the data as `Vec<u8>`
     fn try_serialize(&self) -> ZFResult<Vec<u8>>;
 }
 
+/// This trait abstract user's type deserialization.
+///
+/// User types should implement this trait otherwise Zenoh Flow will
+/// not be able to handle the data, and deserialize them when needed.
+///
+/// Example:
+/// ```no_run
+/// impl Deserializable for MyString {
+///     fn try_deserialize(bytes: &[u8]) -> ZFResult<MyString>
+///     where
+///         Self: Sized,
+///     {
+///         Ok(ZFString(
+///             String::from_utf8(bytes.to_vec()).map_err(|_| ZFError::DeseralizationError)?,
+///         ))
+///     }
+/// }
+/// ```
 pub trait Deserializable {
+    /// Tries to deserialize from a slice of `u8`.
     fn try_deserialize(bytes: &[u8]) -> ZFResult<Self>
     where
         Self: Sized;
 }
 
+/// This trait abstracts the user's state type inside Zenoh Flow.
+///
+/// User types should implement this trait otherwise Zenoh Flow will
+/// not be able to handle the state.
+///
+/// It can be easily derived.
+///
+/// Example:
+///
+/// ```no_run
+/// #[derive(Debug, Clone, ZFState)]
+/// pub struct MyState;
+/// ```
+///
+
 pub trait ZFState: Debug + Send + Sync {
+    /// Donwcast as reference to [`Any`](`Any`)
     fn as_any(&self) -> &dyn Any;
+
+    /// Donwcast as mutable reference to [`Any`](`Any`)
     fn as_mut_any(&mut self) -> &mut dyn Any;
 }
 
+/// The `Node` trait represents a generic node in the data flow graph.
+/// It contains functions that are common between Operator, Sink and Source.
+/// It has to be implemented for each node within a graph.
 pub trait Node {
+    /// This method is used to initialize the state of the node.
+    /// It is called by the Zenoh Flow runtime when initializing the data flow
+    /// graph.
+    /// An example of node state is files that should be opened, connection
+    /// to devices or internal configuration.
     fn initialize(&self, configuration: &Option<Configuration>) -> ZFResult<State>;
 
+    /// This method is used to finalize the state of the node.
+    /// It is called by the Zenoh Flow runtime when tearing down the data
+    /// flow graph.
+    ///
+    /// An example of node state to finalize is files to be closed,
+    /// clean-up of libraries, or devices.
     fn finalize(&self, state: &mut State) -> ZFResult<()>;
 }
 
+/// The `Operator` triait represent an Operator inside Zenoh Flow.
 pub trait Operator: Node + Send + Sync {
+    /// This method is called when data is received on one or more inputs.
+    /// The result of this method is use as discriminant to trigger the
+    /// operator's run function.
+    /// The operator can access to its context and its state during execution.
+    ///
+    /// The received data is provided as [`InputToken`](`InputToken`) that
+    /// represent the state of the associated port.
+    /// Based on the tokens and on the data users can decide if trigger
+    /// the run or not.
+    /// The commodity function [`default_input_rule`](`default_input_rule`)
+    /// can be used if the operator should be triggered based on KPN rules.
     fn input_rule(
         &self,
         context: &mut Context,
@@ -58,6 +147,16 @@ pub trait Operator: Node + Send + Sync {
         tokens: &mut HashMap<PortId, InputToken>,
     ) -> ZFResult<bool>;
 
+    /// This method is the actual one processing the data.
+    /// It is triggered based on the result of the `input_rule`.
+    /// As operators are computing over data,
+    /// *I/O should not be done in the run*.
+    ///
+    /// The operator can access to its context and its state during execution.
+    /// The result of a computation can also not provide any output.
+    /// When it does provide output the `PortId` used should match the one
+    /// defined in the descriptor for the operator. Any not matching `PortId`
+    /// will be dropped.
     fn run(
         &self,
         context: &mut Context,
@@ -65,6 +164,14 @@ pub trait Operator: Node + Send + Sync {
         inputs: &mut HashMap<PortId, DataMessage>,
     ) -> ZFResult<HashMap<PortId, Data>>;
 
+    /// This method is called after the run, and can be used for
+    /// further analysis and adjustment over the computed data.
+    /// E.g. flooring a value to a specified MAX, or check if it is within
+    /// a given range.
+    ///
+    /// The operator can access to its context and its state during execution.
+    /// The commodity function [`default_output_rule`](`default_output_rule`)
+    /// can be used if the operator does not need any post-processing.
     fn output_rule(
         &self,
         context: &mut Context,
@@ -74,13 +181,28 @@ pub trait Operator: Node + Send + Sync {
     ) -> ZFResult<HashMap<PortId, NodeOutput>>;
 }
 
+/// The `Source` trait represent a Source inside Zenoh Flow
 #[async_trait]
 pub trait Source: Node + Send + Sync {
+    /// This method is the actual one producing the data.
+    /// It is triggered on a loop, and if the `period` is specified
+    /// in the descriptor it is triggered with the given period.
+    /// This method is `async` therefore I/O is possible, e.g. reading data
+    /// from a file/external device.
+    ///
+    /// The Source can access its state and context while executing,
     async fn run(&self, context: &mut Context, state: &mut State) -> ZFResult<Data>;
 }
 
+/// The `Sink` trait represent a Sink inside Zenoh Flow
 #[async_trait]
 pub trait Sink: Node + Send + Sync {
+    /// This method is the actual one consuming the data.
+    /// It is triggered whenever data arrives on the Sink input.
+    /// This method is `async` therefore I/O is possible, e.g. writing to
+    /// a file or interacting with an external device.
+    ///
+    /// The Sink can access its state and context while executing,
     async fn run(
         &self,
         context: &mut Context,

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -30,6 +30,7 @@ use std::fmt::Debug;
 ///
 /// Example::
 /// ```no_run
+/// use zenoh_flow::zenoh_flow_derive::ZFData;
 /// #[derive(Debug, Clone, ZFData)]
 /// pub struct MyString(pub String);
 /// ```
@@ -48,6 +49,11 @@ pub trait DowncastAny {
 ///
 /// Example:
 /// ```no_run
+/// use zenoh_flow::zenoh_flow_derive::ZFData;
+/// use zenoh_flow::ZFData;
+///
+/// #[derive(Debug, Clone, ZFData)]
+/// pub struct MyString(pub String);
 /// impl ZFData for MyString {
 ///     fn try_serialize(&self) -> zenoh_flow::ZFResult<Vec<u8>> {
 ///         Ok(self.0.as_bytes().to_vec())
@@ -66,12 +72,19 @@ pub trait ZFData: DowncastAny + Debug + Send + Sync {
 ///
 /// Example:
 /// ```no_run
+///
+/// use zenoh_flow::{Deserializable, ZFResult, ZFError};
+/// use zenoh_flow::zenoh_flow_derive::ZFData;
+///
+/// #[derive(Debug, Clone, ZFData)]
+/// pub struct MyString(pub String);
+///
 /// impl Deserializable for MyString {
 ///     fn try_deserialize(bytes: &[u8]) -> ZFResult<MyString>
 ///     where
 ///         Self: Sized,
 ///     {
-///         Ok(ZFString(
+///         Ok(MyString(
 ///             String::from_utf8(bytes.to_vec()).map_err(|_| ZFError::DeseralizationError)?,
 ///         ))
 ///     }
@@ -94,6 +107,7 @@ pub trait Deserializable {
 /// Example:
 ///
 /// ```no_run
+/// use zenoh_flow::zenoh_flow_derive::ZFState;
 /// #[derive(Debug, Clone, ZFState)]
 /// pub struct MyState;
 /// ```

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -62,6 +62,9 @@ pub trait DowncastAny {
 /// ```
 pub trait ZFData: DowncastAny + Debug + Send + Sync {
     /// Tries to serialize the data as `Vec<u8>`
+    ///
+    /// # Errors
+    /// If it fails to serialize an error variant will be returned.
     fn try_serialize(&self) -> ZFResult<Vec<u8>>;
 }
 
@@ -92,6 +95,9 @@ pub trait ZFData: DowncastAny + Debug + Send + Sync {
 /// ```
 pub trait Deserializable {
     /// Tries to deserialize from a slice of `u8`.
+    ///
+    /// # Errors
+    /// If it fails to deserialize an error variant will be returned.
     fn try_deserialize(bytes: &[u8]) -> ZFResult<Self>
     where
         Self: Sized;
@@ -130,6 +136,9 @@ pub trait Node {
     /// graph.
     /// An example of node state is files that should be opened, connection
     /// to devices or internal configuration.
+    ///
+    /// # Errors
+    /// If it fails to initialize an error variant will be returned.
     fn initialize(&self, configuration: &Option<Configuration>) -> ZFResult<State>;
 
     /// This method is used to finalize the state of the node.
@@ -138,10 +147,13 @@ pub trait Node {
     ///
     /// An example of node state to finalize is files to be closed,
     /// clean-up of libraries, or devices.
+    ///
+    /// # Errors
+    /// If it fails to finalize an error variant will be returned.
     fn finalize(&self, state: &mut State) -> ZFResult<()>;
 }
 
-/// The `Operator` triait represent an Operator inside Zenoh Flow.
+/// The `Operator` trait represent an Operator inside Zenoh Flow.
 pub trait Operator: Node + Send + Sync {
     /// This method is called when data is received on one or more inputs.
     /// The result of this method is use as discriminant to trigger the
@@ -154,6 +166,10 @@ pub trait Operator: Node + Send + Sync {
     /// the run or not.
     /// The commodity function [`default_input_rule`](`default_input_rule`)
     /// can be used if the operator should be triggered based on KPN rules.
+    ///
+    /// # Errors
+    /// If something goes wrong during execution an error
+    /// variant will be returned.
     fn input_rule(
         &self,
         context: &mut Context,
@@ -171,6 +187,10 @@ pub trait Operator: Node + Send + Sync {
     /// When it does provide output the `PortId` used should match the one
     /// defined in the descriptor for the operator. Any not matching `PortId`
     /// will be dropped.
+    ///
+    /// # Errors
+    /// If something goes wrong during execution an error
+    /// variant will be returned.
     fn run(
         &self,
         context: &mut Context,
@@ -186,6 +206,10 @@ pub trait Operator: Node + Send + Sync {
     /// The operator can access to its context and its state during execution.
     /// The commodity function [`default_output_rule`](`default_output_rule`)
     /// can be used if the operator does not need any post-processing.
+    ///
+    /// # Errors
+    /// If something goes wrong during execution an error
+    /// variant will be returned.
     fn output_rule(
         &self,
         context: &mut Context,
@@ -204,7 +228,11 @@ pub trait Source: Node + Send + Sync {
     /// This method is `async` therefore I/O is possible, e.g. reading data
     /// from a file/external device.
     ///
-    /// The Source can access its state and context while executing,
+    /// The Source can access its state and context while executing.
+    ///
+    /// # Errors
+    /// If something goes wrong during execution an error
+    /// variant will be returned.
     async fn run(&self, context: &mut Context, state: &mut State) -> ZFResult<Data>;
 }
 
@@ -216,7 +244,11 @@ pub trait Sink: Node + Send + Sync {
     /// This method is `async` therefore I/O is possible, e.g. writing to
     /// a file or interacting with an external device.
     ///
-    /// The Sink can access its state and context while executing,
+    /// The Sink can access its state and context while executing.
+    ///
+    /// # Errors
+    /// If something goes wrong during execution an error
+    /// variant will be returned.
     async fn run(
         &self,
         context: &mut Context,

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -26,7 +26,7 @@ use std::fmt::Debug;
 /// NOTE: This trait is separate from `ZFDataTrait` so that we can provide
 /// a `#derive` macro to automatically implement it for the users.
 ///
-/// This can be derived using the `#derive(ZFData)
+/// This can be derived using the `#derive(ZFData)`
 ///
 /// Example::
 /// ```no_run
@@ -35,10 +35,10 @@ use std::fmt::Debug;
 /// pub struct MyString(pub String);
 /// ```
 pub trait DowncastAny {
-    /// Donwcast as reference to [`Any`](`Any`)
+    /// Donwcast as a reference to [`Any`](`Any`)
     fn as_any(&self) -> &dyn Any;
 
-    /// Donwcast as mutable reference to [`Any`](`Any`)
+    /// Donwcast as a mutable reference to [`Any`](`Any`)
     fn as_mut_any(&mut self) -> &mut dyn Any;
 }
 
@@ -153,16 +153,17 @@ pub trait Node {
     fn finalize(&self, state: &mut State) -> ZFResult<()>;
 }
 
-/// The `Operator` trait represent an Operator inside Zenoh Flow.
+/// The `Operator` trait represents an Operator inside Zenoh Flow.
 pub trait Operator: Node + Send + Sync {
     /// This method is called when data is received on one or more inputs.
     /// The result of this method is use as discriminant to trigger the
     /// operator's run function.
-    /// The operator can access to its context and its state during execution.
+    /// An operator can access its context and state during
+    /// the execution of this function.
     ///
     /// The received data is provided as [`InputToken`](`InputToken`) that
-    /// represent the state of the associated port.
-    /// Based on the tokens and on the data users can decide if trigger
+    /// represents the state of the associated port.
+    /// Based on the tokens and on the data users can decide to trigger
     /// the run or not.
     /// The commodity function [`default_input_rule`](`default_input_rule`)
     /// can be used if the operator should be triggered based on KPN rules.
@@ -182,7 +183,8 @@ pub trait Operator: Node + Send + Sync {
     /// As operators are computing over data,
     /// *I/O should not be done in the run*.
     ///
-    /// The operator can access to its context and its state during execution.
+    /// An operator can access its context and state
+    /// during the execution of this function.
     /// The result of a computation can also not provide any output.
     /// When it does provide output the `PortId` used should match the one
     /// defined in the descriptor for the operator. Any not matching `PortId`
@@ -198,12 +200,15 @@ pub trait Operator: Node + Send + Sync {
         inputs: &mut HashMap<PortId, DataMessage>,
     ) -> ZFResult<HashMap<PortId, Data>>;
 
-    /// This method is called after the run, and can be used for
-    /// further analysis and adjustment over the computed data.
+    /// This method is called after the run, its main purpose is to check
+    /// for missed local deadlines.
+    /// It can also be used for further analysis and
+    /// adjustment over the computed data.
     /// E.g. flooring a value to a specified MAX, or check if it is within
     /// a given range.
     ///
-    /// The operator can access to its context and its state during execution.
+    /// An operator can access its context and
+    /// state during the execution of this function.
     /// The commodity function [`default_output_rule`](`default_output_rule`)
     /// can be used if the operator does not need any post-processing.
     ///
@@ -219,7 +224,7 @@ pub trait Operator: Node + Send + Sync {
     ) -> ZFResult<HashMap<PortId, NodeOutput>>;
 }
 
-/// The `Source` trait represent a Source inside Zenoh Flow
+/// The `Source` trait represents a Source inside Zenoh Flow
 #[async_trait]
 pub trait Source: Node + Send + Sync {
     /// This method is the actual one producing the data.
@@ -236,7 +241,7 @@ pub trait Source: Node + Send + Sync {
     async fn run(&self, context: &mut Context, state: &mut State) -> ZFResult<Data>;
 }
 
-/// The `Sink` trait represent a Sink inside Zenoh Flow
+/// The `Sink` trait represents a Sink inside Zenoh Flow
 #[async_trait]
 pub trait Sink: Node + Send + Sync {
     /// This method is the actual one consuming the data.

--- a/zenoh-flow/src/types.rs
+++ b/zenoh-flow/src/types.rs
@@ -69,6 +69,10 @@ impl Data {
     /// It does not actually change the internal representation.
     /// The serialized representation in stored inside an `Arc`
     /// to avoid copies.
+    ///
+    /// # Errors
+    /// If it fails to serialize an error
+    /// variant will be returned.
     pub fn try_as_bytes(&self) -> ZFResult<Arc<Vec<u8>>> {
         match &self {
             Self::Bytes(bytes) => Ok(bytes.clone()),
@@ -109,6 +113,10 @@ impl Data {
     /// multiple Inputs, therefore to avoid copies the same `Arc` is send
     /// to multiple operators, this it is multiple-owned and data inside
     /// cannot be modifed.
+    ///
+    /// # Errors
+    /// If fails to cast an error
+    /// variant will be returned.
     pub fn try_get<Typed>(&mut self) -> ZFResult<&Typed>
     where
         Typed: ZFData + crate::Deserializable + 'static,
@@ -165,6 +173,10 @@ impl State {
     /// Tries to cast the state to the given type.
     /// It returns a mutable reference to the internal state, so user can
     /// modify it.
+    ///
+    /// # Errors
+    /// If it fails to cast an error
+    /// variant will be returned.
     pub fn try_get<S>(&mut self) -> ZFResult<&mut S>
     where
         S: ZFState + 'static,
@@ -253,6 +265,8 @@ impl ZFState for EmptyState {
 /// The default output rules are a commodity function provided to
 /// users that do not need output rules in their operators.
 /// It converts all the incoming data to the right node output.
+///
+/// It never returns an error.
 pub fn default_output_rule(
     _state: &mut State,
     outputs: HashMap<PortId, Data>,
@@ -269,6 +283,8 @@ pub fn default_output_rule(
 /// users that do not need inputs rules in their operators.
 /// They provide a KPN input rule. Thus they trigger the execution only when
 /// all inputs are present.
+///
+/// It never returns an error.
 pub fn default_input_rule(
     _state: &mut State,
     tokens: &mut HashMap<PortId, InputToken>,


### PR DESCRIPTION
This PR includes the documentation of:

- zenoh-flow
- zenoh-flow-daemon
- zenoh-flow-derive

The documentation covers user API (the traits, types, and so on) as well as internals like `Runners` or the `Daemon`.

It also includes examples for the macros and the descriptors. 