### PR TITLE
Fixing get_runtime_info_by_name function

### DIFF
--- a/zenoh-flow/src/runtime/resources.rs
+++ b/zenoh-flow/src/runtime/resources.rs
@@ -369,8 +369,13 @@ impl DataStore {
     /// - fails to deserialize
     pub async fn get_runtime_info_by_name(&self, rtid: &str) -> ZFResult<RuntimeInfo> {
         let selector = RT_INFO_PATH!(ROOT_STANDALONE, "*");
-
-        self.get_from_zenoh::<RuntimeInfo>(&selector).await
+        let rts = self.get_vec_from_zenoh::<RuntimeInfo>(&selector).await?;
+        for rt in &rts {
+            if *rt.name == *rtid {
+                return Ok(rt.clone());
+            }
+        }
+        Err(ZFError::NotFound)
     }
 
     /// Removes the information for the given runtime `rtid`.


### PR DESCRIPTION
This fixes an issue in the `get_runtime_info_by_name` function that instead of returning the correct `RuntimeInfo` returns the first one found in Zenoh 