### PR TITLE
rename(commons): `try_load_from_file` to `try_parse_from_file`

### DIFF
--- a/zenoh-flow-commons/src/lib.rs
+++ b/zenoh-flow-commons/src/lib.rs
@@ -33,7 +33,7 @@ mod shared_memory;
 pub use shared_memory::SharedMemoryConfiguration;
 
 mod utils;
-pub use utils::try_load_from_file;
+pub use utils::try_parse_from_file;
 
 mod vars;
 pub use vars::{parse_vars, Vars};

--- a/zenoh-flow-commons/src/utils.rs
+++ b/zenoh-flow-commons/src/utils.rs
@@ -58,7 +58,7 @@ Currently supported file extensions are:
 /// - YAML (`.yaml` or `.yml` extensions)
 ///
 /// This function does not impose writing *all* descriptor file, within the same data flow, in the same format.
-pub fn try_load_from_file<N>(path: impl AsRef<Path>, vars: Vars) -> Result<(N, Vars)>
+pub fn try_parse_from_file<N>(path: impl AsRef<Path>, vars: Vars) -> Result<(N, Vars)>
 where
     N: for<'a> Deserialize<'a>,
 {

--- a/zenoh-flow-daemon/src/lib.rs
+++ b/zenoh-flow-daemon/src/lib.rs
@@ -31,7 +31,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use uhlc::HLC;
 use zenoh::{prelude::r#async::*, queryable::Query};
-use zenoh_flow_commons::{try_load_from_file, Result, Vars};
+use zenoh_flow_commons::{try_parse_from_file, Result, Vars};
 use zenoh_flow_runtime::{Extensions, Loader, Runtime};
 
 use crate::configuration::ExtensionsConfiguration;
@@ -180,7 +180,7 @@ impl Daemon {
         let extensions = if let Some(extensions) = configuration.extensions {
             match extensions {
                 ExtensionsConfiguration::File(path) => {
-                    try_load_from_file::<Extensions>(path, Vars::default()).map(|(ext, _)| ext)
+                    try_parse_from_file::<Extensions>(path, Vars::default()).map(|(ext, _)| ext)
                 }
                 ExtensionsConfiguration::Extensions(extensions) => Ok(extensions),
             }?

--- a/zenoh-flow-descriptors/src/uri.rs
+++ b/zenoh-flow-descriptors/src/uri.rs
@@ -15,7 +15,7 @@
 use anyhow::{bail, Context};
 use serde::Deserialize;
 use url::Url;
-use zenoh_flow_commons::{try_load_from_file, Result, Vars};
+use zenoh_flow_commons::{try_parse_from_file, Result, Vars};
 
 pub(crate) fn try_load_descriptor<N>(uri: &str, vars: Vars) -> Result<(N, Vars)>
 where
@@ -24,7 +24,7 @@ where
     let url = Url::parse(uri).context(format!("Failed to parse uri:\n{}", uri))?;
 
     match url.scheme() {
-        "file" => try_load_from_file::<N>(url.path(), vars).context(format!(
+        "file" => try_parse_from_file::<N>(url.path(), vars).context(format!(
             "Failed to load descriptor from file:\n{}",
             url.path()
         )),

--- a/zenoh-flow-runtime/src/loader/mod.rs
+++ b/zenoh-flow-runtime/src/loader/mod.rs
@@ -88,8 +88,10 @@ impl Loader {
 
     /// TODO@J-Loudet
     pub fn try_from_file(extensions_path: impl AsRef<Path>) -> Result<Self> {
-        let (extensions, _) =
-            zenoh_flow_commons::try_load_from_file::<Extensions>(extensions_path, Vars::default())?;
+        let (extensions, _) = zenoh_flow_commons::try_parse_from_file::<Extensions>(
+            extensions_path,
+            Vars::default(),
+        )?;
 
         Ok(Self {
             extensions,

--- a/zenoh-flow-standalone-runtime/src/main.rs
+++ b/zenoh-flow-standalone-runtime/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
 
     let extensions = match cli.extensions {
         Some(extensions_path) => {
-            let (extensions, _) = zenoh_flow_commons::try_load_from_file::<Extensions>(
+            let (extensions, _) = zenoh_flow_commons::try_parse_from_file::<Extensions>(
                 extensions_path.as_os_str(),
                 Vars::default(),
             )
@@ -70,7 +70,7 @@ async fn main() {
     };
 
     let (data_flow, vars) =
-        zenoh_flow_commons::try_load_from_file::<DataFlowDescriptor>(cli.flow.as_os_str(), vars)
+        zenoh_flow_commons::try_parse_from_file::<DataFlowDescriptor>(cli.flow.as_os_str(), vars)
             .context(format!(
                 "Failed to load data flow descriptor from < {} >",
                 &cli.flow.display()

--- a/zfctl/src/instance_command.rs
+++ b/zfctl/src/instance_command.rs
@@ -90,7 +90,7 @@ impl InstanceCommand {
 
                 tracing::trace!("Path to data flow descriptor is: {}", flow.display());
                 let (data_flow_desc, vars) =
-                    zenoh_flow_commons::try_load_from_file::<DataFlowDescriptor>(&flow, vars)
+                    zenoh_flow_commons::try_parse_from_file::<DataFlowDescriptor>(&flow, vars)
                         .map_err(|e| {
                             tracing::error!("{:?}", e);
                             anyhow!("Failed to parse data flow from < {} >", flow.display())


### PR DESCRIPTION
It's a bit of a nitpick but we're attempting to parse a descriptor (in our case) from the file rather than trying to load anything.