### PR TITLE
refacto(commons): move `parse_vars` function in `commons` crate

### DIFF
--- a/zenoh-flow-commons/src/lib.rs
+++ b/zenoh-flow-commons/src/lib.rs
@@ -34,7 +34,7 @@ mod utils;
 pub use utils::try_load_from_file;
 
 mod vars;
-pub use vars::Vars;
+pub use vars::{parse_vars, Vars};
 
 /// Zenoh-Flow's result type.
 pub type Result<T> = std::result::Result<T, anyhow::Error>;

--- a/zenoh-flow-commons/src/vars.rs
+++ b/zenoh-flow-commons/src/vars.rs
@@ -15,6 +15,7 @@
 use crate::IMergeOverwrite;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::error::Error;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -77,4 +78,21 @@ impl<T: AsRef<str>, U: AsRef<str>> From<Vec<(T, U)>> for Vars {
             ),
         }
     }
+}
+
+
+/// Parse a Vars from a string of the format "KEY=VALUE".
+pub fn parse_vars<T, U>(
+    s: &str,
+) -> std::result::Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }

--- a/zfctl/src/instance_command.rs
+++ b/zfctl/src/instance_command.rs
@@ -14,7 +14,7 @@
 
 use crate::row;
 
-use super::{parse_key_val, ZENOH_FLOW_INTERNAL_ERROR};
+use super::ZENOH_FLOW_INTERNAL_ERROR;
 
 use std::path::PathBuf;
 
@@ -23,7 +23,7 @@ use clap::Subcommand;
 use comfy_table::Table;
 use uuid::Uuid;
 use zenoh::prelude::r#async::*;
-use zenoh_flow_commons::{Result, RuntimeId, Vars};
+use zenoh_flow_commons::{parse_vars, Result, RuntimeId, Vars};
 use zenoh_flow_daemon::{selectors, InstanceStatus, InstancesQuery, Origin};
 use zenoh_flow_descriptors::{DataFlowDescriptor, FlattenedDataFlowDescriptor};
 
@@ -56,7 +56,7 @@ pub(crate) enum InstanceCommand {
         ///
         /// Example:
         ///     --vars HOME_DIR=/home/zenoh-flow --vars BUILD=debug
-        #[arg(long, value_parser = parse_key_val::<String, String>, verbatim_doc_comment)]
+        #[arg(long, value_parser = parse_vars::<String, String>, verbatim_doc_comment)]
         vars: Option<Vec<(String, String)>>,
     },
     /// To delete (and abort, if required) the data flow instance

--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -15,8 +15,6 @@
 mod instance_command;
 mod runtime_command;
 
-use std::error::Error;
-
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};
 use instance_command::InstanceCommand;
@@ -65,22 +63,6 @@ enum Command {
     /// To interact with a Zenoh-Flow runtime.
     #[command(subcommand)]
     Runtime(RuntimeCommand),
-}
-
-/// Parse a single key-value pair
-fn parse_key_val<T, U>(
-    s: &str,
-) -> std::result::Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
-where
-    T: std::str::FromStr,
-    T::Err: Error + Send + Sync + 'static,
-    U: std::str::FromStr,
-    U::Err: Error + Send + Sync + 'static,
-{
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
-    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
 #[async_std::main]


### PR DESCRIPTION
This will allow reusing this logic in all Zenoh-Flow executable.