### PR TITLE
Possibility to enable/disable automatic shared memory transport over Zenoh

### DIFF
--- a/zenoh-flow-daemon/etc/runtime.yaml
+++ b/zenoh-flow-daemon/etc/runtime.yaml
@@ -18,3 +18,4 @@
     extensions: /etc/zenoh-flow/extensions.d
     zenoh_config: /etc/zenoh-flow/zenoh-daemon.json
     worker_pool_size: 4
+    use_shm: false

--- a/zenoh-flow-daemon/src/daemon.rs
+++ b/zenoh-flow-daemon/src/daemon.rs
@@ -42,7 +42,7 @@ use zenoh_flow::types::ControlMessage;
 use zenoh_flow::utils::{deserialize_size, deserialize_time};
 use zenoh_flow::{
     bail, DaemonResult, DEFAULT_SHM_ALLOCATION_BACKOFF_NS, DEFAULT_SHM_ELEMENT_SIZE,
-    DEFAULT_SHM_TOTAL_ELEMENTS,
+    DEFAULT_SHM_TOTAL_ELEMENTS, DEFAULT_USE_SHM,
 };
 use zrpc::ZServe;
 use zrpc_macros::zserver;
@@ -81,6 +81,8 @@ pub struct DaemonConfig {
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_time")]
     pub default_shared_memory_backoff: Option<u64>,
+    // Whether or not Shared Memory is enabled.
+    pub use_shm: Option<bool>,
 }
 
 /// The Zenoh flow daemon
@@ -300,6 +302,7 @@ impl Daemon {
             shared_memory_backoff: config
                 .default_shared_memory_backoff
                 .unwrap_or(DEFAULT_SHM_ALLOCATION_BACKOFF_NS),
+            use_shm: config.use_shm.unwrap_or(DEFAULT_USE_SHM),
         };
 
         Ok(Self::new(z, ctx, rt_config, pool_size))

--- a/zenoh-flow-plugin/etc/zenoh-zf-plugin.json
+++ b/zenoh-flow-plugin/etc/zenoh-zf-plugin.json
@@ -33,7 +33,8 @@
             "path":"/etc/zenoh-flow",
             "pid_file": "/var/zenoh-flow/runtime.pid",
             "extensions": "/etc/zenoh-flow/extensions.d",
-            "worker_pool_size":4
+            "worker_pool_size":4,
+            "use_shm": false
         }
     }
 }

--- a/zenoh-flow/src/lib.rs
+++ b/zenoh-flow/src/lib.rs
@@ -81,3 +81,6 @@ pub static DEFAULT_SHM_TOTAL_ELEMENTS: u64 = 10;
 
 /// Default Shared allocation backoff time (100ms)
 pub static DEFAULT_SHM_ALLOCATION_BACKOFF_NS: u64 = 100_000_000;
+
+/// Default Shared memory usage (false)
+pub static DEFAULT_USE_SHM: bool = false;

--- a/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/builtin/zenoh.rs
@@ -267,7 +267,7 @@ pub(crate) struct ZenohSink<'a> {
     inputs: HashMap<PortId, InputRaw>,
     publishers: HashMap<PortId, Publisher<'a>>,
     futs: Arc<Mutex<Vec<ZFInputFut>>>,
-    shm: Arc<Mutex<SharedMemoryManager>>,
+    shm: Option<Arc<Mutex<SharedMemoryManager>>>,
     shm_element_size: usize,
     shm_backoff: u64,
 }
@@ -348,23 +348,43 @@ impl<'a> Sink for ZenohSink<'a> {
                     default
                 };
 
-                let shm_elem_size = get_or_default(
-                    &configuration,
-                    KEY_SHM_ELEM_SIZE,
-                    *context.shared_memory_element_size() as u64,
-                ) as usize;
-                let shm_elem_count = get_or_default(
-                    &configuration,
-                    KEY_SHM_TOTAL_ELEMENTS,
-                    *context.shared_memory_elements() as u64,
-                ) as usize;
-                let shm_backoff = get_or_default(
-                    &configuration,
-                    KEY_SHM_BACKOFF,
-                    *context.shared_memory_backoff(),
-                );
+                let (shm_element_size, shm_backoff, shm_manager) =
+                    match context.shared_memory_enabled() {
+                        true => {
+                            let shm_elem_size = get_or_default(
+                                &configuration,
+                                KEY_SHM_ELEM_SIZE,
+                                *context.shared_memory_element_size() as u64,
+                            ) as usize;
+                            let shm_elem_count = get_or_default(
+                                &configuration,
+                                KEY_SHM_TOTAL_ELEMENTS,
+                                *context.shared_memory_elements() as u64,
+                            ) as usize;
+                            let shm_backoff = get_or_default(
+                                &configuration,
+                                KEY_SHM_BACKOFF,
+                                *context.shared_memory_backoff(),
+                            );
 
-                let shm_size = shm_elem_size * shm_elem_count;
+                            let shm_size = shm_elem_size * shm_elem_count;
+
+                            let shm_manager =
+                                SharedMemoryManager::make(id, shm_size).map_err(|_| {
+                                    zferror!(
+                                        ErrorKind::ConfigurationError,
+                                        "Unable to allocate {shm_size} bytes of shared memory"
+                                    )
+                                })?;
+
+                            (
+                                shm_elem_size,
+                                shm_backoff,
+                                Some(Arc::new(Mutex::new(shm_manager))),
+                            )
+                        }
+                        false => (0, 0, None),
+                    };
 
                 let keyexpressions = configuration.get(KEY_KEYEXPRESSIONS).ok_or_else(|| {
                     zferror!(
@@ -413,15 +433,8 @@ impl<'a> Sink for ZenohSink<'a> {
                     inputs: sink_inputs,
                     publishers,
                     futs: Arc::new(Mutex::new(futs)),
-                    shm: Arc::new(Mutex::new(
-                        SharedMemoryManager::make(id, shm_size).map_err(|_| {
-                            zferror!(
-                                ErrorKind::ConfigurationError,
-                                "Unable to allocate {shm_size} bytes of shared memory"
-                            )
-                        })?,
-                    )),
-                    shm_element_size: shm_elem_size,
+                    shm: shm_manager,
+                    shm_element_size,
                     shm_backoff,
                 })
             }
@@ -438,9 +451,6 @@ impl<'a> Sink for ZenohSink<'a> {
 #[async_trait]
 impl<'a> Node for ZenohSink<'a> {
     async fn iteration(&self) -> ZFResult<()> {
-        // Getting shared memory manager
-        let mut shm = self.shm.lock().await;
-
         // Getting the list of futures to poll in a temporary variable (that `select_all` can take
         // ownership of)
         let mut futs = self.futs.lock().await;
@@ -458,49 +468,56 @@ impl<'a> Node for ZenohSink<'a> {
                     zferror!(ErrorKind::SendError, "Unable to find Publisher for {id}")
                 })?;
 
-                // Getting the shared memory buffer
-                let mut buff = match shm.alloc(self.shm_element_size) {
-                    Ok(buf) => buf,
-                    Err(_) => {
-                        async_std::task::sleep(std::time::Duration::from_nanos(self.shm_backoff))
-                            .await;
-                        log::trace!(
-                            "After failing allocation the GC collected: {} bytes -- retrying",
-                            shm.garbage_collect()
-                        );
-                        log::trace!(
-                            "Trying to de-fragment memory... De-fragmented {} bytes",
-                            shm.defragment()
-                        );
-                        shm.alloc(self.shm_element_size).map_err(|_| {
-                            zferror!(
-                                ErrorKind::ConfigurationError,
-                                "Unable to allocated {} in the shared memory buffer!",
-                                self.shm_element_size
-                            )
-                        })?
+                match &self.shm {
+                    Some(shm) => {
+                        // Getting shared memory manager
+                        let mut shm = shm.lock().await;
+                        let mut buff = match shm.alloc(self.shm_element_size) {
+                            Ok(buf) => buf,
+                            Err(_) => {
+                                async_std::task::sleep(std::time::Duration::from_nanos(
+                                    self.shm_backoff,
+                                ))
+                                .await;
+                                log::trace!(
+                                    "After failing allocation the GC collected: {} bytes -- retrying",
+                                    shm.garbage_collect()
+                                );
+                                log::trace!(
+                                    "Trying to de-fragment memory... De-fragmented {} bytes",
+                                    shm.defragment()
+                                );
+                                shm.alloc(self.shm_element_size).map_err(|_| {
+                                    zferror!(
+                                        ErrorKind::ConfigurationError,
+                                        "Unable to allocated {} in the shared memory buffer!",
+                                        self.shm_element_size
+                                    )
+                                })?
+                            }
+                        };
+
+                        // Getting the underlying slice in the shared memory
+                        let slice = unsafe { buff.as_mut_slice() };
+
+                        let data_len = data.len();
+
+                        // If the shared memory block is big enough we send the data through it,
+                        // otherwise we go through the network.
+                        if data_len < slice.len() {
+                            // WARNING ACHTUNG ATTENTION
+                            // We are coping memory here!
+                            // we should be able to serialize directly in the shared
+                            // memory buffer.
+                            slice[0..data_len].copy_from_slice(&data);
+                            publisher.put(buff).res().await?;
+                        } else {
+                            log::warn!("[ZenohSink] Sending data via network as we are unable to send it over shared memory, the serialized size is {} while shared memory is {}", data_len, self.shm_element_size);
+                            publisher.put(&**data).res().await?;
+                        }
                     }
+                    None => publisher.put(&**data).res().await?,
                 };
-
-                // Getting the underlying slice in the shared memory
-                let slice = unsafe { buff.as_mut_slice() };
-
-                let data_len = data.len();
-
-                // If the shared memory block is big enough we send the data through it,
-                // otherwise we go through the network.
-                if data_len < slice.len() {
-                    // WARNING ACHTUNG ATTENTION
-                    // We are coping memory here!
-                    // we should be able to serialize directly in the shared
-                    // memory buffer.
-                    slice[0..data_len].copy_from_slice(&data);
-                    // Sending the data as shared memory
-                    publisher.put(buff).res().await?;
-                } else {
-                    publisher.put(&**data).res().await?;
-                    log::warn!("[ZenohSink] Sending data via network as we are unable to send it over shared memory, the serialized size is {} while shared memory is {}", data_len, self.shm_element_size);
-                }
             }
             Ok(_) => (), // Not the right message, ignore it.
             Err(e) => log::error!("[ZenohSink] got error on link {id}: {e:?}"),

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -38,7 +38,7 @@ pub(crate) struct ZenohSender {
     pub(crate) input_raw: InputRaw,
     pub(crate) z_session: Arc<zenoh::Session>,
     pub(crate) key_expr: KeyExpr<'static>,
-    pub(crate) shm: Arc<Mutex<SharedMemoryManager>>,
+    pub(crate) shm: Option<Arc<Mutex<SharedMemoryManager>>>,
     pub(crate) shm_element_size: usize,
     pub(crate) shm_backoff: u64,
 }
@@ -68,6 +68,8 @@ impl ZenohSender {
             )
         })?;
 
+        let use_shm = ctx.runtime.use_shm;
+
         let key_expr = ctx
             .runtime
             .session
@@ -76,15 +78,38 @@ impl ZenohSender {
             .await?
             .into_owned();
 
-        let shm_size = record
-            .shared_memory_element_size
-            .unwrap_or(ctx.runtime.shared_memory_element_size)
-            * record
-                .shared_memory_elements
-                .unwrap_or(ctx.runtime.shared_memory_elements);
-        let shm_backoff = record
-            .shared_memory_backoff
-            .unwrap_or(ctx.runtime.shared_memory_backoff);
+        let (shm_element_size, shm_backoff, shm_manager) = match use_shm {
+            true => {
+                let shm_size = record
+                    .shared_memory_element_size
+                    .unwrap_or(ctx.runtime.shared_memory_element_size)
+                    * record
+                        .shared_memory_elements
+                        .unwrap_or(ctx.runtime.shared_memory_elements);
+                let shm_backoff = record
+                    .shared_memory_backoff
+                    .unwrap_or(ctx.runtime.shared_memory_backoff);
+
+                let shm_manager = SharedMemoryManager::make(record.resource.clone(), shm_size)
+                    .map_err(|_| {
+                        zferror!(
+                            ErrorKind::ConfigurationError,
+                            "Unable to allocate {shm_size} bytes of shared memory"
+                        )
+                    })?;
+
+                let shm_element_size = record
+                    .shared_memory_element_size
+                    .unwrap_or(ctx.runtime.shared_memory_element_size);
+
+                (
+                    shm_element_size,
+                    shm_backoff,
+                    Some(Arc::new(Mutex::new(shm_manager))),
+                )
+            }
+            false => (0, 0, None),
+        };
 
         Ok(Self {
             id: record.id.clone(),
@@ -94,17 +119,8 @@ impl ZenohSender {
             },
             z_session: ctx.runtime.session.clone(),
             key_expr,
-            shm: Arc::new(Mutex::new(
-                SharedMemoryManager::make(record.resource.clone(), shm_size).map_err(|_| {
-                    zferror!(
-                        ErrorKind::ConfigurationError,
-                        "Unable to allocate {shm_size} bytes of shared memory"
-                    )
-                })?,
-            )),
-            shm_element_size: record
-                .shared_memory_element_size
-                .unwrap_or(ctx.runtime.shared_memory_element_size),
+            shm: shm_manager,
+            shm_element_size,
             shm_backoff,
         })
     }
@@ -122,72 +138,84 @@ impl Node for ZenohSender {
     /// - zenoh put fails
     /// - link recv fails
     async fn iteration(&self) -> ZFResult<()> {
-        // Getting shared memory manager
-        let mut shm = self.shm.lock().await;
         match self.input_raw.recv().await {
-            Ok(message) => {
-                // Getting the shared memory buffer
-                let mut buff = match shm.alloc(self.shm_element_size) {
-                    Ok(buf) => buf,
-                    Err(_) => {
-                        async_std::task::sleep(std::time::Duration::from_millis(self.shm_backoff))
+            Ok(message) => match &self.shm {
+                Some(shm) => {
+                    // Getting shared memory manager
+                    let mut shm = shm.lock().await;
+                    // Getting the shared memory buffer
+                    let mut buff = match shm.alloc(self.shm_element_size) {
+                        Ok(buf) => buf,
+                        Err(_) => {
+                            async_std::task::sleep(std::time::Duration::from_millis(
+                                self.shm_backoff,
+                            ))
                             .await;
-                        log::trace!(
-                            "[ZenohSender: {}] After failing allocation the GC collected: {} bytes -- retrying",
-                            self.id,
-                            shm.garbage_collect()
-                        );
-                        log::trace!(
-                            "[ZenohSender: {}] Trying to de-fragment memory... De-fragmented {} bytes",
-                            self.id,
-                            shm.defragment()
-                        );
-                        shm.alloc(self.shm_element_size).map_err(|_| {
-                            zferror!(
-                                ErrorKind::ConfigurationError,
-                                "Unable to allocated {} in the shared memory buffer!",
-                                self.shm_element_size
-                            )
-                        })?
-                    }
-                };
+                            log::trace!(
+                                "[ZenohSender: {}] After failing allocation the GC collected: {} bytes -- retrying",
+                                self.id,
+                                shm.garbage_collect()
+                            );
+                            log::trace!(
+                                "[ZenohSender: {}] Trying to de-fragment memory... De-fragmented {} bytes",
+                                self.id,
+                                shm.defragment()
+                            );
+                            shm.alloc(self.shm_element_size).map_err(|_| {
+                                zferror!(
+                                    ErrorKind::ConfigurationError,
+                                    "Unable to allocated {} in the shared memory buffer!",
+                                    self.shm_element_size
+                                )
+                            })?
+                        }
+                    };
 
-                // Getting the underlying slice in the shared memory
-                let slice = unsafe { buff.as_mut_slice() };
+                    // Getting the underlying slice in the shared memory
+                    let slice = unsafe { buff.as_mut_slice() };
 
-                // WARNING ACHTUNG ATTENTION
-                // This may fail as the message could be bigger than
-                // the shared memory buffer that was allocated.
-                match message.serialize_bincode_into(slice) {
-                    Ok(_) => {
-                        // If the serialization is success then we send the
-                        // shared memory buffer.
-                        self.z_session
-                            .put(self.key_expr.clone(), buff)
-                            .congestion_control(CongestionControl::Block)
-                            .res()
-                            .await
-                    }
-                    Err(e) => {
-                        // Otherwise we log a warn and we serialize on a normal
-                        // Vec<u8>
-                        let data = message.serialize_bincode()?;
-                        log::warn!(
-                            "[ZenohSender: {}] Unable to serialize into shared memory: {}, serialized size {}, shared memory size {}",
-                            self.id,
-                            e,
-                            data.len(),
-                            self.shm_element_size,
-                        );
+                    // WARNING ACHTUNG ATTENTION
+                    // This may fail as the message could be bigger than
+                    // the shared memory buffer that was allocated.
+                    match message.serialize_bincode_into(slice) {
+                        Ok(_) => {
+                            // If the serialization is success then we send the
+                            // shared memory buffer.
+                            self.z_session
+                                .put(self.key_expr.clone(), buff)
+                                .congestion_control(CongestionControl::Block)
+                                .res()
+                                .await
+                        }
+                        Err(e) => {
+                            // Otherwise we log a warn and we serialize on a normal
+                            // Vec<u8>
+                            let data = message.serialize_bincode()?;
+                            log::warn!(
+                                "[ZenohSender: {}] Unable to serialize into shared memory: {}, serialized size {}, shared memory size {}",
+                                self.id,
+                                e,
+                                data.len(),
+                                self.shm_element_size,
+                            );
 
-                        self.z_session
-                            .put(self.key_expr.clone(), data)
-                            .congestion_control(CongestionControl::Block)
-                            .res()
-                            .await
+                            self.z_session
+                                .put(self.key_expr.clone(), data)
+                                .congestion_control(CongestionControl::Block)
+                                .res()
+                                .await
+                        }
                     }
                 }
-            }
+                None => {
+                    let data = message.serialize_bincode()?;
+                    self.z_session
+                        .put(self.key_expr.clone(), data)
+                        .congestion_control(CongestionControl::Block)
+                        .res()
+                        .await
+                }
+            },
             Err(e) => Err(zferror!(
                 ErrorKind::Disconnected,
                 "[ZenohSender: {}] {:?}",
@@ -198,7 +226,6 @@ impl Node for ZenohSender {
         }
     }
 }
-
 /// A `ZenohReceiver` receives the messages from Zenoh when nodes are running on different runtimes.
 pub(crate) struct ZenohReceiver {
     pub(crate) id: NodeId,

--- a/zenoh-flow/src/runtime/mod.rs
+++ b/zenoh-flow/src/runtime/mod.rs
@@ -53,6 +53,7 @@ pub struct RuntimeContext {
     pub shared_memory_element_size: usize,
     pub shared_memory_elements: usize,
     pub shared_memory_backoff: u64,
+    pub use_shm: bool,
 }
 
 /// The context of a Zenoh Flow graph instance.

--- a/zenoh-flow/src/types/context.rs
+++ b/zenoh-flow/src/types/context.rs
@@ -91,6 +91,11 @@ impl Context {
     pub fn shared_memory_backoff(&self) -> &u64 {
         &self.instance_ctx.runtime.shared_memory_backoff
     }
+
+    /// Returns wheteher the shared memory is enabled or not
+    pub fn shared_memory_enabled(&self) -> &bool {
+        &self.instance_ctx.runtime.use_shm
+    }
 }
 
 impl Deref for Context {

--- a/zenoh-flow/tests/dataflow.rs
+++ b/zenoh-flow/tests/dataflow.rs
@@ -252,6 +252,7 @@ async fn single_runtime() {
         shared_memory_element_size: DEFAULT_SHM_ELEMENT_SIZE as usize,
         shared_memory_elements: DEFAULT_SHM_TOTAL_ELEMENTS as usize,
         shared_memory_backoff: DEFAULT_SHM_ALLOCATION_BACKOFF_NS,
+        use_shm: false,
     };
 
     let mut dataflow = zenoh_flow::runtime::dataflow::DataFlow::new("test", ctx.clone());


### PR DESCRIPTION
Adding a new configuration parameter to enable/disable the automatic Shared Memory transport over Zenoh.

Shared Memory can cause `SIGBUS` errors on docker containers, therefore it is disabled by default.

Configuration file look like this:

```yaml
---
    pid_file : /var/zenoh-flow/runtime.pid
    path : /etc/zenoh-flow
    extensions: /etc/zenoh-flow/extensions.d
    zenoh_config: /etc/zenoh-flow/zenoh-daemon.json
    worker_pool_size: 4
    use_shm: false #change to true to enable, WARNING in docker this can cause BUS Errors!!!
```