### PR TITLE
chores: update dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -199,7 +199,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.37.19",
  "slab",
  "socket2 0.4.9",
  "waker-fn",
@@ -211,7 +211,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -225,9 +225,9 @@ dependencies = [
  "autocfg",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-lite",
- "rustix",
+ "rustix 0.37.19",
  "signal-hook",
  "windows-sys 0.48.0",
 ]
@@ -240,7 +240,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -295,7 +295,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -357,12 +357,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -389,10 +383,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.4.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.37",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -470,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.13.3"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
+checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
 dependencies = [
  "serde",
  "toml",
@@ -483,6 +506,15 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -501,15 +533,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.7.4",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "strsim",
  "termcolor",
  "textwrap",
@@ -546,7 +589,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -703,8 +746,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -722,14 +775,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -770,20 +848,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -794,17 +863,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -844,19 +902,6 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
@@ -867,6 +912,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
@@ -903,6 +954,17 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e56284f00d94c1bc7fd3c77027b4623c88c1f53d8d2394c6199f2921dea325"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "exitfailure"
@@ -960,6 +1022,18 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
  "spin 0.9.8",
 ]
 
@@ -1055,7 +1129,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1177,6 +1251,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -1302,6 +1382,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,7 +1443,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
 
@@ -1362,6 +1452,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1429,10 +1528,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.144"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.148"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -1442,6 +1547,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1455,6 +1570,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -1509,10 +1630,12 @@ dependencies = [
 
 [[package]]
 name = "machine-uid"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1595709b0a7386bcd56ba34d250d626e5503917d05d32cdccddcd68603e212"
+checksum = "958d2e0ee250103b08a70a5785ca5abcd077a47584b35087248a93758c699f29"
 dependencies = [
+ "bindgen",
+ "cc",
  "winreg",
 ]
 
@@ -1545,6 +1668,12 @@ checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1587,7 +1716,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -1600,7 +1729,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
@@ -1613,6 +1742,16 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-bigint-dig"
@@ -1727,6 +1866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,7 +1916,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1792,7 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -1812,14 +1957,14 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1947,7 +2092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -1961,6 +2106,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -2017,9 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2027,15 +2182,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2044,7 +2199,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -2206,7 +2361,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2324,11 +2479,24 @@ version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.7",
  "windows-sys 0.48.0",
 ]
 
@@ -2418,7 +2586,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2471,7 +2639,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2486,12 +2654,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -2549,8 +2726,14 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 dependencies = [
- "dirs 5.0.1",
+ "dirs",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook"
@@ -2684,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2703,6 +2886,18 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "syn-serde"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c304c2cec7c24cf8d9da6435d88d1a12eadd1d96212a14bebf2a540155c1e2de"
+dependencies = [
+ "proc-macro2",
+ "serde",
+ "serde_json",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2770,7 +2965,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2832,7 +3027,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2849,11 +3044,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2877,7 +3097,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2945,7 +3165,7 @@ checksum = "2c3e1c30cedd24fc597f7d37a721efdbdc2b1acae012c1ef1218f4c7c2c0f3e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2953,21 +3173,6 @@ name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
-name = "uhlc"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
-dependencies = [
- "hex",
- "humantime",
- "lazy_static",
- "log",
- "serde",
- "spin 0.9.8",
- "uuid",
-]
 
 [[package]]
 name = "uhlc"
@@ -3163,7 +3368,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -3197,7 +3402,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3235,6 +3440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.14",
 ]
 
 [[package]]
@@ -3444,12 +3661,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
-name = "winreg"
-version = "0.6.2"
+name = "winnow"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
- "winapi",
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3462,9 +3689,9 @@ dependencies = [
  "async-std",
  "async-trait",
  "base64 0.21.2",
- "env_logger 0.10.0",
- "event-listener",
- "flume",
+ "env_logger",
+ "event-listener 2.5.3",
+ "flume 0.10.14",
  "form_urlencoded",
  "futures",
  "git-version",
@@ -3480,7 +3707,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.3",
  "stop-token",
- "uhlc 0.6.0",
+ "uhlc",
  "uuid",
  "vec_map",
  "zenoh-buffers",
@@ -3525,7 +3752,7 @@ version = "0.7.2-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26a335017307325b945695321ab104053169400c392a441bf9a8cbb66a45e20f"
 dependencies = [
- "uhlc 0.6.0",
+ "uhlc",
  "zenoh-buffers",
  "zenoh-protocol",
  "zenoh-shm",
@@ -3543,7 +3770,7 @@ version = "0.7.2-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "163e56bb816e795ef4d77171779c0c154c17b5b2c6c81df4ad3d720e43508964"
 dependencies = [
- "flume",
+ "flume 0.10.14",
  "json5",
  "num_cpus",
  "serde",
@@ -3590,8 +3817,8 @@ checksum = "c6e4b40416a10ab26fbd3a9b5c3a57ec97e6c6e2a2d512b40fa0f494ef6d459d"
 dependencies = [
  "async-std",
  "bincode",
- "env_logger 0.10.0",
- "flume",
+ "env_logger",
+ "flume 0.10.14",
  "futures",
  "log",
  "serde",
@@ -3612,21 +3839,21 @@ dependencies = [
  "async-recursion",
  "async-std",
  "async-trait",
- "base64 0.20.0",
+ "base64 0.21.2",
  "bincode",
  "bytesize",
  "clap 4.4.5",
  "const_format",
  "derive_more",
- "env_logger 0.10.0",
- "event-listener",
- "flume",
+ "env_logger",
+ "event-listener 3.0.0",
+ "flume 0.11.0",
  "futures",
  "futures-lite",
  "git-version",
  "humantime",
- "itertools",
- "libloading",
+ "itertools 0.11.0",
+ "libloading 0.8.0",
  "log",
  "more-asserts",
  "paste",
@@ -3642,7 +3869,7 @@ dependencies = [
  "serde_yaml",
  "tempdir",
  "typetag",
- "uhlc 0.5.2",
+ "uhlc",
  "url",
  "uuid",
  "zenoh",
@@ -3661,8 +3888,8 @@ dependencies = [
  "async-std",
  "async-trait",
  "clap 4.4.5",
- "env_logger 0.10.0",
- "flume",
+ "env_logger",
+ "flume 0.11.0",
  "futures",
  "git-version",
  "hostname",
@@ -3672,7 +3899,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "uhlc 0.5.2",
+ "uhlc",
  "uuid",
  "zenoh",
  "zenoh-flow",
@@ -3687,16 +3914,16 @@ version = "0.6.0-dev"
 dependencies = [
  "Inflector",
  "async-std",
- "darling",
- "env_logger 0.9.3",
+ "darling 0.20.3",
+ "env_logger",
  "futures",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde",
  "serde_derive",
- "syn 1.0.109",
- "syn-serde",
+ "syn 2.0.37",
+ "syn-serde 0.3.0",
 ]
 
 [[package]]
@@ -3706,8 +3933,8 @@ dependencies = [
  "async-std",
  "async-trait",
  "clap 4.4.5",
- "env_logger 0.10.0",
- "flume",
+ "env_logger",
+ "flume 0.11.0",
  "futures",
  "git-version",
  "lazy_static",
@@ -3767,7 +3994,7 @@ checksum = "6a4cd6695c8ef48d6e4b1d94afefff756a3c1c67ae76c7da72b1d7a99611b009"
 dependencies = [
  "async-std",
  "async-trait",
- "flume",
+ "flume 0.10.14",
  "serde",
  "typenum",
  "zenoh-buffers",
@@ -3923,7 +4150,7 @@ version = "0.7.2-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76064f47c2b4e5e250f0981d4cda4ac6043cc6cf3625b6bc8c7dae38c0cf403"
 dependencies = [
- "libloading",
+ "libloading 0.7.4",
  "log",
  "serde_json",
  "zenoh-macros",
@@ -3940,7 +4167,7 @@ dependencies = [
  "hex",
  "rand 0.8.5",
  "serde",
- "uhlc 0.6.0",
+ "uhlc",
  "uuid",
  "zenoh-buffers",
  "zenoh-keyexpr",
@@ -3977,8 +4204,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4954bb734cc609e657be29afb33feb571b5eb0a042cc3b4c163ea75aae1e1d"
 dependencies = [
  "async-std",
- "event-listener",
- "flume",
+ "event-listener 2.5.3",
+ "flume 0.10.14",
  "futures",
  "tokio",
  "zenoh-buffers",
@@ -3996,7 +4223,7 @@ dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "flume",
+ "flume 0.10.14",
  "log",
  "lz4_flex",
  "paste",
@@ -4028,14 +4255,14 @@ dependencies = [
  "async-std",
  "async-trait",
  "clap 3.2.25",
- "flume",
+ "flume 0.10.14",
  "futures",
  "hex",
  "home",
  "humantime",
  "lazy_static",
  "libc",
- "libloading",
+ "libloading 0.7.4",
  "log",
  "pnet",
  "pnet_datalink",
@@ -4057,11 +4284,11 @@ name = "zfctl"
 version = "0.6.0-dev"
 dependencies = [
  "async-std",
- "base64 0.20.0",
+ "base64 0.21.2",
  "clap 4.4.5",
  "derive_more",
- "dirs 4.0.0",
- "env_logger 0.10.0",
+ "dirs",
+ "env_logger",
  "exitfailure",
  "failure",
  "git-version",
@@ -4089,7 +4316,7 @@ checksum = "4924c0ef36ac76eac19468c7f800c24d51058a6f59049b5781fc0c40d002eca5"
 dependencies = [
  "async-std",
  "base64 0.21.2",
- "flume",
+ "flume 0.10.14",
  "futures",
  "log",
  "serde",
@@ -4109,7 +4336,7 @@ dependencies = [
  "Inflector",
  "async-std",
  "base64 0.21.2",
- "darling",
+ "darling 0.14.4",
  "futures",
  "log",
  "proc-macro2",
@@ -4117,7 +4344,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "syn 1.0.109",
- "syn-serde",
+ "syn-serde 0.2.4",
  "zenoh",
  "zenoh-util",
  "zrpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,22 @@ repository = "https://github.com/eclipse-zenoh/zenoh-flow"
 version = "0.6.0-dev"
 
 [workspace.dependencies]
-clap = { version = "4.0" }
+async-std = "1.12"
+async-trait = "0.1.50"
+base64 = "0.21"
+clap = "4.0"
+env_logger = "0.10"
+flume = "0.11"
+futures = "0.3.15"
+git-version = "0.3"
+log = "0.4"
+serde = "1.0"
+serde_cbor = "0.11"
+serde_derive = "1.0"
+serde_json = "1.0"
+serde_yaml = "0.9"
+uhlc = "0.6"
+uuid = "1.1"
 zenoh = { version = "0.7.2-rc" }
 zenoh-collections = { version = "0.7.2-rc" }
 zenoh-core = { version = "0.7.2-rc" }

--- a/cargo-zenoh-flow/Cargo.toml
+++ b/cargo-zenoh-flow/Cargo.toml
@@ -27,17 +27,17 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-std = { version = "=1.12.0", features = ["attributes"] }
-cargo_toml = "0.13"
+async-std = { workspace = true, features = ["attributes"] }
+cargo_toml = "0.15"
 clap = { workspace = true, features = ["derive"] }
 colored = "2"
 rand = { version = "0.8", optional = true }
-serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
-serde_json = "1.0"
-serde_yaml = { version = "0.9" }
+serde = { workspace = true, features = ["derive"] }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tinytemplate = "1.2"
-toml = "0.5.8"
+toml = "0.7"
 zenoh = { workspace = true, optional = true }
 zenoh-flow = { path = "../zenoh-flow", version = "0.6.0-dev" }
 zenoh-util = { workspace = true, optional = true }

--- a/cargo-zenoh-flow/src/utils.rs
+++ b/cargo-zenoh-flow/src/utils.rs
@@ -118,24 +118,24 @@ pub fn from_manifest(
     let manifest_path = Path::new(&root_package.manifest_path);
 
     let manifest_dir = manifest_path.parent().unwrap();
-    let content = std::fs::read(manifest_path)?;
 
-    let metadata = toml::from_slice::<Cargo>(&content)?
-        .package
-        .metadata
-        .ok_or_else(|| {
-            CZFError::MissingField(
-                root_package.id.clone(),
-                "Missing package.metadata.zenohflow",
-            )
-        })?
-        .zenohflow
-        .ok_or_else(|| {
-            CZFError::MissingField(
-                root_package.id.clone(),
-                "Missing package.metadata.zenohflow",
-            )
-        })?;
+    let metadata =
+        toml::from_str::<Cargo>(&String::from_utf8_lossy(&std::fs::read(manifest_path)?))?
+            .package
+            .metadata
+            .ok_or_else(|| {
+                CZFError::MissingField(
+                    root_package.id.clone(),
+                    "Missing package.metadata.zenohflow",
+                )
+            })?
+            .zenohflow
+            .ok_or_else(|| {
+                CZFError::MissingField(
+                    root_package.id.clone(),
+                    "Missing package.metadata.zenohflow",
+                )
+            })?;
 
     Ok((metadata, target_dir.into(), manifest_dir.into()))
 }

--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -24,26 +24,24 @@ readme.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 async-ctrlc = { version = "1.2.0", features = ["stream"] }
-async-std = { version = "=1.12.0", features = ["attributes"] }
-async-trait = "0.1.50"
+async-std = { workspace = true, features = ["attributes"] }
+async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-env_logger = "0.10.0"
-flume = "0.10"
-futures = "0.3.5"
-git-version = "0.3"
+env_logger = { workspace = true }
+flume = { workspace = true }
+futures = { workspace = true }
+git-version = { workspace = true }
 hostname = "0.3.1"
-log = "0.4"
-machine-uid = "0.2.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_derive = "1.0"
-serde_json = "1.0"
-serde_yaml = { version = "0.9" }
-uhlc = "0.5.1"
-uuid = { version = "1.1", features = ["serde", "v4"] }
+log = { workspace = true }
+machine-uid = "0.5.0"
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+uhlc = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
 zenoh = { workspace = true }
 zenoh-flow = { version = "0.6.0-dev", path = "../zenoh-flow" }
 zenoh-util = { workspace = true }

--- a/zenoh-flow-derive/Cargo.toml
+++ b/zenoh-flow-derive/Cargo.toml
@@ -28,19 +28,19 @@ version.workspace = true
 
 [dependencies]
 Inflector = "0.11.4"
-async-std = { version = "=1.12.0", features = ["attributes"] }
-darling = "0.14"
-futures = "0.3.5"
+async-std = { workspace = true, features = ["attributes"] }
+darling = "0.20"
+futures = { workspace = true }
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
-serde = { version = "1.0.55", features = ["derive"] }
-serde_derive = "1.0.55"
-syn = { version = "1.0", features = ["full"] }
-syn-serde = { version = "0.2", features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_derive = { workspace = true }
+syn = { version = "2", features = ["full"] }
+syn-serde = { version = "0.3", features = ["json"] }
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/zenoh-flow-plugin/Cargo.toml
+++ b/zenoh-flow-plugin/Cargo.toml
@@ -33,17 +33,17 @@ default = ["no_mangle"]
 no_mangle = ["zenoh-plugin-trait/no_mangle"]
 
 [dependencies]
-async-std = "=1.12.0"
-async-trait = "0.1.57"
+async-std = { workspace = true }
+async-trait = { workspace = true }
 clap = { workspace = true }
-env_logger = "0.10"
-flume = "0.10.14"
-futures = "0.3.24"
-git-version = "0.3.5"
+env_logger = { workspace = true }
+flume = { workspace = true }
+futures = { workspace = true }
+git-version = { workspace = true }
 lazy_static = "1.4.0"
-log = "0.4.17"
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = "1.0"
+log = { workspace = true }
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json = { workspace = true }
 zenoh = { workspace = true, features = ["unstable"] }
 zenoh-collections = { workspace = true }
 zenoh-core = { workspace = true }

--- a/zenoh-flow/Cargo.toml
+++ b/zenoh-flow/Cargo.toml
@@ -28,38 +28,38 @@ version.workspace = true
 anyhow = { version = "1.0", default-features = false, features = ["std"] }
 async-lock = "2.4.0"
 async-recursion = "1.0.0"
-async-std = { version = "=1.12.0", features = ["attributes"] }
-async-trait = "0.1.50"
-base64 = "0.20.0"
+async-std = { workspace = true, features = ["attributes"] }
+async-trait = { workspace = true }
+base64 = { workspace = true }
 bincode = { version = "1.3" }
 bytesize = "1.2.0"
 clap = { workspace = true, features = ["derive"] }
 const_format = "0.2.22"
 derive_more = "0.99.10"
-env_logger = "0.10"
-event-listener = "2.5.1"
-flume = "0.10"
-futures = "0.3.15"
+env_logger = { workspace = true }
+event-listener = "3.0"
+flume = { workspace = true }
+futures = { workspace = true }
 futures-lite = "1.12"
-git-version = "0.3"
-humantime = "2.1.0"
-itertools = "0.10.3"
-libloading = "0.7.0"
-log = "0.4"
+git-version = { workspace = true }
+humantime = "2.1"
+itertools = "0.11"
+libloading = "0.8"
+log = { workspace = true }
 more-asserts = "0.3"
 paste = "1.0"
 petgraph = "0.6.0"
 pin-project-lite = "0.2.4"
 ramhorns = "0.14"
-serde = { version = "1.0.55", features = ["derive", "rc"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_cbor = { version = "0.11", optional = true }
-serde_derive = "1.0.55"
-serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.9" }
+serde_derive = { workspace = true }
+serde_json = { workspace = true, optional = true }
+serde_yaml = { workspace = true }
 typetag = "0.2"
-uhlc = "0.5.1"
+uhlc = { workspace = true }
 url = "2.2"
-uuid = { version = "1.1", features = ["serde", "v4"] }
+uuid = { workspace = true, features = ["serde", "v4"] }
 zenoh = { workspace = true, features = ["shared-memory"] }
 zenoh-flow-derive = { version = "0.6.0-dev", path = "../zenoh-flow-derive" }
 zenoh-sync = { workspace = true }
@@ -68,7 +68,7 @@ zrpc = { workspace = true }
 zrpc-macros = { workspace = true }
 
 [dev-dependencies]
-prost = "0.11"
+prost = "0.12"
 tempdir = "0.3.7"
 
 [build-dependencies]

--- a/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
+++ b/zenoh-flow/src/runtime/dataflow/instance/runners/connector.rs
@@ -23,12 +23,11 @@ use crate::zfresult::ErrorKind;
 use crate::Result as ZFResult;
 use async_std::sync::Mutex;
 use async_trait::async_trait;
-use flume::Receiver;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use zenoh::prelude::r#async::*;
 use zenoh::shm::SharedMemoryManager;
-use zenoh::subscriber::Subscriber;
+use zenoh::subscriber::FlumeSubscriber;
 use zenoh_util::core::AsyncResolve;
 
 /// The `ZenohSender` is the connector that sends the data to Zenoh when nodes are running on
@@ -258,7 +257,7 @@ impl Node for ZenohSender {
 pub(crate) struct ZenohReceiver {
     pub(crate) id: NodeId,
     pub(crate) output_raw: OutputRaw,
-    pub(crate) subscriber: Subscriber<'static, Receiver<Sample>>,
+    pub(crate) subscriber: FlumeSubscriber<'static>,
 }
 
 impl ZenohReceiver {

--- a/zenoh-flow/src/runtime/resources.rs
+++ b/zenoh-flow/src/runtime/resources.rs
@@ -779,7 +779,7 @@ impl DataStore {
     pub async fn subscribe_sumbitted_jobs(
         &self,
         rtid: &ZenohId,
-    ) -> Result<zenoh::subscriber::Subscriber<'static, flume::Receiver<Sample>>> {
+    ) -> Result<zenoh::subscriber::FlumeSubscriber<'static>> {
         let selector = JQ_SUMBITTED_SEL!(ROOT_STANDALONE, rtid);
         self.z.declare_subscriber(&selector).res().await
     }

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -25,25 +25,25 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-async-std = { version = "=1.12.0", features = ["attributes"] }
-base64 = "0.20.0"
+async-std = { workspace = true, features = ["attributes"] }
+base64 = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 derive_more = "0.99.10"
 # FIXME: Remove when `std::env::home_dir` gets fixed.
-dirs = "4.0.0"
-env_logger = "0.10.0"
+dirs = "5.0"
+env_logger = { workspace = true }
 exitfailure = "0.5.1"
 failure = "0.1.8"
-git-version = "0.3.4"
-log = "0.4"
+git-version = { workspace = true }
+log = { workspace = true }
 prettytable-rs = "^0.10"
 rand = "0.8.3"
 semver = { version = "1.0.4", features = ["serde"] }
-serde = { version = "1.0.55", features = ["derive"] }
-serde_derive = "1.0.55"
-serde_json = "1.0.55"
-serde_yaml = "0.9"
-uuid = { version = "1.1", features = ["serde", "v4"] }
+serde = { workspace = true, features = ["derive"] }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
 zenoh = { workspace = true }
 zenoh-flow = { version = "0.6.0-dev", path = "../zenoh-flow" }
 zenoh-util = { workspace = true }


### PR DESCRIPTION
The updates that induced changes were:

- (Zenoh-Flow) flume 0.10 -> 0.11: as we were explicitly defining the Subscriber (in particular the `Receiver<Sample>`), the version of flume we were using was tied to Zenoh's. By using Zenoh's `FlumeSubscriber`, we can update the version of flume independently of Zenoh.

- (cargo-zenoh-flow) toml 0.5 -> 0.7: parsing must be done via a String rather than via slice.