### PR TITLE
deps: bump version of zrpc to 0.6.1-alpha.1

### DIFF
--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -40,8 +40,8 @@ uuid = { version = "1.1", features = ["serde", "v4"] }
 uhlc = "0.5.1"
 zenoh = { version = "=0.7.0-rc" }
 zenoh-util = { version = "=0.7.0-rc" }
-zrpc = { version= "=0.6.0-alpha1" }
-zrpc-macros = { version= "=0.6.0-alpha1" }
+zrpc = { version= "=0.6.1-alpha.1" }
+zrpc-macros = { version= "=0.6.1-alpha.1" }
 clap = { version = "4.0", features = ["derive"] }
 hostname = "0.3.1"
 machine-uid = "0.2.0"

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -64,8 +64,8 @@ zenoh = { version = "=0.7.0-rc", features = ["shared-memory"]}
 zenoh-flow-derive = {version = "=0.5.0-dev", path = "../zenoh-flow-derive"}
 zenoh-sync = { version = "=0.7.0-rc" }
 zenoh-util = { version = "=0.7.0-rc" }
-zrpc = { version= "=0.6.0-alpha1" }
-zrpc-macros = { version= "=0.6.0-alpha1" }
+zrpc = { version= "=0.6.1-alpha.1" }
+zrpc-macros = { version= "=0.6.1-alpha.1" }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -47,8 +47,8 @@ uuid = { version = "1.1", features = ["serde", "v4"] }
 zenoh = { version = "=0.7.0-rc" }
 zenoh-flow = {version = "=0.5.0-dev", path = "../zenoh-flow"}
 zenoh-util = { version = "=0.7.0-rc" }
-zrpc = { version= "=0.6.0-alpha1" }
-zrpc-macros = { version= "=0.6.0-alpha1" }
+zrpc = { version= "=0.6.1-alpha.1" }
+zrpc-macros = { version= "=0.6.1-alpha.1" }
 
 # Debian package configuration
 


### PR DESCRIPTION
zenoh-rpc was requiring the version "=1.0.23" of the `quote` crate which, somehow, forced Cargo to:
- bump `pest_meta` to the version "2.6.0",
- bump `pest_generator` to the version "2.5.6".

Unfortunately these crates are incompatible, eventually preventing us from building Zenoh-Flow.