### PR TITLE
cargo zenoh-flow to provide boilerplates for Python and C++ nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
               ;;
             *alpine*)
               apk update
-              apk add git curl build-base
+              apk add git curl build-base libressl-dev
               ;;
           esac
 
@@ -208,15 +208,15 @@ jobs:
           case ${{ matrix.job.target }} in
             arm-unknown-linux-gnueabi)
               sudo apt-get -y update
-              sudo apt-get -y install gcc-arm-linux-gnueabi
+              sudo apt-get -y install gcc-arm-linux-gnueabi libssl-dev
               ;;
             arm*-unknown-linux-gnueabihf)
               sudo apt-get -y update
-              sudo apt-get -y install gcc-arm-linux-gnueabihf
+              sudo apt-get -y install gcc-arm-linux-gnueabihf libssl-dev
               ;;
             aarch64-unknown-linux-gnu)
               sudo apt-get -y update
-              sudo apt-get -y install gcc-aarch64-linux-gnu
+              sudo apt-get -y install gcc-aarch64-linux-gnu libssl-dev
               ;;
           esac
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           case ${{ matrix.job.container }} in
             *fedora*)
               dnf update -y
-              dnf install -y git curl
+              dnf install -y git curl openssl-devel
               dnf groupinstall "Development Tools" "Development Libraries" -y
               case ${{ matrix.job.target }} in
               aarch64-unknown-linux-gnu)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <img src="https://raw.githubusercontent.com/eclipse-zenoh/zenoh/master/zenoh-dragon.png" height="150">
 
+
+[![Eclipse CI](https://ci.eclipse.org/zenoh/buildStatus/icon?job=zenoh-flow-nightly&subject=Eclipse%20CI)](https://ci.eclipse.org/zenoh/view/Zenoh%20Flow/job/zenoh-flow-nightly/)
+[![CI](https://github.com/eclipse-zenoh/zenoh-flow/actions/workflows/ci.yml/badge.svg)](https://github.com/eclipse-zenoh/zenoh-flow/actions/workflows/ci.yml)
 [![Discussion](https://img.shields.io/badge/discussion-on%20github-blue)](https://github.com/eclipse-zenoh/roadmap/discussions)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-blue)](https://discord.gg/vSDSpqnbkm)
+
 
 # Eclipse Zenoh-Flow
 

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 rand = { version = "0.8", optional =  true}
 tinytemplate = "1.2"
 colored = "2"
-git2 = { version = "0.14.2", default_features = false, features = [ "https", "vendored-libgit2" ]}
+git2 = { version = "0.14.2", default_features = false, features = [ "https" ]}
 
 
 [[bin]]

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = "1.0"
 rand = { version = "0.8", optional =  true}
 tinytemplate = "1.2"
 colored = "2"
-git2 = { version = "0.14.2", default_features = false, features = [ "https" ]}
 
 
 [[bin]]

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1.0"
 rand = { version = "0.8", optional =  true}
 tinytemplate = "1.2"
 colored = "2"
+git2 = "0.14.2"
 
 
 [[bin]]

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 rand = { version = "0.8", optional =  true}
 tinytemplate = "1.2"
 colored = "2"
-git2 = "0.14.2"
+git2 = { version = "0.14.2", default_features = false, features = [ "https", "vendored-libgit2", "vendored-openssl" ]}
 
 
 [[bin]]

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -44,7 +44,7 @@ serde_json = "1.0"
 rand = { version = "0.8", optional =  true}
 tinytemplate = "1.2"
 colored = "2"
-git2 = { version = "0.14.2", default_features = false, features = [ "https", "vendored-libgit2", "vendored-openssl" ]}
+git2 = { version = "0.14.2", default_features = false, features = [ "https", "vendored-libgit2" ]}
 
 
 [[bin]]

--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -510,26 +510,72 @@ async fn main() {
                 node_info.id
             );
         }
-        ZFCtl::New { name, kind, .. } => {
-            match cargo_zenoh_flow::utils::create_crate(&name, kind.clone()).await {
-                Ok(_) => {
-                    println!(
-                        "{} boilerplate for {} {} ",
-                        "Created".green().bold(),
-                        kind.to_string(),
-                        name.bold()
-                    );
-                }
-                Err(_) => {
-                    println!(
-                        "{}: failed to create boilerplate for {} {}",
-                        "error".red().bold(),
-                        kind.to_string(),
-                        name.bold(),
-                    );
+        ZFCtl::New {
+            name,
+            kind,
+            language,
+        } => match language {
+            Languages::Rust => {
+                match cargo_zenoh_flow::utils::create_crate(&name, kind.clone()).await {
+                    Ok(_) => {
+                        println!(
+                            "{} boilerplate for {} {} ",
+                            "Created".green().bold(),
+                            kind.to_string(),
+                            name.bold()
+                        );
+                    }
+                    Err(_) => {
+                        println!(
+                            "{}: failed to create boilerplate for {} {}",
+                            "error".red().bold(),
+                            kind.to_string(),
+                            name.bold(),
+                        );
+                    }
                 }
             }
-        }
+            Languages::Python => {
+                match cargo_zenoh_flow::utils::create_python_module(&name, kind.clone()).await {
+                    Ok(_) => {
+                        println!(
+                            "{} boilerplate for {} {} ",
+                            "Created".green().bold(),
+                            kind.to_string(),
+                            name.bold()
+                        );
+                    }
+                    Err(_) => {
+                        println!(
+                            "{}: failed to create boilerplate for {} {}",
+                            "error".red().bold(),
+                            kind.to_string(),
+                            name.bold(),
+                        );
+                    }
+                }
+            }
+            Languages::Cpp => {
+                match cargo_zenoh_flow::utils::create_cpp_node(&name, kind.clone()).await {
+                    Ok(_) => {
+                        println!(
+                            "{} boilerplate for {} {} ",
+                            "Created".green().bold(),
+                            kind.to_string(),
+                            name.bold()
+                        );
+                    }
+                    Err(_) => {
+                        println!(
+                            "{}: failed to create boilerplate for {} {}",
+                            "error".red().bold(),
+                            kind.to_string(),
+                            name.bold(),
+                        );
+                    }
+                }
+            }
+        },
         ZFCtl::List => {
             #[cfg(feature = "local_registry")]
             match client {

--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -525,12 +525,13 @@ async fn main() {
                             name.bold()
                         );
                     }
-                    Err(_) => {
+                    Err(e) => {
                         println!(
-                            "{}: failed to create boilerplate for {} {}",
+                            "{}: failed to create boilerplate for {} {}: {}",
                             "error".red().bold(),
                             kind.to_string(),
                             name.bold(),
+                            e
                         );
                     }
                 }
@@ -545,12 +546,13 @@ async fn main() {
                             name.bold()
                         );
                     }
-                    Err(_) => {
+                    Err(e) => {
                         println!(
-                            "{}: failed to create boilerplate for {} {}",
+                            "{}: failed to create boilerplate for {} {}: {}",
                             "error".red().bold(),
                             kind.to_string(),
                             name.bold(),
+                            e
                         );
                     }
                 }
@@ -565,12 +567,13 @@ async fn main() {
                             name.bold()
                         );
                     }
-                    Err(_) => {
+                    Err(e) => {
                         println!(
-                            "{}: failed to create boilerplate for {} {}",
+                            "{}: failed to create boilerplate for {} {}: {}",
                             "error".red().bold(),
                             kind.to_string(),
                             name.bold(),
+                            e
                         );
                     }
                 }

--- a/cargo-zenoh-flow/src/bin/main.rs
+++ b/cargo-zenoh-flow/src/bin/main.rs
@@ -16,6 +16,7 @@ use async_std::process::exit;
 use clap::Parser;
 use colored::*;
 
+use cargo_zenoh_flow::error::CZFError;
 use zenoh_flow::model::node::{OperatorDescriptor, SinkDescriptor, SourceDescriptor};
 use zenoh_flow::model::{NodeKind, RegistryNode, RegistryNodeArchitecture, RegistryNodeTag};
 use zenoh_flow::NodeId;
@@ -30,6 +31,40 @@ use zenoh::*;
 use zenoh_flow_registry::RegistryClient;
 #[cfg(feature = "local_registry")]
 use zenoh_flow_registry::RegistryFileClient;
+
+#[derive(Debug)]
+pub enum Languages {
+    Rust,
+    Python,
+    Cpp,
+}
+
+impl std::str::FromStr for Languages {
+    type Err = CZFError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "rust" => Ok(Self::Rust),
+            "python" => Ok(Self::Python),
+            "py" => Ok(Self::Python),
+            "cpp" => Ok(Self::Cpp),
+            "c++" => Ok(Self::Cpp),
+            _ => Err(CZFError::LanguageNotCompatible(format!(
+                "Language {s} is not supported. Supported languages are: rust, python, cpp"
+            ))),
+        }
+    }
+}
+
+impl std::string::ToString for Languages {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Rust => String::from("rust"),
+            Self::Python => String::from("python"),
+            Self::Cpp => String::from("c++"),
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 pub enum ZFCtl {
@@ -48,6 +83,8 @@ pub enum ZFCtl {
         name: String,
         #[clap(short = 'k', long = "kind", default_value = "operator")]
         kind: NodeKind,
+        #[clap(short = 'l', long = "l", default_value = "rust")]
+        language: Languages,
     },
     List,
     Push {
@@ -473,7 +510,7 @@ async fn main() {
                 node_info.id
             );
         }
-        ZFCtl::New { name, kind } => {
+        ZFCtl::New { name, kind, .. } => {
             match cargo_zenoh_flow::utils::create_crate(&name, kind.clone()).await {
                 Ok(_) => {
                     println!(

--- a/cargo-zenoh-flow/src/error.rs
+++ b/cargo-zenoh-flow/src/error.rs
@@ -12,11 +12,14 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use std::error::Error;
+
 #[derive(Debug)]
 pub enum CZFError {
     PackageNotFoundInWorkspace(String, String),
     NoRootFoundInWorkspace(String),
     CrateTypeNotCompatible(String),
+    LanguageNotCompatible(String),
     CommandFailed(std::io::Error, &'static str),
     CommandError(&'static str, String, Vec<u8>),
     ParseTOML(toml::de::Error),
@@ -75,5 +78,8 @@ impl std::fmt::Display for CZFError {
         write!(f, "{:?}", self)
     }
 }
+
+// This is needed to make clap happy.
+impl Error for CZFError {}
 
 pub type CZFResult<T> = Result<T, CZFError>;

--- a/cargo-zenoh-flow/src/templates.rs
+++ b/cargo-zenoh-flow/src/templates.rs
@@ -225,12 +225,83 @@ fn register() -> ZFResult<Arc<dyn Sink>> \{
 
 "#;
 
+static PY_SINK_TEMPLATE: &str = r#"
+from zenoh_flow.interfaces import Sink
+from zenoh_flow.types import Context, DataMessage
+from typing import Any
+
+class {name}(Sink):
+    def initialize(self, configuration = dict) -> Any:
+        raise NotImplementedError("Please implement your own method")
+
+    def finalize(self, state: Any) -> None:
+        raise NotImplementedError("Please implement your own method")
+
+    def run(self, ctx : Context, state: Any, input: DataMessage) -> None:
+        raise NotImplementedError("Please implement your own method")
+
+
+def register():
+    return {name}
+
+"#;
+
+static PY_SRC_TEMPATE: &str = r#"
+from zenoh_flow.interface import Source
+from zenoh_flow.types import Context
+from typing import Any
+
+class {name}(Source):
+
+    def initialize(self, configuration: dict) -> Any:
+        raise NotImplementedError("Please implement your own method")
+
+    def finalize(self, state: Any) -> None:
+        raise NotImplementedError("Please implement your own method")
+
+    def run(self, context: Context, state: Any) -> bytes:
+        raise NotImplementedError("Please implement your own method")
+
+
+
+def register():
+    return {name}
+"#;
+
+static PY_OP_TEMPLATE: &str = r#"
+from zenoh_flow.interfaces import Operator
+from zenoh_flow.types import Context, InputToken, LocalDeadlineMiss, DataMessage
+from typing import Dict, Optional, Any
+
+class {name}(Operator):
+
+    def input_rule(self, context: Context, state : Any, tokens: Dict[str, InputToken]) -> bool:
+        raise NotImplementedError("Please implement your own method")
+
+    def output_rule(self, context: Context, state : Any, outputs : Dict[str, bytes] , deadline_miss: Optional[LocalDeadlineMiss] = None) -> Dict[str, bytes]:
+        raise NotImplementedError("Please implement your own method")
+
+    def run(self, context: Context, state : Any, inputs: Dict[str, DataMessage]) -> Dict[str, bytes]:
+        raise NotImplementedError("Please implement your own method")
+
+    def initialize(self, configuration: dict) -> Any:
+        raise NotImplementedError("Please implement your own method")
+
+    def finalize(self, state : Any) -> None:
+        raise NotImplementedError("Please implement your own method")
+
+
+def register():
+    return {name}
+"#;
+
 #[derive(Serialize)]
 struct OperatorContext {
     name: String,
 }
 
 fn some_kind_of_uppercase_first_letter(s: &str) -> String {
+    let s = str::replace(s, "-", "_");
     let mut c = s.chars();
     match c.next() {
         None => String::new(),
@@ -307,5 +378,44 @@ pub fn sink_template_cargo(name: String) -> CZFResult<String> {
     let ctx = OperatorContext { name };
 
     tt.render("sink", &ctx)
+        .map_err(|e| CZFError::GenericError(format!("{}", e)))
+}
+
+pub fn source_template_py(name: &str) -> CZFResult<String> {
+    let mut tt = TinyTemplate::new();
+    tt.add_template("source", PY_SRC_TEMPATE)
+        .map_err(|e| CZFError::GenericError(format!("{}", e)))?;
+
+    let ctx = OperatorContext {
+        name: some_kind_of_uppercase_first_letter(name),
+    };
+
+    tt.render("source", &ctx)
+        .map_err(|e| CZFError::GenericError(format!("{}", e)))
+}
+
+pub fn operator_template_py(name: &str) -> CZFResult<String> {
+    let mut tt = TinyTemplate::new();
+    tt.add_template("source", PY_OP_TEMPLATE)
+        .map_err(|e| CZFError::GenericError(format!("{}", e)))?;
+
+    let ctx = OperatorContext {
+        name: some_kind_of_uppercase_first_letter(name),
+    };
+
+    tt.render("source", &ctx)
+        .map_err(|e| CZFError::GenericError(format!("{}", e)))
+}
+
+pub fn sink_template_py(name: &str) -> CZFResult<String> {
+    let mut tt = TinyTemplate::new();
+    tt.add_template("source", PY_SINK_TEMPLATE)
+        .map_err(|e| CZFError::GenericError(format!("{}", e)))?;
+
+    let ctx = OperatorContext {
+        name: some_kind_of_uppercase_first_letter(name),
+    };
+
+    tt.render("source", &ctx)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))
 }

--- a/cargo-zenoh-flow/src/templates.rs
+++ b/cargo-zenoh-flow/src/templates.rs
@@ -69,8 +69,8 @@ use zenoh_flow::async_std::sync::Arc;
 use std::collections::HashMap;
 use zenoh_flow::zenoh_flow_derive::ZFState;
 use zenoh_flow::\{
-    default_input_rule, default_output_rule, downcast_mut, Node, NodeOutput, Data, Operator,
-    ZFResult, ZFState, PortId
+    default_input_rule, default_output_rule, Node, NodeOutput, Data, Operator,
+    ZFResult, ZFState, PortId, Configuration, State, LocalDeadlineMiss
 };
 
 #[derive(Debug)]
@@ -84,8 +84,8 @@ impl Operator for {name} \{
     fn input_rule(
         &self,
         _context: &mut zenoh_flow::Context,
-        state: &mut Box<dyn zenoh_flow::ZFState>,
-        tokens: &mut HashMap<PortId, zenoh_flow::Token>,
+        state: &mut State,
+        tokens: &mut HashMap<PortId, zenoh_flow::InputToken>,
     ) -> ZFResult<bool> \{
         default_input_rule(state, tokens)
     }
@@ -93,7 +93,7 @@ impl Operator for {name} \{
     fn run(
         &self,
         _context: &mut zenoh_flow::Context,
-        state: &mut Box<dyn zenoh_flow::ZFState>,
+        state: &mut State,
         inputs: &mut HashMap<PortId, zenoh_flow::runtime::message::DataMessage>,
     ) -> ZFResult<HashMap<PortId, Data>> \{
         todo!()
@@ -102,8 +102,9 @@ impl Operator for {name} \{
     fn output_rule(
         &self,
         _context: &mut zenoh_flow::Context,
-        state: &mut Box<dyn zenoh_flow::ZFState>,
+        state: &mut State,
         outputs: HashMap<PortId, Data>,
+        _deadlinemiss: Option<LocalDeadlineMiss>,
     ) -> ZFResult<HashMap<PortId, NodeOutput>> \{
         default_output_rule(state, outputs)
     }
@@ -112,8 +113,8 @@ impl Operator for {name} \{
 impl Node for {name} \{
     fn initialize(
         &self,
-        _configuration: &Option<HashMap<String, String>>,
-    ) -> Box<dyn zenoh_flow::ZFState> \{
+        _configuration: &Option<Configuration>,
+    ) -> ZFResult<State>  \{
         zenoh_flow::zf_empty_state!()
     }
 
@@ -136,8 +137,8 @@ use zenoh_flow::async_std::sync::Arc;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use zenoh_flow::zenoh_flow_derive::ZFState;
-use zenoh_flow::\{downcast_mut, Node, Data, Source,
-    ZFResult, ZFState, PortId
+use zenoh_flow::\{Node, Data, Source,
+    ZFResult, ZFState, PortId, Configuration, State
 };
 
 #[derive(Debug)]
@@ -148,7 +149,7 @@ impl Source for {name} \{
     async fn run(
         &self,
         _context: &mut zenoh_flow::Context,
-        state: &mut Box<dyn zenoh_flow::ZFState>,
+        state: &mut State,
     ) -> ZFResult<Data> \{
         todo!()
     }
@@ -159,8 +160,8 @@ impl Source for {name} \{
 impl Node for {name} \{
     fn initialize(
         &self,
-        _configuration: &Option<HashMap<String, String>>,
-    ) -> Box<dyn zenoh_flow::ZFState> \{
+        _configuration: &Option<Configuration>,
+    ) -> ZFResult<State>  \{
         zenoh_flow::zf_empty_state!()
     }
 
@@ -183,8 +184,8 @@ use zenoh_flow::async_std::sync::Arc;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use zenoh_flow::zenoh_flow_derive::ZFState;
-use zenoh_flow::\{downcast_mut, Node, Data, Sink,
-    ZFResult, ZFState, PortId
+use zenoh_flow::\{Node, Data, Sink,
+    ZFResult, ZFState, PortId, Configuration, State
 };
 
 #[derive(Debug)]
@@ -195,7 +196,7 @@ impl Sink for {name} \{
     async fn run(
         &self,
         _context: &mut zenoh_flow::Context,
-        state: &mut Box<dyn zenoh_flow::ZFState>,
+        state: &mut State,
         mut input: zenoh_flow::runtime::message::DataMessage,
     ) -> ZFResult<()> \{
         todo!()
@@ -206,8 +207,8 @@ impl Sink for {name} \{
 impl Node for {name} \{
     fn initialize(
         &self,
-        _configuration: &Option<HashMap<String, String>>,
-    ) -> Box<dyn zenoh_flow::ZFState> \{
+        _configuration: &Option<Configuration>,
+    ) -> ZFResult<State>  \{
         zenoh_flow::zf_empty_state!()
     }
 
@@ -314,7 +315,9 @@ pub fn operator_template_cargo(name: String) -> CZFResult<String> {
     tt.add_template("operator", CARGO_OPERATOR_TEMPLATE)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))?;
 
-    let ctx = OperatorContext { name };
+    let ctx = OperatorContext {
+        name: some_kind_of_uppercase_first_letter(&name),
+    };
 
     tt.render("operator", &ctx)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))
@@ -351,7 +354,9 @@ pub fn source_template_cargo(name: String) -> CZFResult<String> {
     tt.add_template("source", CARGO_SOURCE_TEMPLATE)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))?;
 
-    let ctx = OperatorContext { name };
+    let ctx = OperatorContext {
+        name: some_kind_of_uppercase_first_letter(&name),
+    };
 
     tt.render("source", &ctx)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))
@@ -375,7 +380,9 @@ pub fn sink_template_cargo(name: String) -> CZFResult<String> {
     tt.add_template("sink", CARGO_SINK_TEMPLATE)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))?;
 
-    let ctx = OperatorContext { name };
+    let ctx = OperatorContext {
+        name: some_kind_of_uppercase_first_letter(&name),
+    };
 
     tt.render("sink", &ctx)
         .map_err(|e| CZFError::GenericError(format!("{}", e)))

--- a/cargo-zenoh-flow/src/utils.rs
+++ b/cargo-zenoh-flow/src/utils.rs
@@ -243,15 +243,17 @@ pub async fn create_cpp_node(name: &str, kind: NodeKind) -> CZFResult<()> {
     drop(repo);
 
     // Removing .git directory;
-    async_std::fs::remove_dir(format!("{name}/.git")).await?;
+    async_std::fs::remove_dir_all(format!("{name}/.git")).await?;
 
     match kind {
         NodeKind::Operator => {
-            // Removing useless files
+            // Removing useless files and directories
             async_std::fs::remove_file(format!("{name}/src/sink.cpp")).await?;
             async_std::fs::remove_file(format!("{name}/src/source.cpp")).await?;
             async_std::fs::remove_file(format!("{name}/include/sink.hpp")).await?;
             async_std::fs::remove_file(format!("{name}/include/source.hpp")).await?;
+            async_std::fs::remove_dir_all(format!("{name}/vendor/source")).await?;
+            async_std::fs::remove_dir_all(format!("{name}/vendor/sink")).await?;
 
             // Creating cmake build directory
             async_std::fs::create_dir(format!("{name}/build"))
@@ -287,6 +289,8 @@ pub async fn create_cpp_node(name: &str, kind: NodeKind) -> CZFResult<()> {
             async_std::fs::remove_file(format!("{name}/src/operator.cpp")).await?;
             async_std::fs::remove_file(format!("{name}/include/sink.hpp")).await?;
             async_std::fs::remove_file(format!("{name}/include/operator.hpp")).await?;
+            async_std::fs::remove_dir_all(format!("{name}/vendor/operator")).await?;
+            async_std::fs::remove_dir_all(format!("{name}/vendor/sink")).await?;
 
             // Creating cmake build directory
             async_std::fs::create_dir(format!("{name}/build"))
@@ -322,6 +326,8 @@ pub async fn create_cpp_node(name: &str, kind: NodeKind) -> CZFResult<()> {
             async_std::fs::remove_file(format!("{name}/src/operator.cpp")).await?;
             async_std::fs::remove_file(format!("{name}/include/source.hpp")).await?;
             async_std::fs::remove_file(format!("{name}/include/operator.hpp")).await?;
+            async_std::fs::remove_dir_all(format!("{name}/vendor/source")).await?;
+            async_std::fs::remove_dir_all(format!("{name}/vendor/operator")).await?;
 
             // Creating cmake build directory
             async_std::fs::create_dir(format!("{name}/build"))

--- a/cargo-zenoh-flow/src/utils.rs
+++ b/cargo-zenoh-flow/src/utils.rs
@@ -209,6 +209,22 @@ pub async fn create_crate(name: &str, kind: NodeKind) -> CZFResult<()> {
     Ok(())
 }
 
+pub async fn create_python_module(name: &str, kind: NodeKind) -> CZFResult<()> {
+    async_std::fs::create_dir(name).await.map_err(|e| {
+        CZFError::GenericError(format!("Error when creating directory {:?} {:?}", name, e))
+    })?;
+
+    let node_template = match kind {
+        NodeKind::Operator => crate::templates::operator_template_py(name)?,
+        NodeKind::Sink => crate::templates::sink_template_py(name)?,
+        NodeKind::Source => crate::templates::source_template_py(name)?,
+    };
+
+    let filename = Path::new(name).join(format!("{name}.py"));
+
+    write_string_to_file(&filename, &node_template).await
+}
+
 pub async fn write_string_to_file(filename: &Path, content: &str) -> CZFResult<()> {
     let mut file = async_std::fs::File::create(filename).await.map_err(|e| {
         CZFError::GenericError(format!("Error when creating file {:?} {:?}", filename, e))


### PR DESCRIPTION
This PR extends `cargo zenoh-flow`, providing the possibility to generate boilerplates for **Python** and **C++** Zenoh Flow nodes.

This addresses #112 #111 

- [x] Python
- [x] C++