### PR TITLE
fix(deps): Cargo.lock dependencies for standalone runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,8 @@ dependencies = [
  "async-std",
  "clap",
  "serde",
+ "tracing",
+ "tracing-subscriber",
  "uhlc",
  "zenoh-flow-commons",
  "zenoh-flow-descriptors",


### PR DESCRIPTION
The `tracing` and `tracing-subscriber` dependencies were, somehow, forgotten.