### PR TITLE
Fixing finalize function not being called when cleaning a data flow intance

### DIFF
--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -626,24 +626,44 @@ impl Runtime for Daemon {
             Some(mut dfg) => {
                 // Calling finalize on all nodes of a the graph.
 
-                let sources = dfg.get_sources();
-                for id in &sources {
-                    dfg.clean_node(id).await?;
+                let mut sources = dfg.get_sources();
+                for id in sources.drain(..) {
+                    dfg.clean_node(&id).await.map_or_else(
+                        |e| {
+                            log::error!("Unable to clean source {}, got error: {}", &id, e);
+                        },
+                        |_| (),
+                    );
                 }
 
                 let mut sinks = dfg.get_sinks();
                 for id in sinks.drain(..) {
-                    dfg.clean_node(&id).await?;
+                    dfg.clean_node(&id).await.map_or_else(
+                        |e| {
+                            log::error!("Unable to clean sink {}, got error: {}", &id, e);
+                        },
+                        |_| (),
+                    );
                 }
 
                 let mut operators = dfg.get_operators();
                 for id in operators.drain(..) {
-                    dfg.clean_node(&id).await?;
+                    dfg.clean_node(&id).await.map_or_else(
+                        |e| {
+                            log::error!("Unable to operator source {}, got error: {}", &id, e);
+                        },
+                        |_| (),
+                    );
                 }
 
                 let mut connectors = dfg.get_connectors();
                 for id in connectors.drain(..) {
-                    dfg.clean_node(&id).await?;
+                    dfg.clean_node(&id).await.map_or_else(
+                        |e| {
+                            log::error!("Unable to clean connector {}, got error: {}", &id, e);
+                        },
+                        |_| (),
+                    );
                 }
 
                 let record = self

--- a/zenoh-flow/src/runtime/dataflow/instance/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/mod.rs
@@ -358,7 +358,7 @@ impl DataflowInstance {
     /// Finalizing a node means cleaning up its state.
     ///
     /// # Errors
-    /// If fails if the node is not found or it is not running.
+    /// If fails if the node is not found.
     pub async fn clean_node(&mut self, node_id: &NodeId) -> ZFResult<()> {
         let runner = self
             .runners

--- a/zenoh-flow/src/runtime/dataflow/instance/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/mod.rs
@@ -354,6 +354,19 @@ impl DataflowInstance {
         Ok(manager.await?)
     }
 
+    /// Finalized the given node.
+    /// Finalizing a node means cleaning up its state.
+    ///
+    /// # Errors
+    /// If fails if the node is not found or it is not running.
+    pub async fn clean_node(&mut self, node_id: &NodeId) -> ZFResult<()> {
+        let runner = self
+            .runners
+            .get(node_id)
+            .ok_or_else(|| ZFError::NodeNotFound(node_id.clone()))?;
+        runner.clean().await
+    }
+
     /// Starts the recording for the given source.
     ///
     /// It returns the key expression where the recording is stored.

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/replay.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/replay.rs
@@ -187,7 +187,7 @@ impl Runner for ZenohReplay {
             let mut zf_data: Vec<Message> = data
                 .iter()
                 .filter_map(|msg| {
-                    bincode::deserialize::<Message>(&msg.data.value.payload.contiguous()).ok()
+                    bincode::deserialize::<Message>(&msg.sample.value.payload.contiguous()).ok()
                 })
                 .collect();
             zf_data.sort();

--- a/zenoh-flow/src/runtime/resources.rs
+++ b/zenoh-flow/src/runtime/resources.rs
@@ -562,7 +562,7 @@ impl DataStore {
         let mut runtimes = Vec::new();
 
         for kv in data.into_iter() {
-            let path = String::from(kv.data.key_expr.as_str());
+            let path = String::from(kv.sample.key_expr.as_str());
             let id = path.split('/').collect::<Vec<&str>>()[3];
             runtimes.push(Uuid::parse_str(id).map_err(|_| ZFError::DeseralizationError)?);
         }
@@ -675,11 +675,11 @@ impl DataStore {
             0 => Err(ZFError::Empty),
             _ => {
                 let kv = &data[0];
-                match &kv.data.value.encoding {
+                match &kv.sample.value.encoding {
                     //@FIXME This is workaround because zenoh apis are broken, it should just be &Encoding::APP_OCTET_STREAM
                     e if e.starts_with(&Encoding::APP_OCTET_STREAM) => {
                         let ni =
-                            deserialize_data::<T>(&kv.data.value.payload.contiguous().to_vec())?;
+                            deserialize_data::<T>(&kv.sample.value.payload.contiguous().to_vec())?;
                         Ok(ni)
                     }
                     _ => Err(ZFError::DeseralizationError),
@@ -705,10 +705,10 @@ impl DataStore {
         let mut zf_data: Vec<T> = Vec::new();
 
         for kv in data.into_iter() {
-            match &kv.data.value.encoding {
+            match &kv.sample.value.encoding {
                 //@FIXME This is workaround because zenoh apis are broken, it should just be &Encoding::APP_OCTET_STREAM
                 e if e.starts_with(&Encoding::APP_OCTET_STREAM) => {
-                    let ni = deserialize_data::<T>(&kv.data.value.payload.contiguous().to_vec())?;
+                    let ni = deserialize_data::<T>(&kv.sample.value.payload.contiguous().to_vec())?;
                     zf_data.push(ni);
                 }
                 _ => return Err(ZFError::DeseralizationError),


### PR DESCRIPTION
This PR fixes an issue with the `DataflowInstance` not exposing any function to call the `finalize` function for any nodes of the graph.

Now the `DataflowInstance` expose the `clean_node` function that calls the `finalize` function for a given node.

The `zenoh-flow-daemon` calls this function when cleaning an instance.