### PR TITLE
feat: reuse buffer when serializing

### DIFF
--- a/zenoh-flow/src/io/tests/input-tests.rs
+++ b/zenoh-flow/src/io/tests/input-tests.rs
@@ -72,7 +72,7 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
         Payload::Typed((
             Arc::new(expected_data.clone()) as Arc<dyn SendSyncAny>,
             // The serializer should never be called, hence the panic.
-            Arc::new(|_data| panic!("Unexpected call to serialize the data")),
+            Arc::new(|_buffer, _data| panic!("Unexpected call to serialize the data")),
         )),
         hlc.new_timestamp(),
     );

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -38,9 +38,23 @@ pub(crate) struct ZenohSender {
     pub(crate) input_raw: InputRaw,
     pub(crate) z_session: Arc<zenoh::Session>,
     pub(crate) key_expr: KeyExpr<'static>,
-    pub(crate) shm: Option<Arc<Mutex<SharedMemoryManager>>>,
+    pub(crate) state: Arc<Mutex<ZenohSenderState>>,
     pub(crate) shm_element_size: usize,
     pub(crate) shm_backoff: u64,
+}
+
+/// The `ZenohSenderState` stores in a single structure all the fields protected by a lock.
+///
+/// The fields are:
+/// - `shm` holds the [SharedMemoryManager] used to send data through Zenoh's shared memory;
+/// - `buffer` holds a growable vector of bytes in which the result of the serialization of the
+///   [LinkMessage] is stored.
+/// - `inner_buffer` holds a growable vector of bytes in which the result of the serialization
+///   of the [Payload] contained inside the [LinkMessage] is stored.
+pub(crate) struct ZenohSenderState {
+    pub(crate) shm: Option<SharedMemoryManager>,
+    pub(crate) message_buffer: Vec<u8>,
+    pub(crate) payload_buffer: Vec<u8>,
 }
 
 impl ZenohSender {
@@ -91,14 +105,14 @@ impl ZenohSender {
                 .shared_memory_backoff
                 .unwrap_or(ctx.runtime.shared_memory_backoff);
 
-            shm_manager = Some(Arc::new(Mutex::new(
+            shm_manager = Some(
                 SharedMemoryManager::make(record.resource.clone(), shm_size).map_err(|_| {
                     zferror!(
                         ErrorKind::ConfigurationError,
                         "Unable to allocate {shm_size} bytes of shared memory"
                     )
                 })?,
-            )));
+            );
 
             shm_element_size = record
                 .shared_memory_element_size
@@ -113,9 +127,13 @@ impl ZenohSender {
             },
             z_session: ctx.runtime.session.clone(),
             key_expr,
-            shm: shm_manager,
             shm_element_size,
             shm_backoff,
+            state: Arc::new(Mutex::new(ZenohSenderState {
+                shm: shm_manager,
+                message_buffer: Vec::default(),
+                payload_buffer: Vec::default(),
+            })),
         })
     }
 }
@@ -125,7 +143,7 @@ impl Node for ZenohSender {
     /// An iteration of a ZenohSender: wait for some data to publish, serialize it using `bincode`
     /// and publish it on Zenoh.
     ///
-    /// ## Errors
+    /// # Errors
     ///
     /// An error variant is returned if:
     /// - serialization fails
@@ -133,83 +151,99 @@ impl Node for ZenohSender {
     /// - link recv fails
     async fn iteration(&self) -> ZFResult<()> {
         match self.input_raw.recv().await {
-            Ok(message) => match &self.shm {
-                Some(shm) => {
-                    // Getting shared memory manager
-                    let mut shm = shm.lock().await;
-                    // Getting the shared memory buffer
-                    let mut buff = match shm.alloc(self.shm_element_size) {
-                        Ok(buf) => buf,
-                        Err(_) => {
-                            async_std::task::sleep(std::time::Duration::from_millis(
-                                self.shm_backoff,
-                            ))
-                            .await;
-                            log::trace!(
-                                "[ZenohSender: {}] After failing allocation the GC collected: {} bytes -- retrying",
-                                self.id,
-                                shm.garbage_collect()
-                            );
-                            log::trace!(
-                                "[ZenohSender: {}] Trying to de-fragment memory... De-fragmented {} bytes",
-                                self.id,
-                                shm.defragment()
-                            );
-                            shm.alloc(self.shm_element_size).map_err(|_| {
-                                zferror!(
-                                    ErrorKind::ConfigurationError,
-                                    "Unable to allocated {} in the shared memory buffer!",
-                                    self.shm_element_size
-                                )
-                            })?
-                        }
-                    };
+            Ok(message) => {
+                let mut state = self.state.lock().await;
 
-                    // Getting the underlying slice in the shared memory
-                    let slice = unsafe { buff.as_mut_slice() };
+                // NOTE: as per the documentation of Vec::default, which is what the
+                // `std::mem::take` will call, no allocation is performed until elements are pushed
+                // in the vector.
+                let mut message_buffer = std::mem::take(&mut state.message_buffer);
+                let mut payload_buffer = std::mem::take(&mut state.payload_buffer);
 
-                    // WARNING ACHTUNG ATTENTION
-                    // This may fail as the message could be bigger than
-                    // the shared memory buffer that was allocated.
-                    match message.serialize_bincode_into(slice) {
-                        Ok(_) => {
-                            // If the serialization is success then we send the
-                            // shared memory buffer.
-                            self.z_session
-                                .put(self.key_expr.clone(), buff)
-                                .congestion_control(CongestionControl::Block)
-                                .res()
-                                .await
-                        }
-                        Err(e) => {
-                            // Otherwise we log a warn and we serialize on a normal
-                            // Vec<u8>
-                            let data = message.serialize_bincode()?;
-                            log::warn!(
-                                "[ZenohSender: {}] Unable to serialize into shared memory: {}, serialized size {}, shared memory size {}",
-                                self.id,
-                                e,
-                                data.len(),
-                                self.shm_element_size,
-                            );
+                match state.shm {
+                    Some(ref mut shm) => {
+                        // Getting the shared memory buffer
+                        let mut buff = match shm.alloc(self.shm_element_size) {
+                            Ok(buf) => buf,
+                            Err(_) => {
+                                async_std::task::sleep(std::time::Duration::from_millis(
+                                    self.shm_backoff,
+                                ))
+                                .await;
+                                log::trace!(
+                                    "[ZenohSender: {}] After failing allocation the GC collected: {} bytes -- retrying",
+                                    self.id,
+                                    shm.garbage_collect()
+                                );
+                                log::trace!(
+                                    "[ZenohSender: {}] Trying to de-fragment memory... De-fragmented {} bytes",
+                                    self.id,
+                                    shm.defragment()
+                                );
+                                shm.alloc(self.shm_element_size).map_err(|_| {
+                                    zferror!(
+                                        ErrorKind::ConfigurationError,
+                                        "Unable to allocated {} in the shared memory buffer!",
+                                        self.shm_element_size
+                                    )
+                                })?
+                            }
+                        };
 
-                            self.z_session
-                                .put(self.key_expr.clone(), data)
-                                .congestion_control(CongestionControl::Block)
-                                .res()
-                                .await
+                        // Getting the underlying slice in the shared memory
+                        let slice = unsafe { buff.as_mut_slice() };
+
+                        // WARNING ACHTUNG ATTENTION
+                        // This may fail as the message could be bigger than
+                        // the shared memory buffer that was allocated.
+                        match message.serialize_bincode_into_shm(slice, &mut payload_buffer) {
+                            Ok(_) => {
+                                // If the serialization is success then we send the
+                                // shared memory buffer.
+                                self.z_session
+                                    .put(self.key_expr.clone(), buff)
+                                    .congestion_control(CongestionControl::Block)
+                                    .res()
+                                    .await?;
+                            }
+                            Err(e) => {
+                                // Otherwise we log a warn and we serialize on a normal
+                                // Vec<u8>
+                                message.serialize_bincode_into(
+                                    &mut message_buffer,
+                                    &mut payload_buffer,
+                                )?;
+                                log::warn!(
+                                    "[ZenohSender: {}] Unable to serialize into shared memory: {}, serialized size {}, shared memory size {}",
+                                    self.id,
+                                    e,
+                                    state.message_buffer.len(),
+                                    self.shm_element_size,
+                                );
+
+                                self.z_session
+                                    .put(self.key_expr.clone(), message_buffer.clone())
+                                    .congestion_control(CongestionControl::Block)
+                                    .res()
+                                    .await?;
+                            }
                         }
                     }
+                    None => {
+                        message.serialize_bincode_into(&mut message_buffer, &mut payload_buffer)?;
+                        self.z_session
+                            .put(self.key_expr.clone(), message_buffer.clone())
+                            .congestion_control(CongestionControl::Block)
+                            .res()
+                            .await?;
+                    }
                 }
-                None => {
-                    let data = message.serialize_bincode()?;
-                    self.z_session
-                        .put(self.key_expr.clone(), data)
-                        .congestion_control(CongestionControl::Block)
-                        .res()
-                        .await
-                }
-            },
+
+                // NOTE: set back the buffers such that we don't have to allocate memory again.
+                state.message_buffer = message_buffer;
+                state.payload_buffer = payload_buffer;
+                Ok(())
+            }
             Err(e) => Err(zferror!(
                 ErrorKind::Disconnected,
                 "[ZenohSender: {}] {:?}",

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -47,10 +47,10 @@ pub(crate) struct ZenohSender {
 ///
 /// The fields are:
 /// - `shm` holds the [SharedMemoryManager] used to send data through Zenoh's shared memory;
-/// - `buffer` holds a growable vector of bytes in which the result of the serialization of the
-///   [LinkMessage] is stored.
-/// - `inner_buffer` holds a growable vector of bytes in which the result of the serialization
-///   of the [Payload] contained inside the [LinkMessage] is stored.
+/// - `message_buffer` holds a growable vector of bytes in which the result of the serialization of
+///   the [LinkMessage] is stored.
+/// - `payload_buffer` holds a growable vector of bytes in which the result of the serialization of
+///   the [Payload] contained inside the [LinkMessage] is stored.
 pub(crate) struct ZenohSenderState {
     pub(crate) shm: Option<SharedMemoryManager>,
     pub(crate) message_buffer: Vec<u8>,
@@ -198,8 +198,8 @@ impl Node for ZenohSender {
                         // the shared memory buffer that was allocated.
                         match message.serialize_bincode_into_shm(slice, &mut payload_buffer) {
                             Ok(_) => {
-                                // If the serialization is success then we send the
-                                // shared memory buffer.
+                                // If the serialization succeeded then we send the shared memory
+                                // buffer.
                                 self.z_session
                                     .put(self.key_expr.clone(), buff)
                                     .congestion_control(CongestionControl::Block)

--- a/zenoh-flow/src/traits.rs
+++ b/zenoh-flow/src/traits.rs
@@ -74,7 +74,7 @@ impl<T: 'static + Send + Sync> SendSyncAny for T {
 ///         let output = outputs
 ///             .take("out")
 ///             .expect("No output called 'out' found")
-///             .build_typed(|data| todo!("Provide your serializer here"));
+///             .build_typed(|buffer, data| todo!("Provide your serializer here"));
 ///             
 ///         Ok(Self { output })
 ///     }
@@ -226,7 +226,7 @@ pub trait Sink: Node + Send + Sync {
 ///             output: outputs
 ///                 .take("out")
 ///                 .expect("No output called 'out' found")
-///                 .build_typed(|data| todo!("Provide your serializer here")),
+///                 .build_typed(|buffer, data| todo!("Provide your serializer here")),
 ///         })
 ///     }
 /// }


### PR DESCRIPTION
These commits try to minimize the number of allocations performed when
serializing data. For this end, the connector and built-in Source now create
internal `Vec<u8>` buffers that are reused whenever a message is serialized.

This change should hopefully (slightly) improve performance.