### PR TITLE
Using clap instead of structopt

### DIFF
--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -20,11 +20,10 @@ async-std = { version = "=1.10.0", features = ["attributes"] }
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", optional = true}
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master", optional = true }
 zenoh-flow = {path = "../zenoh-flow"}
-structopt = "0.3"
-clap = "2.33"
+clap = { version = "3.1", features = ["derive"] }
 serde_derive = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-cargo_toml = "0.10"
+cargo_toml = "0.11"
 toml = "0.5.8"
 serde_yaml = {version = "0.8"}
 serde_json = "1.0"

--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -13,8 +13,8 @@
 //
 
 use async_std::process::exit;
+use clap::Parser;
 use colored::*;
-use structopt::StructOpt;
 
 use zenoh_flow::model::node::{OperatorDescriptor, SinkDescriptor, SourceDescriptor};
 use zenoh_flow::model::{NodeKind, RegistryNode, RegistryNodeArchitecture, RegistryNodeTag};
@@ -31,22 +31,22 @@ use zenoh_flow_registry::RegistryClient;
 #[cfg(feature = "local_registry")]
 use zenoh_flow_registry::RegistryFileClient;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum ZFCtl {
     Build {
-        #[structopt(short, long)]
+        #[clap(short, long)]
         package: Option<String>,
-        #[structopt(short = "m", long = "manifest-path", default_value = "Cargo.toml")]
+        #[clap(short = 'm', long = "manifest-path", default_value = "Cargo.toml")]
         manifest_path: std::path::PathBuf,
-        #[structopt(short, long)]
+        #[clap(short, long)]
         release: bool,
-        #[structopt(short = "t", long = "tag", default_value = "latest")]
+        #[clap(short = 't', long = "tag", default_value = "latest")]
         version_tag: String,
         cargo_build_flags: Vec<String>,
     },
     New {
         name: String,
-        #[structopt(short = "k", long = "kind", default_value = "operator")]
+        #[clap(short = 'k', long = "kind", default_value = "operator")]
         kind: NodeKind,
     },
     List,
@@ -64,7 +64,7 @@ async fn main() {
     let mut args: Vec<String> = std::env::args().collect();
     args.remove(1);
 
-    let args = ZFCtl::from_iter(args.iter());
+    let args = ZFCtl::parse_from(args.iter());
 
     #[cfg(feature = "local_registry")]
     {

--- a/zenoh-flow-ctl/Cargo.toml
+++ b/zenoh-flow-ctl/Cargo.toml
@@ -21,8 +21,7 @@ zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "mas
 zrpc = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
 znrpc-macros = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
 async-std = { version = "=1.10.0", features = ["attributes"] }
-structopt = "0.3.13"
-clap = "2.33"
+clap = { version = "3.1", features = ["derive"] }
 exitfailure = "0.5.1"
 failure = "0.1.8"
 prettytable-rs = "^0.8"

--- a/zenoh-flow-ctl/src/main.rs
+++ b/zenoh-flow-ctl/src/main.rs
@@ -21,37 +21,37 @@ extern crate prettytable;
 extern crate base64;
 extern crate exitfailure;
 
+use clap::{Parser, Subcommand};
 use git_version::git_version;
 use prettytable::Table;
 use rand::seq::SliceRandom;
 use std::collections::HashSet;
 use std::fs::read_to_string;
-use structopt::StructOpt;
 use uuid::Uuid;
 use zenoh_flow::async_std::sync::Arc;
 use zenoh_flow::runtime::resources::DataStore;
 use zenoh_flow::runtime::RuntimeClient;
 const GIT_VERSION: &str = git_version!(prefix = "v", cargo_prefix = "v");
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum AddKind {
     Flow {
-        #[structopt(parse(from_os_str), name = "Flow descriptor path")]
+        #[clap(parse(from_os_str), name = "Flow descriptor path")]
         descriptor_path: std::path::PathBuf,
     },
     // When registry will be in place the code below will be used
     // Instance {
     //     flow_id: String,
-    //     #[structopt(short = "r", long = "rt-id", name = "Runtime UUID")]
+    //     #[clap(short = 'r', long = "rt-id", name = "Runtime UUID")]
     //     rt_id: Option<Uuid>,
     // },
     Instance {
-        #[structopt(parse(from_os_str), name = "Flow descriptor path")]
+        #[clap(parse(from_os_str), name = "Flow descriptor path")]
         descriptor_path: std::path::PathBuf,
     },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum StartKind {
     Node {
         instance_id: Uuid,
@@ -68,7 +68,7 @@ pub enum StartKind {
     },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum StopKind {
     Node {
         instance_id: Uuid,
@@ -85,25 +85,30 @@ pub enum StopKind {
     },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum GetKind {
     Flow { id: Option<String> },
     Instance { id: Option<Uuid> },
     Runtime { id: Option<Uuid> },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum DeleteKind {
     Flow { id: String },
     Instance { id: Uuid },
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum ZFCtl {
+    #[clap(subcommand)]
     Add(AddKind),
+    #[clap(subcommand)]
     Get(GetKind),
+    #[clap(subcommand)]
     Delete(DeleteKind),
+    #[clap(subcommand)]
     Start(StartKind),
+    #[clap(subcommand)]
     Stop(StopKind),
 }
 
@@ -112,7 +117,7 @@ async fn main() {
     env_logger::init();
     log::debug!("Eclipse Zenoh-Flow Ctl {}", GIT_VERSION);
 
-    let args = ZFCtl::from_args();
+    let args = ZFCtl::parse();
     log::debug!("Args: {:?}", args);
 
     let zsession = Arc::new(zenoh::open(zenoh::config::Config::default()).await.unwrap());

--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -29,7 +29,7 @@ zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master"}
 zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
 zrpc = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
 znrpc-macros = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
-structopt = "0.3"
+clap = { version = "3.1", features = ["derive"] }
 hostname = "0.3.1"
 machine-uid = "0.2.0"
 git-version = "0.3"

--- a/zenoh-flow-daemon/src/main.rs
+++ b/zenoh-flow-daemon/src/main.rs
@@ -10,7 +10,7 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
-use structopt::StructOpt;
+use clap::Parser;
 
 use async_ctrlc::CtrlC;
 use std::str;
@@ -30,14 +30,14 @@ static RUNTIME_CONFIG_FILE: &str = "/etc/zenoh-flow/runtime.yaml";
 const GIT_VERSION: &str = git_version::git_version!(prefix = "v", cargo_prefix = "v");
 
 /// The CLI parameters accepted by the runtime.
-#[derive(Debug, StructOpt)]
-#[structopt(name = "dpn")]
+#[derive(Debug, Parser)]
+#[clap(name = "dpn")]
 struct RuntimeOpt {
-    #[structopt(short = "c", long = "configuration", default_value = RUNTIME_CONFIG_FILE)]
+    #[clap(short = 'c', long = "configuration", default_value = RUNTIME_CONFIG_FILE)]
     config: String,
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     print_version: bool,
-    #[structopt(short = "i", long = "node_uuid")]
+    #[clap(short = 'i', long = "node_uuid")]
     node_uuid: bool,
 }
 
@@ -74,7 +74,7 @@ async fn main() {
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
     );
 
-    let args = RuntimeOpt::from_args();
+    let args = RuntimeOpt::parse();
 
     if args.print_version {
         println!("Zenoh Flow runtime version: {}", GIT_VERSION);

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1.50"
 base64 = "0.13.0"
 bincode = { version = "1.3"}
 derive_more = "0.99.10"
+clap = { version = "3.1", features = ["derive"] }
 const_format = "0.2.22"
 env_logger = "0.9"
 event-listener = "2.5.1"
@@ -39,7 +40,6 @@ serde_cbor = {version = "0.11", optional = true}
 serde_derive = "1.0.55"
 serde_json = { version = "1.0", optional = true}
 serde_yaml = {version = "0.8.13"}
-structopt = "0.3.21"
 typetag = "0.1"
 uhlc = "0.4"
 url = "2.2.2"

--- a/zenoh-flow/src/error.rs
+++ b/zenoh-flow/src/error.rs
@@ -14,6 +14,7 @@
 use crate::serde::{Deserialize, Serialize};
 use crate::{NodeId, PortId, PortType};
 use std::convert::From;
+use std::error::Error;
 use uuid::Uuid;
 use zrpc::zrpcresult::ZRPCError;
 
@@ -143,3 +144,6 @@ impl std::fmt::Display for ZFError {
         write!(f, "{:?}", self)
     }
 }
+
+// This is needed to make clap happy.
+impl Error for ZFError {}


### PR DESCRIPTION
This PR replaces all the usage of `structopt` with `clap`.

`structopt` is now deprecated: https://docs.rs/structopt/latest/structopt/#maintenance

Signed-off-by: gabrik <gabriele.baldoni@gmail.com>