### PR TITLE
fix: show path of file not found when loading fails

### DIFF
--- a/zenoh-flow/src/model/dataflow/descriptor.rs
+++ b/zenoh-flow/src/model/dataflow/descriptor.rs
@@ -30,7 +30,7 @@ use std::hash::{Hash, Hasher};
 /// ```yaml
 /// id: SumOperator
 /// runtime: runtime1
-//// ```
+/// ```
 ///
 ///
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/zenoh-flow/src/runtime/dataflow/loader.rs
+++ b/zenoh-flow/src/runtime/dataflow/loader.rs
@@ -438,7 +438,8 @@ impl Loader {
             None => uri.path().to_string(),
         };
         path.push(file_path);
-        let path = std::fs::canonicalize(path)?;
+        let path = std::fs::canonicalize(&path)
+            .map_err(|e| ZFError::IOError(format!("{}: {}", e, &path.to_string_lossy())))?;
         Ok(path)
     }
 


### PR DESCRIPTION
With this commit, when a library is not found, the incriminated path is shown.