### PR TITLE
Fix descriptor generation for builtin sinks and builtin sources.

### DIFF
--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -99,7 +99,23 @@ pub(crate) fn get_zenoh_source_descriptor(
             configuration
         )
     })?;
-    for id in local_configuration.keys() {
+
+    let keyexpressions = local_configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| {
+        zferror!(
+            ErrorKind::ConfigurationError,
+            "Missing key-expressions in builtin sink configuration"
+        )
+    })?;
+
+    let keyexpressions = keyexpressions.as_object().ok_or_else(|| {
+        zferror!(
+            ErrorKind::ConfigurationError,
+            "Unable to convert configuration to HashMap: {:?}",
+            configuration
+        )
+    })?;
+
+    for id in keyexpressions.keys() {
         outputs.push(id.clone().into());
     }
 
@@ -280,7 +296,23 @@ pub(crate) fn get_zenoh_sink_descriptor(configuration: &Configuration) -> ZFResu
             configuration
         )
     })?;
-    for id in local_configuration.keys() {
+
+    let keyexpressions = local_configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| {
+        zferror!(
+            ErrorKind::ConfigurationError,
+            "Missing key-expressions in builtin sink configuration"
+        )
+    })?;
+
+    let keyexpressions = keyexpressions.as_object().ok_or_else(|| {
+        zferror!(
+            ErrorKind::ConfigurationError,
+            "Unable to convert configuration to HashMap: {:?}",
+            configuration
+        )
+    })?;
+
+    for id in keyexpressions.keys() {
         inputs.push(id.clone().into());
     }
 


### PR DESCRIPTION
There is a bug introduced by #151 on the built-in source and sink configuration parsing, it generates a wrong descriptor.

This descriptor:
```yaml
  - id: houses
    configuration:
      key-expressions:
        house_data: house_data
    descriptor: "builtin://zenoh"
```

generates:
```yaml
  houses:
    id: houses
    uid: 4
    outputs:
    - uid: 3
      port_id: key-expressions 
    uri: builtin://zenoh
    configuration:
      key-expressions:
        house_data: house_data
    runtime: aggregator
```

That is wrong as the descriptor should be:
```yaml
  houses:
    id: houses
    uid: 4
    outputs:
    - uid: 3
      port_id: house_data 
    uri: builtin://zenoh
    configuration:
      key-expressions:
        house_data: house_data
    runtime: aggregator
```