### PR TITLE
Using Zenoh's Shared Memory Buffer

### DIFF
--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -39,8 +39,9 @@ use zenoh_flow::runtime::{
     DaemonInterface, DaemonInterfaceInternal, RuntimeConfig, RuntimeContext,
 };
 use zenoh_flow::types::ControlMessage;
+use zenoh_flow::utils::{deserialize_size, deserialize_time};
 use zenoh_flow::{
-    bail, DaemonResult, DEFAULT_SHM_ALLOCATION_BACKOFF_MS, DEFAULT_SHM_ELEMENT_SIZE,
+    bail, DaemonResult, DEFAULT_SHM_ALLOCATION_BACKOFF_NS, DEFAULT_SHM_ELEMENT_SIZE,
     DEFAULT_SHM_TOTAL_ELEMENTS,
 };
 use zrpc::ZServe;
@@ -71,10 +72,14 @@ pub struct DaemonConfig {
     /// The size of the worker pool.
     pub worker_pool_size: usize,
     /// The default size of the shared memory element.
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_size")]
     pub default_shared_memory_element_size: Option<usize>,
     /// The default number of the shared memory elements.
     pub default_shared_memory_elements: Option<usize>,
     /// The default backoff when shared memory elements are not available.
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_time")]
     pub default_shared_memory_backoff: Option<u64>,
 }
 
@@ -294,7 +299,7 @@ impl Daemon {
                 .unwrap_or(DEFAULT_SHM_TOTAL_ELEMENTS as usize),
             shared_memory_backoff: config
                 .default_shared_memory_backoff
-                .unwrap_or(DEFAULT_SHM_ALLOCATION_BACKOFF_MS),
+                .unwrap_or(DEFAULT_SHM_ALLOCATION_BACKOFF_NS),
         };
 
         Ok(Self::new(z, ctx, rt_config, pool_size))

--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -39,7 +39,10 @@ use zenoh_flow::runtime::{
     DaemonInterface, DaemonInterfaceInternal, RuntimeConfig, RuntimeContext,
 };
 use zenoh_flow::types::ControlMessage;
-use zenoh_flow::{bail, DaemonResult};
+use zenoh_flow::{
+    bail, DaemonResult, DEFAULT_SHM_ALLOCATION_BACKOFF_MS, DEFAULT_SHM_ELEMENT_SIZE,
+    DEFAULT_SHM_TOTAL_ELEMENTS,
+};
 use zrpc::ZServe;
 use zrpc_macros::zserver;
 
@@ -67,6 +70,12 @@ pub struct DaemonConfig {
     pub extensions: String,
     /// The size of the worker pool.
     pub worker_pool_size: usize,
+    /// The default size of the shared memory element.
+    pub default_shared_memory_element_size: Option<usize>,
+    /// The default number of the shared memory elements.
+    pub default_shared_memory_elements: Option<usize>,
+    /// The default backoff when shared memory elements are not available.
+    pub default_shared_memory_backoff: Option<u64>,
 }
 
 /// The Zenoh flow daemon
@@ -277,6 +286,15 @@ impl Daemon {
             loader,
             runtime_name: rt_config.name.clone().into(),
             runtime_uuid: uuid,
+            shared_memory_element_size: config
+                .default_shared_memory_element_size
+                .unwrap_or(DEFAULT_SHM_ELEMENT_SIZE as usize),
+            shared_memory_elements: config
+                .default_shared_memory_elements
+                .unwrap_or(DEFAULT_SHM_TOTAL_ELEMENTS as usize),
+            shared_memory_backoff: config
+                .default_shared_memory_backoff
+                .unwrap_or(DEFAULT_SHM_ALLOCATION_BACKOFF_MS),
         };
 
         Ok(Self::new(z, ctx, rt_config, pool_size))

--- a/zenoh-flow-daemon/tests/configuration.rs
+++ b/zenoh-flow-daemon/tests/configuration.rs
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use zenoh_flow_daemon::daemon::DaemonConfig;
+
+static EXAMPLE_OK_CONFIG: &str = r#"
+---
+    pid_file : /var/zenoh-flow/runtime.pid
+    path : /etc/zenoh-flow
+    extensions: /etc/zenoh-flow/extensions.d
+    zenoh_config: /etc/zenoh-flow/zenoh-daemon.json
+    worker_pool_size: 4
+    default_shared_memory_element_size: 10KiB
+    default_shared_memory_elements: 10
+    default_shared_memory_backoff: 100us
+"#;
+
+#[test]
+fn daemon_configuration_ok() {
+    let _ = env_logger::try_init();
+
+    let deserialized_config: Result<DaemonConfig, serde_yaml::Error> =
+        serde_yaml::from_str(EXAMPLE_OK_CONFIG);
+
+    assert!(deserialized_config.is_ok());
+
+    let deserialized_config = deserialized_config.unwrap();
+
+    assert_eq!(
+        deserialized_config.pid_file,
+        "/var/zenoh-flow/runtime.pid".to_string()
+    );
+    assert_eq!(deserialized_config.path, "/etc/zenoh-flow".to_string());
+    assert_eq!(
+        deserialized_config.extensions,
+        "/etc/zenoh-flow/extensions.d".to_string()
+    );
+
+    assert!(deserialized_config.zenoh_config.is_some());
+    assert_eq!(
+        deserialized_config.zenoh_config.unwrap(),
+        "/etc/zenoh-flow/zenoh-daemon.json".to_string()
+    );
+
+    assert_eq!(deserialized_config.worker_pool_size, 4);
+
+    assert!(deserialized_config
+        .default_shared_memory_element_size
+        .is_some());
+    assert_eq!(
+        deserialized_config
+            .default_shared_memory_element_size
+            .unwrap(),
+        10240
+    );
+
+    assert!(deserialized_config.default_shared_memory_elements.is_some());
+    assert_eq!(
+        deserialized_config.default_shared_memory_elements.unwrap(),
+        10
+    );
+
+    assert!(deserialized_config.default_shared_memory_backoff.is_some());
+    assert_eq!(
+        deserialized_config.default_shared_memory_backoff.unwrap(),
+        100_000
+    );
+}
+
+static EXAMPLE_KO_CONFIG: &str = r#"
+---
+    pid_file : /var/zenoh-flow/runtime.pid
+    uuid: 123,
+    path : /etc/zenoh-flow
+    extensions: /etc/zenoh-flow/extensions.d
+    zenoh_config: /etc/zenoh-flow/zenoh-daemon.json
+    worker_pool_size: 4
+"#;
+
+#[test]
+fn daemon_configuration_ko() {
+    let _ = env_logger::try_init();
+
+    let deserialized_config: Result<DaemonConfig, serde_yaml::Error> =
+        serde_yaml::from_str(EXAMPLE_KO_CONFIG);
+
+    assert!(deserialized_config.is_err());
+}

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -58,7 +58,7 @@ typetag = "0.2"
 uhlc = "0.5.1"
 url = "2.2"
 uuid = { version = "1.1", features = ["serde", "v4"] }
-zenoh = { version = "=0.7.0-rc" }
+zenoh = { version = "=0.7.0-rc", features = ["shared-memory"]}
 zenoh-flow-derive = {version = "=0.5.0-dev", path = "../zenoh-flow-derive"}
 zenoh-sync = { version = "=0.7.0-rc" }
 zenoh-util = { version = "=0.7.0-rc" }

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -32,6 +32,7 @@ async-std = { version = "=1.12.0", features = ["attributes"] }
 async-trait = "0.1.50"
 base64 = "0.20.0"
 bincode = { version = "1.3"}
+bytesize = "1.2.0"
 clap = { version = "4.0", features = ["derive"] }
 const_format = "0.2.22"
 derive_more = "0.99.10"
@@ -41,6 +42,7 @@ flume = "0.10"
 futures = "0.3.15"
 futures-lite = "1.12"
 git-version = "0.3"
+humantime = "2.1.0"
 itertools = "0.10.3"
 libloading = "0.7.0"
 log = "0.4"

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -74,10 +74,10 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const FULL_VERSION: &str = formatcp!("{}-{}", VERSION, GIT_VERSION);
 
 /// Default Shared Memory size (10MiB).
-static DEFAULT_SHM_ELEMENT_SIZE: u64 = 10_485_760;
+pub static DEFAULT_SHM_ELEMENT_SIZE: u64 = 10_485_760;
 
 /// Default Shared Memory elements (10).
-static DEFAULT_SHM_TOTAL_ELEMENTS: u64 = 10;
+pub static DEFAULT_SHM_TOTAL_ELEMENTS: u64 = 10;
 
 /// Default Shared allocation backoff time (100ms)
-static DEFAULT_SHM_ALLOCATION_BACKOFF_MS: u64 = 100;
+pub static DEFAULT_SHM_ALLOCATION_BACKOFF_MS: u64 = 100;

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -72,3 +72,12 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Complete string with the Zenoh Flow version, including commit id.
 pub const FULL_VERSION: &str = formatcp!("{}-{}", VERSION, GIT_VERSION);
+
+/// Default Shared Memory size (10MiB).
+static DEFAULT_SHM_ELEMENT_SIZE: u64 = 10_485_760;
+
+/// Default Shared Memory elements (10).
+static DEFAULT_SHM_TOTAL_ELEMENTS: u64 = 10;
+
+/// Default Shared allocation backoff time (100ms)
+static DEFAULT_SHM_ALLOCATION_BACKOFF_MS: u64 = 100;

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -46,7 +46,7 @@ pub mod traits;
 pub mod types;
 pub mod zfdata;
 
-pub(crate) mod utils;
+pub mod utils;
 pub mod zfresult;
 
 pub use anyhow::anyhow;
@@ -80,4 +80,4 @@ pub static DEFAULT_SHM_ELEMENT_SIZE: u64 = 10_485_760;
 pub static DEFAULT_SHM_TOTAL_ELEMENTS: u64 = 10;
 
 /// Default Shared allocation backoff time (100ms)
-pub static DEFAULT_SHM_ALLOCATION_BACKOFF_MS: u64 = 100;
+pub static DEFAULT_SHM_ALLOCATION_BACKOFF_NS: u64 = 100_000_000;

--- a/zenoh-flow/src/model/descriptor/link.rs
+++ b/zenoh-flow/src/model/descriptor/link.rs
@@ -13,6 +13,7 @@
 //
 
 use crate::types::{NodeId, PortId};
+use crate::utils::{deserialize_size, deserialize_time};
 use serde::{Deserialize, Serialize};
 use std::{fmt, sync::Arc};
 
@@ -34,8 +35,12 @@ use std::{fmt, sync::Arc};
 pub struct LinkDescriptor {
     pub from: OutputDescriptor,
     pub to: InputDescriptor,
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_size")]
     pub shared_memory_element_size: Option<usize>,
     pub shared_memory_elements: Option<usize>,
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_time")]
     pub shared_memory_backoff: Option<u64>,
 }
 

--- a/zenoh-flow/src/model/descriptor/link.rs
+++ b/zenoh-flow/src/model/descriptor/link.rs
@@ -34,9 +34,9 @@ use std::{fmt, sync::Arc};
 pub struct LinkDescriptor {
     pub from: OutputDescriptor,
     pub to: InputDescriptor,
-    pub size: Option<usize>,
-    pub queueing_policy: Option<String>,
-    pub priority: Option<usize>,
+    pub shared_memory_element_size: Option<usize>,
+    pub shared_memory_elements: Option<usize>,
+    pub shared_memory_backoff: Option<u64>,
 }
 
 impl std::fmt::Display for LinkDescriptor {
@@ -50,9 +50,9 @@ impl LinkDescriptor {
         Self {
             from,
             to,
-            size: None,
-            queueing_policy: None,
-            priority: None,
+            shared_memory_element_size: None,
+            shared_memory_elements: None,
+            shared_memory_backoff: None,
         }
     }
 }

--- a/zenoh-flow/src/model/record/connector.rs
+++ b/zenoh-flow/src/model/record/connector.rs
@@ -40,6 +40,9 @@ pub struct ZFConnectorRecord {
     pub resource: String,
     pub link_id: PortRecord,
     pub runtime: RuntimeId,
+    pub shared_memory_element_size: Option<usize>,
+    pub shared_memory_elements: Option<usize>,
+    pub shared_memory_backoff: Option<u64>,
 }
 
 impl std::fmt::Display for ZFConnectorRecord {

--- a/zenoh-flow/src/model/record/dataflow.rs
+++ b/zenoh-flow/src/model/record/dataflow.rs
@@ -207,7 +207,9 @@ impl DataFlowRecord {
                             uid: self.counter,
                             port_id: l.from.output.clone(),
                         },
-
+                        shared_memory_element_size: l.shared_memory_element_size,
+                        shared_memory_elements: l.shared_memory_elements,
+                        shared_memory_backoff: l.shared_memory_backoff,
                         runtime: from_runtime,
                     };
                     self.counter += 1;
@@ -219,9 +221,9 @@ impl DataFlowRecord {
                             node: sender_id.clone(),
                             input: l.from.output.clone(),
                         },
-                        size: None,
-                        queueing_policy: None,
-                        priority: None,
+                        shared_memory_element_size: l.shared_memory_element_size,
+                        shared_memory_elements: l.shared_memory_elements,
+                        shared_memory_backoff: l.shared_memory_backoff,
                     };
 
                     // storing info in the dataflow record
@@ -244,7 +246,9 @@ impl DataFlowRecord {
                         uid: self.counter,
                         port_id: l.to.input.clone(),
                     },
-
+                    shared_memory_element_size: l.shared_memory_element_size,
+                    shared_memory_elements: l.shared_memory_elements,
+                    shared_memory_backoff: l.shared_memory_backoff,
                     runtime: to_runtime,
                 };
                 self.counter += 1;
@@ -256,9 +260,9 @@ impl DataFlowRecord {
                         output: l.to.input.clone(),
                     },
                     to: l.to.clone(),
-                    size: None,
-                    queueing_policy: None,
-                    priority: None,
+                    shared_memory_element_size: l.shared_memory_element_size,
+                    shared_memory_elements: l.shared_memory_elements,
+                    shared_memory_backoff: l.shared_memory_backoff,
                 };
 
                 // storing info in the data flow record

--- a/zenoh-flow/src/model/record/link.rs
+++ b/zenoh-flow/src/model/record/link.rs
@@ -35,9 +35,9 @@ pub struct LinkRecord {
     pub uid: u32,
     pub from: OutputDescriptor,
     pub to: InputDescriptor,
-    pub size: Option<usize>,
-    pub queueing_policy: Option<String>,
-    pub priority: Option<usize>,
+    pub shared_memory_element_size: Option<usize>,
+    pub shared_memory_elements: Option<usize>,
+    pub shared_memory_backoff: Option<u64>,
 }
 
 impl std::fmt::Display for LinkRecord {
@@ -54,9 +54,9 @@ impl From<(LinkDescriptor, u32)> for LinkRecord {
             uid,
             from: desc.from,
             to: desc.to,
-            size: desc.size,
-            queueing_policy: desc.queueing_policy,
-            priority: desc.priority,
+            shared_memory_element_size: desc.shared_memory_element_size,
+            shared_memory_elements: desc.shared_memory_elements,
+            shared_memory_backoff: desc.shared_memory_backoff,
         }
     }
 }

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -420,7 +420,7 @@ impl<'a> Node for ZenohSink<'a> {
                 let mut buff = match shm.alloc(self.shm_size) {
                     Ok(buf) => buf,
                     Err(_) => {
-                        async_std::task::sleep(std::time::Duration::from_millis(self.shm_backoff))
+                        async_std::task::sleep(std::time::Duration::from_nanos(self.shm_backoff))
                             .await;
                         log::trace!(
                             "After failing allocation the GC collected: {} bytes -- retrying",

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -123,16 +123,20 @@ impl<'a> Source for ZenohSource<'a> {
 
         match configuration {
             Some(configuration) => {
-                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| zferror!(
-                    ErrorKind::ConfigurationError,
-                    "Missing key-expressions in builtin sink configuration"
-                ))?;
+                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| {
+                    zferror!(
+                        ErrorKind::ConfigurationError,
+                        "Missing key-expressions in builtin sink configuration"
+                    )
+                })?;
 
-                let keyexpressions = keyexpressions.as_object().ok_or_else(|| zferror!(
-                    ErrorKind::ConfigurationError,
-                    "Unable to convert configuration to HashMap: {:?}",
-                    configuration
-                ))?;
+                let keyexpressions = keyexpressions.as_object().ok_or_else(|| {
+                    zferror!(
+                        ErrorKind::ConfigurationError,
+                        "Unable to convert configuration to HashMap: {:?}",
+                        configuration
+                    )
+                })?;
 
                 for (id, value) in keyexpressions {
                     let ke = value
@@ -330,16 +334,20 @@ impl<'a> Sink for ZenohSink<'a> {
 
                 let shm_size = shm_elem_size * shm_elem_count;
 
-                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| zferror!(
-                    ErrorKind::ConfigurationError,
-                    "Missing key-expressions in builtin sink configuration"
-                ))?;
+                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| {
+                    zferror!(
+                        ErrorKind::ConfigurationError,
+                        "Missing key-expressions in builtin sink configuration"
+                    )
+                })?;
 
-                let keyexpressions = keyexpressions.as_object().ok_or_else(|| zferror!(
-                    ErrorKind::ConfigurationError,
-                    "Unable to convert configuration to HashMap: {:?}",
-                    configuration
-                ))?;
+                let keyexpressions = keyexpressions.as_object().ok_or_else(|| {
+                    zferror!(
+                        ErrorKind::ConfigurationError,
+                        "Unable to convert configuration to HashMap: {:?}",
+                        configuration
+                    )
+                })?;
 
                 for (id, value) in keyexpressions {
                     let ke = value
@@ -414,10 +422,9 @@ impl<'a> Node for ZenohSink<'a> {
                 let data = dm.get_inner_data().try_as_bytes()?;
 
                 // Getting publisher
-                let publisher = self.publishers.get(&id).ok_or_else(|| zferror!(
-                    ErrorKind::SendError,
-                    "Unable to find Publisher for {id}"
-                ))?;
+                let publisher = self.publishers.get(&id).ok_or_else(|| {
+                    zferror!(ErrorKind::SendError, "Unable to find Publisher for {id}")
+                })?;
 
                 // Getting the shared memory buffer
                 let mut buff = match shm.alloc(self.shm_element_size) {

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -123,12 +123,12 @@ impl<'a> Source for ZenohSource<'a> {
 
         match configuration {
             Some(configuration) => {
-                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or(zferror!(
+                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| zferror!(
                     ErrorKind::ConfigurationError,
                     "Missing key-expressions in builtin sink configuration"
                 ))?;
 
-                let keyexpressions = keyexpressions.as_object().ok_or(zferror!(
+                let keyexpressions = keyexpressions.as_object().ok_or_else(|| zferror!(
                     ErrorKind::ConfigurationError,
                     "Unable to convert configuration to HashMap: {:?}",
                     configuration
@@ -301,7 +301,7 @@ impl<'a> Sink for ZenohSink<'a> {
         let id = uuid::Uuid::new_v4().to_string();
         match configuration {
             Some(configuration) => {
-                let get_or_default = |configuration : &serde_json::Value, key, default| {
+                let get_or_default = |configuration: &serde_json::Value, key, default| {
                     if let Some(value) = configuration.get(key) {
                         if let Some(value) = value.as_u64() {
                             return value;
@@ -330,12 +330,12 @@ impl<'a> Sink for ZenohSink<'a> {
 
                 let shm_size = shm_elem_size * shm_elem_count;
 
-                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or(zferror!(
+                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| zferror!(
                     ErrorKind::ConfigurationError,
                     "Missing key-expressions in builtin sink configuration"
                 ))?;
 
-                let keyexpressions = keyexpressions.as_object().ok_or(zferror!(
+                let keyexpressions = keyexpressions.as_object().ok_or_else(|| zferror!(
                     ErrorKind::ConfigurationError,
                     "Unable to convert configuration to HashMap: {:?}",
                     configuration
@@ -414,7 +414,7 @@ impl<'a> Node for ZenohSink<'a> {
                 let data = dm.get_inner_data().try_as_bytes()?;
 
                 // Getting publisher
-                let publisher = self.publishers.get(&id).ok_or(zferror!(
+                let publisher = self.publishers.get(&id).ok_or_else(|| zferror!(
                     ErrorKind::SendError,
                     "Unable to find Publisher for {id}"
                 ))?;
@@ -481,3 +481,4 @@ impl<'a> Node for ZenohSink<'a> {
 
         Ok(())
     }
+}

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -24,8 +24,7 @@ use crate::{
         node::{SinkFn, SourceFn},
     },
     types::LinkMessage,
-    Result as ZFResult, DEFAULT_SHM_ALLOCATION_BACKOFF_MS, DEFAULT_SHM_ELEMENT_SIZE,
-    DEFAULT_SHM_TOTAL_ELEMENTS,
+    Result as ZFResult,
 };
 use async_std::sync::Mutex;
 use async_trait::async_trait;
@@ -304,25 +303,29 @@ impl<'a> Sink for ZenohSink<'a> {
             Some(configuration) => {
                 let shm_elem_size = configuration
                     .get(KEY_SHM_ELEM_SIZE)
-                    .unwrap_or(&serde_json::Value::from(DEFAULT_SHM_ELEMENT_SIZE))
+                    .unwrap_or(&serde_json::Value::from(
+                        *context.shared_memory_element_size() as u64,
+                    ))
                     .as_u64()
-                    .unwrap_or(DEFAULT_SHM_ELEMENT_SIZE)
+                    .unwrap_or(*context.shared_memory_element_size() as u64)
                     as usize;
 
                 let shm_elem_count = configuration
                     .get(KEY_SHM_TOTAL_ELEMENTS)
-                    .unwrap_or(&serde_json::Value::from(DEFAULT_SHM_TOTAL_ELEMENTS))
+                    .unwrap_or(&serde_json::Value::from(
+                        *context.shared_memory_elements() as u64
+                    ))
                     .as_u64()
-                    .unwrap_or(DEFAULT_SHM_TOTAL_ELEMENTS)
+                    .unwrap_or(*context.shared_memory_elements() as u64)
                     as usize;
 
                 let shm_size = shm_elem_size * shm_elem_count;
 
                 let shm_backoff = configuration
                     .get(KEY_SHM_BACKOFF)
-                    .unwrap_or(&serde_json::Value::from(DEFAULT_SHM_ALLOCATION_BACKOFF_MS))
+                    .unwrap_or(&serde_json::Value::from(*context.shared_memory_backoff()))
                     .as_u64()
-                    .unwrap_or(DEFAULT_SHM_ALLOCATION_BACKOFF_MS);
+                    .unwrap_or(*context.shared_memory_backoff());
 
                 let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or(zferror!(
                     ErrorKind::ConfigurationError,

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -37,6 +37,8 @@ use zenoh::buffers::SharedMemoryManager;
 use zenoh::{prelude::r#async::*, publication::Publisher, subscriber::Subscriber};
 
 static DEFAULT_SHM_SIZE_MB: u64 = 10_485_760; //10MiB
+static KEY_KEYEXPRESSIONS: &str = "key-expressions";
+static KEY_SHM_SIZE: &str = "shared_memory_size";
 
 /// Internal type of pending futures for the ZenohSource
 pub(crate) type ZSubFut =
@@ -112,7 +114,7 @@ impl<'a> Source for ZenohSource<'a> {
 
         match configuration {
             Some(configuration) => {
-                let keyexpressions = configuration.get("key-expressions").ok_or(zferror!(
+                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or(zferror!(
                     ErrorKind::ConfigurationError,
                     "Missing key-expressions in builtin sink configuration"
                 ))?;
@@ -290,12 +292,12 @@ impl<'a> Sink for ZenohSink<'a> {
         match configuration {
             Some(configuration) => {
                 let shm_size = configuration
-                    .get("shared_memory_size")
+                    .get(KEY_SHM_SIZE)
                     .unwrap_or(&serde_json::Value::from(DEFAULT_SHM_SIZE_MB))
                     .as_u64()
                     .unwrap_or(DEFAULT_SHM_SIZE_MB) as usize;
 
-                let keyexpressions = configuration.get("key-expressions").ok_or(zferror!(
+                let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or(zferror!(
                     ErrorKind::ConfigurationError,
                     "Missing key-expressions in builtin sink configuration"
                 ))?;

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -467,7 +467,7 @@ impl<'a> Node for ZenohSink<'a> {
                     publisher.put(buff).res().await?;
                 } else {
                     publisher.put(&**data).res().await?;
-                    log::warn!("[ZenohSink] Sending data via network, has we are unable to send it over shared memory, the serialized size is {} while shared memory is {}", data_len, self.shm_element_size);
+                    log::warn!("[ZenohSink] Sending data via network as we are unable to send it over shared memory, the serialized size is {} while shared memory is {}", data_len, self.shm_element_size);
                 }
             }
             Ok(_) => (), // Not the right message, ignore it.

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -31,7 +31,11 @@ use zenoh::prelude::r#async::*;
 use zenoh::subscriber::Subscriber;
 use zenoh_util::core::AsyncResolve;
 
-static DEFAULT_SHM_SIZE_MB: usize = 10_485_760; //10MiB
+/// Default Shared Memory size (10MiB)
+static DEFAULT_SHM_SIZE: usize = 10_485_760;
+
+/// Default Shared allocation backoff time (100ms)
+static SHM_ALLOCATION_BACKOFF_MS: u64 = 100;
 
 /// The `ZenohSender` is the connector that sends the data to Zenoh when nodes are running on
 /// different runtimes.
@@ -83,11 +87,11 @@ impl ZenohSender {
             z_session: session.clone(),
             key_expr,
             shm: Arc::new(Mutex::new(
-                SharedMemoryManager::make(record.resource.clone(), DEFAULT_SHM_SIZE_MB).map_err(
+                SharedMemoryManager::make(record.resource.clone(), DEFAULT_SHM_SIZE).map_err(
                     |_| {
                         zferror!(
                             ErrorKind::ConfigurationError,
-                            "Unable to allocate {DEFAULT_SHM_SIZE_MB} bytes of shared memory"
+                            "Unable to allocate {DEFAULT_SHM_SIZE} bytes of shared memory"
                         )
                     },
                 )?,
@@ -112,14 +116,14 @@ impl Node for ZenohSender {
         let mut shm = self.shm.lock().await;
         match self.input_raw.recv().await {
             Ok(message) => {
-                // Serializing
-                let serialized = message.serialize_bincode()?;
-
                 // Getting the shared memory buffer
-                let mut buff = match shm.alloc(DEFAULT_SHM_SIZE_MB) {
+                let mut buff = match shm.alloc(DEFAULT_SHM_SIZE) {
                     Ok(buf) => buf,
                     Err(_) => {
-                        async_std::task::sleep(std::time::Duration::from_millis(100)).await;
+                        async_std::task::sleep(std::time::Duration::from_millis(
+                            SHM_ALLOCATION_BACKOFF_MS,
+                        ))
+                        .await;
                         log::trace!(
                             "After failing allocation the GC collected: {} bytes -- retrying",
                             shm.garbage_collect()
@@ -128,10 +132,10 @@ impl Node for ZenohSender {
                             "Trying to de-fragment memory... De-fragmented {} bytes",
                             shm.defragment()
                         );
-                        shm.alloc(DEFAULT_SHM_SIZE_MB).map_err(|_| {
+                        shm.alloc(DEFAULT_SHM_SIZE).map_err(|_| {
                             zferror!(
                                 ErrorKind::ConfigurationError,
-                                "Unable to allocated {DEFAULT_SHM_SIZE_MB} in the shared memory buffer!"
+                                "Unable to allocated {DEFAULT_SHM_SIZE} in the shared memory buffer!"
                             )
                         })?
                     }
@@ -141,11 +145,9 @@ impl Node for ZenohSender {
                 let slice = unsafe { buff.as_mut_slice() };
 
                 // WARNING ACHTUNG ATTENTION
-                // We are coping memory here!
-                // we should be able to serialize directly in the shared
-                // memory buffer.
-                let data_len = serialized.len();
-                slice[0..data_len].copy_from_slice(&serialized);
+                // This may fail as the message could be bigger than
+                // the shared memory buffer that was allocated.
+                message.serialize_bincode_into(slice)?;
 
                 self.z_session
                     .put(self.key_expr.clone(), buff)

--- a/zenoh-flow/src/runtime/dataflow/mod.rs
+++ b/zenoh-flow/src/runtime/dataflow/mod.rs
@@ -118,9 +118,9 @@ impl DataFlow {
             uid: self.counter,
             from,
             to,
-            size: None,
-            queueing_policy: None,
-            priority: None,
+            shared_memory_element_size: None,
+            shared_memory_elements: None,
+            shared_memory_backoff: None,
         });
         self.counter += 1;
     }

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -50,6 +50,9 @@ pub struct RuntimeContext {
     pub hlc: Arc<HLC>,
     pub runtime_name: RuntimeId,
     pub runtime_uuid: Uuid,
+    pub shared_memory_element_size: usize,
+    pub shared_memory_elements: usize,
+    pub shared_memory_backoff: u64,
 }
 
 /// The context of a Zenoh Flow graph instance.

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -24,7 +24,7 @@ use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::types::{Configuration, Context, LinkMessage, Message};
 use zenoh_flow::{
-    prelude::*, DEFAULT_SHM_ALLOCATION_BACKOFF_MS, DEFAULT_SHM_ELEMENT_SIZE,
+    prelude::*, DEFAULT_SHM_ALLOCATION_BACKOFF_NS, DEFAULT_SHM_ELEMENT_SIZE,
     DEFAULT_SHM_TOTAL_ELEMENTS,
 };
 
@@ -251,7 +251,7 @@ async fn single_runtime() {
         runtime_uuid: rt_uuid,
         shared_memory_element_size: DEFAULT_SHM_ELEMENT_SIZE as usize,
         shared_memory_elements: DEFAULT_SHM_TOTAL_ELEMENTS as usize,
-        shared_memory_backoff: DEFAULT_SHM_ALLOCATION_BACKOFF_MS,
+        shared_memory_backoff: DEFAULT_SHM_ALLOCATION_BACKOFF_NS,
     };
 
     let mut dataflow = zenoh_flow::runtime::dataflow::DataFlow::new("test", ctx.clone());

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -19,11 +19,14 @@ use zenoh::prelude::r#async::*;
 use zenoh_flow::io::{Inputs, Outputs};
 use zenoh_flow::model::descriptor::{InputDescriptor, OutputDescriptor};
 use zenoh_flow::model::record::{OperatorRecord, PortRecord, SinkRecord, SourceRecord};
-use zenoh_flow::prelude::*;
 use zenoh_flow::runtime::dataflow::instance::DataFlowInstance;
 use zenoh_flow::runtime::dataflow::loader::{Loader, LoaderConfig};
 use zenoh_flow::runtime::RuntimeContext;
 use zenoh_flow::types::{Configuration, Context, LinkMessage, Message};
+use zenoh_flow::{
+    prelude::*, DEFAULT_SHM_ALLOCATION_BACKOFF_MS, DEFAULT_SHM_ELEMENT_SIZE,
+    DEFAULT_SHM_TOTAL_ELEMENTS,
+};
 
 static SOURCE: &str = "counter-source";
 static OP_RAW: &str = "operator-raw";
@@ -246,6 +249,9 @@ async fn single_runtime() {
         loader: Arc::new(Loader::new(LoaderConfig::new())),
         runtime_name: runtime_name.clone(),
         runtime_uuid: rt_uuid,
+        shared_memory_element_size: DEFAULT_SHM_ELEMENT_SIZE as usize,
+        shared_memory_elements: DEFAULT_SHM_TOTAL_ELEMENTS as usize,
+        shared_memory_backoff: DEFAULT_SHM_ALLOCATION_BACKOFF_MS,
     };
 
     let mut dataflow = zenoh_flow::runtime::dataflow::DataFlow::new("test", ctx.clone());


### PR DESCRIPTION
Currently, Zenoh-Flow connectors and built-in Zenoh Sinks do not use the Shared Memory transport of zenoh. 
Using it means exposing some configuration to users, as the Shared Memory has to be allocated and there is no one-size-fits-them-all that we can automatically use when allocating it.

To this extent, the proposal for connectors (the internal components automatically do the zenoh connection when things are on different runtimes) and one for the built-in sink.

# Connector

The connectors are the components that take care of sending user-plane data between two nodes, of the same flow, running on two different runtimes. Connectors are generated automatically by Zenoh Flow when instantiating the graph.

When using shared memory this connector, the one on sending side, must allocate a shared memory area where data is serialized and sent over zenoh to the receiving connector.

In order to do so the connector needs to have a configurable size for this memory.

### Connectors

Configuration within the runtime configuration, used for default values.

```yaml
---
    pid_file : /var/zenoh-flow/runtime.pid
    path : /etc/zenoh-flow
    extensions: /etc/zenoh-flow/extensions.d
    zenoh_config: /etc/zenoh-flow/zenoh-daemon.json
    worker_pool_size: 4
    default_shared_memory_element_size: 10MiB
    default_shared_memory_elements: 10
    default_shared_memory_backoff: 100ms

```

And Configuration within the link descriptor is used only when specified

```yaml
from:
   node : Counter
   output : Counter
to:
   node : SumOperator
   input : Number
shared_memory_element_size: 10MiB
shared_memory_elements: 10
shared_memory_backoff: 100ms

```
The configuration of the connector overwrites the one from the runtime.


# Built-in sink

While for the built-in sink, the configuration can be part of the configuration dictionary

```yaml
sinks:
  - id: zenoh-pub
    configuration:
        key-expressions: 
            id1: some/key/expr/to/publish
            id2: some/key/expr/to/publish2
         shared_memory_element_size: 5MiB
         shared_memory_elements: 10
         shared_memory_backoff: 100ms
    descriptor: builtin://zenoh
```
The configuration of the sink overwrites the one from the runtime.

--- 
 - [x] Use shared memory in Connector
 - [x]  Use shared memory in Builtin Sink
 - [x] Add and parse configuration to built-in sink
 - [x] Add and parse configuration to the runtime
 - [x] Add and parse configuration to link
 - [x] Parse the values from human-readable values  (i.e. ms, KiB...)