### PR TITLE
fix: get $HOME dir through crate `dirs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 # Output files
 outfile.png
 output.dot
+
+**/Makefile
+**/*.zfext
+**/.rustfmt.toml

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -31,6 +31,7 @@ async-std = { version = "=1.11.0", features = ["attributes"] }
 base64 = "0.13.0"
 clap = { version = "3.1", features = ["derive"] }
 derive_more = "0.99.10"
+# FIXME: Remove when `std::env::home_dir` gets fixed.
 dirs = "4.0.0"
 env_logger = "0.9.0"
 exitfailure = "0.5.1"

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -27,29 +27,30 @@ description = "Zenoh-Flow command line tool"
 readme = "README.md"
 
 [dependencies]
-zenoh-flow = {path = "../zenoh-flow"}
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
-zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
-zrpc = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
-znrpc-macros = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
 async-std = { version = "=1.11.0", features = ["attributes"] }
+base64 = "0.13.0"
 clap = { version = "3.1", features = ["derive"] }
+derive_more = "0.99.10"
+dirs = "4.0.0"
+env_logger = "0.9.0"
 exitfailure = "0.5.1"
 failure = "0.1.8"
-prettytable-rs = "^0.8"
-uuid = { version = "0.8.1", features = ["serde", "v4"] }
-base64 = "0.13.0"
-derive_more = "0.99.10"
-semver = { version = "1.0.4", features = ["serde"]}
-rand = "0.8.3"
-serde_derive = "1.0.55"
-serde = { version = "1.0.55", features = ["derive"] }
-serde_yaml = "0.8.13"
-serde_json = "1.0.55"
-serde-aux = "3.0.1"
-log = "0.4"
-env_logger = "0.9.0"
 git-version = "0.3.4"
+log = "0.4"
+prettytable-rs = "^0.8"
+rand = "0.8.3"
+semver = { version = "1.0.4", features = ["serde"]}
+serde = { version = "1.0.55", features = ["derive"] }
+serde-aux = "3.0.1"
+serde_derive = "1.0.55"
+serde_json = "1.0.55"
+serde_yaml = "0.8.13"
+uuid = { version = "0.8.1", features = ["serde", "v4"] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
+zenoh-flow = {path = "../zenoh-flow"}
+zenoh-util = { git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "master" }
+znrpc-macros = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
+zrpc = { git = "https://github.com/atolab/zenoh-rpc.git", branch = "master" }
 
 # Debian package configuration
 

--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -36,7 +36,7 @@ use zenoh_flow::runtime::resources::DataStore;
 use zenoh_flow::runtime::RuntimeClient;
 const GIT_VERSION: &str = git_version!(prefix = "v", cargo_prefix = "v");
 
-const DEFAULT_ZENOH_CFG: &str = "~/.config/zenoh-flow/zfctl-zenoh.json";
+const DEFAULT_ZENOH_CFG: &str = ".config/zenoh-flow/zfctl-zenoh.json";
 const ENV_ZENOH_CFG: &str = "ZFCTL_CFG";
 
 #[derive(Subcommand, Debug)]
@@ -573,9 +573,14 @@ async fn main() {
 }
 
 async fn get_zenoh() -> Result<Session, Box<dyn Error + Send + Sync + 'static>> {
-    let z_config_file = std::env::var(ENV_ZENOH_CFG)
-        .ok()
-        .unwrap_or_else(|| DEFAULT_ZENOH_CFG.to_string());
+    let z_config_file = std::env::var(ENV_ZENOH_CFG).ok().unwrap_or_else(|| {
+        let mut config_path = dirs::home_dir().expect("Could not get $HOME directory, aborting.");
+        config_path.push(DEFAULT_ZENOH_CFG);
+        config_path
+            .into_os_string()
+            .into_string()
+            .expect("Invalid unicode data found while trying to get `zftcl-zenoh.json`")
+    });
     let zconfig = zenoh::config::Config::from_file(z_config_file)?;
 
     Ok(zenoh::open(zconfig).await.unwrap())

--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -574,6 +574,7 @@ async fn main() {
 
 async fn get_zenoh() -> Result<Session, Box<dyn Error + Send + Sync + 'static>> {
     let z_config_file = std::env::var(ENV_ZENOH_CFG).ok().unwrap_or_else(|| {
+        // FIXME: Replace with `std::env::home_dir` when it gets fixed + remove dependency to dirs.
         let mut config_path = dirs::home_dir().expect("Could not get $HOME directory, aborting.");
         config_path.push(DEFAULT_ZENOH_CFG);
         config_path


### PR DESCRIPTION
Rust does not expand the `~` correctly. This commit leverages the `dirs` crate
to get it --- as recommended by the official documentation:
https://doc.rust-lang.org/std/env/fn.home_dir.html

(the dependencies in Cargo.toml were also sorted alphabetically)