### PR TITLE
feat: optionally toggle parts of a data flow using flags

### DIFF
--- a/zenoh-flow/src/model/dataflow/descriptor.rs
+++ b/zenoh-flow/src/model/dataflow/descriptor.rs
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use crate::model::dataflow::flag::Flag;
 use crate::model::dataflow::validator::DataflowValidator;
 use crate::model::deadline::E2EDeadlineDescriptor;
 use crate::model::link::LinkDescriptor;
@@ -91,6 +92,7 @@ pub struct DataFlowDescriptor {
     pub loops: Option<Vec<LoopDescriptor>>,
     #[serde(alias = "configuration")]
     pub global_configuration: Option<Configuration>,
+    pub flags: Option<Vec<Flag>>,
 }
 
 impl DataFlowDescriptor {

--- a/zenoh-flow/src/model/dataflow/flag.rs
+++ b/zenoh-flow/src/model/dataflow/flag.rs
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use crate::NodeId;
+use async_std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// A Flag is an optional structure to indicate which part(s) of a data flow to activate.
+///
+/// The YAML definition is as follow:
+///
+/// ```yaml
+/// flags:
+/// - id: my-flag
+///   toggle: true
+///   nodes:
+///   - A
+///   - B
+/// - id: my-second-flag
+///   toggle: false
+///   nodes:
+///   - B
+///   - C
+/// ```
+///
+/// This definition tells Zenoh-Flow to activate nodes A and B, and to deactivate node C.
+///
+/// Node A is activated because it is specified under the flag `my-flag` which is toggled. Although
+/// node B is present under the flag `my-second-flag` which is not toggled, as it is present under
+/// the flag `my-flag` that is toggled, Zenoh-Flow will activate it.
+///
+/// Node C is deactivated as it is present under the flag `my-second-flag` which is _not_ toggled.
+///
+/// **All the nodes that are not present under any flag are activated.**
+///
+/// Zenoh-Flow will ensure the validity of the toggled flags: if they mention a node that does not
+/// exist, an error is returned.
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Flag {
+    pub(crate) id: Arc<str>,
+    pub(crate) toggle: bool,
+    pub(crate) nodes: Vec<NodeId>,
+}
+
+/// Given a set of flags, return the list of nodes that should be "removed" (i.e. not activate).
+///
+/// The logic is:
+/// 1. if a flag is toggled, put it aside to be processed later,
+/// 2. if a flag is _not_ toggled, add all the nodes it indicates to the list of nodes to remove,
+/// 3. processing the toggled flags, remove the nodes that should be activated from the list.
+pub(crate) fn get_nodes_to_remove(flags: &[Flag]) -> HashSet<NodeId> {
+    let mut nodes = HashSet::new();
+    let mut flags_on = Vec::new();
+
+    for flag in flags {
+        if flag.toggle {
+            flags_on.push(flag);
+        } else {
+            nodes.extend(flag.nodes.iter().cloned());
+        }
+    }
+
+    flags_on.iter().for_each(|flag| {
+        flag.nodes.iter().for_each(|node| {
+            let _ = nodes.remove(node);
+        })
+    });
+
+    nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_nodes_to_remove() {
+        let flag1 = Flag {
+            id: "flag1".into(),
+            toggle: true,
+            nodes: vec!["A".into()],
+        };
+        let flag2 = Flag {
+            id: "flag2".into(),
+            toggle: false,
+            nodes: vec!["A".into(), "B".into(), "C".into()],
+        };
+        let flag3 = Flag {
+            id: "flag3".into(),
+            toggle: true,
+            nodes: vec!["C".into()],
+        };
+        let flag4 = Flag {
+            id: "flag4".into(),
+            toggle: false,
+            nodes: vec!["A".into(), "C".into()],
+        };
+
+        // Flag1 activates A.
+        // Flag2 deactivates A, B, C.
+        // Flag3 activates C.
+        // Flag4 deactivates A, C.
+        //
+        // The only node that should be deactivated is B.
+        assert_eq!(
+            get_nodes_to_remove(&[flag1, flag2, flag3, flag4]),
+            ["B".into()].into()
+        );
+    }
+}

--- a/zenoh-flow/src/model/dataflow/mod.rs
+++ b/zenoh-flow/src/model/dataflow/mod.rs
@@ -13,5 +13,6 @@
 //
 
 pub mod descriptor;
+pub mod flag;
 pub mod record;
 pub mod validator;

--- a/zenoh-flow/tests/validator.rs
+++ b/zenoh-flow/tests/validator.rs
@@ -1864,3 +1864,163 @@ fn validate_ko_egress_reused_as_ingress() {
         r
     )
 }
+
+/*
+ *
+ * Flags
+ *
+ */
+
+static DESCRIPTOR_OK_FLAGS: &str = r#"
+flow: DESCRIPTOR_OK_FLAGS
+
+flags:
+- id: flag-A
+  toggle: true
+  nodes:
+    - A
+- id: flag-B-C
+  toggle: false
+  nodes:
+    - B
+    - C
+
+sources:
+- id : Source
+  uri: file://./source.dylib
+  output:
+    id: out-Source
+    type: any
+
+operators:
+- id : A
+  uri: file://./A.dylib
+  inputs:
+    - id: in-A
+      type: any
+  outputs:
+    - id: out-A
+      type: any
+- id : B
+  uri: file://./B.dylib
+  inputs:
+    - id: in-B
+      type: any
+  outputs:
+    - id: out-B
+      type: any
+- id : C
+  uri: file://./C.dylib
+  inputs:
+    - id: in-C
+      type: any
+  outputs:
+    - id: out-C
+      type: any
+
+sinks:
+  - id : Sink
+    uri: file://./sink.dylib
+    input:
+      id: in-Sink
+      type: any
+
+links:
+# Flag: A
+- from:
+    node : Source
+    output : out-Source
+  to:
+    node : A
+    input : in-A
+- from:
+    node : A
+    output : out-A
+  to:
+    node : Sink
+    input : in-Sink
+# Flag: B-C
+- from:
+    node : Source
+    output : out-Source
+  to:
+    node : B
+    input : in-B
+- from:
+    node : B
+    output : out-B
+  to:
+    node : C
+    input : in-C
+- from:
+    node : C
+    output : out-C
+  to:
+    node : Sink
+    input : in-Sink
+"#;
+
+#[test]
+fn validate_ok_flags() {
+    let r = DataFlowDescriptor::from_yaml(DESCRIPTOR_OK_FLAGS);
+    assert!(r.is_ok(), "Expecting no error, have: {:?}", r)
+}
+
+static DESCRIPTOR_KO_FLAGS_NODE_NOT_FOUND: &str = r#"
+flow: DESCRIPTOR_KO_FLAGS_NODE_NOT_FOUND
+
+flags:
+- id: flag-A
+  toggle: true
+  nodes:
+    - A
+    - D
+
+sources:
+- id : Source
+  uri: file://./source.dylib
+  output:
+    id: out-Source
+    type: any
+
+operators:
+- id : A
+  uri: file://./A.dylib
+  inputs:
+    - id: in-A
+      type: any
+  outputs:
+    - id: out-A
+      type: any
+
+sinks:
+  - id : Sink
+    uri: file://./sink.dylib
+    input:
+      id: in-Sink
+      type: any
+
+links:
+- from:
+    node : Source
+    output : out-Source
+  to:
+    node : A
+    input : in-A
+- from:
+    node : A
+    output : out-A
+  to:
+    node : Sink
+    input : in-Sink
+"#;
+
+#[test]
+fn validate_ko_flags_node_not_found() {
+    let r = DataFlowDescriptor::from_yaml(DESCRIPTOR_KO_FLAGS_NODE_NOT_FOUND);
+    assert!(
+        r.is_err(),
+        "Expecting error 'Err(NodeNotFound(D))', have: {:?}",
+        r
+    )
+}


### PR DESCRIPTION
A flag allows user to specify which part of a data flow to activate or
deactivate by declaring a set of nodes.

Nodes that are not present under any flag are activated.

The validity of toggled flags is checked, raising an error if need be. For flags
that are not toggled, only a warning is emitted.