### PR TITLE
refacto(descriptors): use `Url` instead of `Arc<str>`

### DIFF
--- a/zenoh-flow-descriptors/src/flattened/nodes/operator.rs
+++ b/zenoh-flow-descriptors/src/flattened/nodes/operator.rs
@@ -61,7 +61,7 @@ impl FlattenedOperatorDescriptor {
         mut outer_configuration: Configuration,
         mut overwritting_configuration: Configuration,
         overwritting_vars: Vars,
-        ancestors: &mut HashSet<Arc<str>>,
+        ancestors: &mut HashSet<Url>,
     ) -> Result<(Vec<Self>, Vec<LinkDescriptor>, Patch)> {
         let descriptor = match operator_descriptor.variant {
             OperatorVariants::Remote(remote_desc) => {

--- a/zenoh-flow-descriptors/src/flattened/tests.rs
+++ b/zenoh-flow-descriptors/src/flattened/tests.rs
@@ -45,7 +45,7 @@ fn test_flatten_descriptor() {
     let runtime_composite = RuntimeId::rand();
 
     let (descriptor, vars) = try_load_descriptor::<DataFlowDescriptor>(
-        &format!("file://{}/data-flow.yml", base_dir),
+        &Url::parse(&format!("file://{}/data-flow.yml", base_dir)).unwrap(),
         Vars::from([
             ("BASE_DIR", base_dir.as_str()),
             ("RUNTIME_1", format!("{}", runtime_1).as_str()),
@@ -333,10 +333,10 @@ fn test_flatten_descriptor() {
 #[test]
 fn test_detect_recursion() {
     let base_dir = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), BASE_DIR);
-    let path = format!("{}{}/data-flow-recursion.yml", SCHEME, base_dir);
+    let url = Url::parse(&format!("{}{}/data-flow-recursion.yml", SCHEME, base_dir)).unwrap();
 
     let (descriptor, vars) = try_load_descriptor::<DataFlowDescriptor>(
-        &path,
+        &url,
         Vars::from([("BASE_DIR", base_dir.as_str()), ("SCHEME", SCHEME)]),
     )
     .expect("Failed to parse descriptor");
@@ -346,10 +346,11 @@ fn test_detect_recursion() {
 #[test]
 fn test_duplicate_composite_at_same_level_not_detected_as_recursion() {
     let base_dir = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), BASE_DIR);
-    let path = format!(
+    let path = Url::parse(&format!(
         "{}/{}/data-flow-recursion-duplicate-composite.yml",
         SCHEME, base_dir,
-    );
+    ))
+    .unwrap();
 
     let (descriptor, vars) = try_load_descriptor::<DataFlowDescriptor>(
         &path,

--- a/zenoh-flow-descriptors/src/nodes/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/mod.rs
@@ -18,12 +18,12 @@ pub(crate) mod sink;
 pub(crate) mod source;
 
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use url::Url;
 use zenoh_flow_commons::{Configuration, RuntimeId};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct RemoteNodeDescriptor {
-    pub descriptor: Arc<str>,
+    pub descriptor: Url,
     #[serde(default)]
     pub configuration: Configuration,
     #[serde(default)]

--- a/zenoh-flow-descriptors/src/uri.rs
+++ b/zenoh-flow-descriptors/src/uri.rs
@@ -17,21 +17,15 @@ use serde::Deserialize;
 use url::Url;
 use zenoh_flow_commons::{try_load_from_file, Result, Vars};
 
-pub(crate) fn try_load_descriptor<N>(uri: &str, vars: Vars) -> Result<(N, Vars)>
+pub(crate) fn try_load_descriptor<N>(url: &Url, vars: Vars) -> Result<(N, Vars)>
 where
     N: for<'a> Deserialize<'a>,
 {
-    let url = Url::parse(uri).context(format!("Failed to parse uri:\n{}", uri))?;
-
     match url.scheme() {
         "file" => try_load_from_file::<N>(url.path(), vars).context(format!(
             "Failed to load descriptor from file:\n{}",
             url.path()
         )),
-        _ => bail!(
-            "Failed to parse uri, unsupported scheme < {} > found:\n{}",
-            url.scheme(),
-            uri
-        ),
+        _ => bail!("Unsupported URL scheme < {} >", url.scheme(),),
     }
 }

--- a/zenoh-flow-descriptors/tests/descriptors/data-flow-recursion.yml
+++ b/zenoh-flow-descriptors/tests/descriptors/data-flow-recursion.yml
@@ -1,22 +1,22 @@
 name: test-recursion
 
 vars:
-  BASE_DIR: file://./src/tests
+  BASE_DIR: ./src/tests
 
 sources:
   - id: source-1
-    descriptor: "{{ BASE_DIR }}/source-1.yml"
+    descriptor: "file://{{ BASE_DIR }}/source-1.yml"
 
 operators:
   - id: operator-1
-    descriptor: "{{ BASE_DIR }}/operator-1.yml"
+    descriptor: "file://{{ BASE_DIR }}/operator-1.yml"
 
   - id: operator-infinite
-    descriptor: "{{ BASE_DIR }}/operator-infinite.yml"
+    descriptor: "file://{{ BASE_DIR }}/operator-infinite.yml"
 
 sinks:
   - id: sink-1
-    descriptor: "{{ BASE_DIR }}/sink-1.yml"
+    descriptor: "file://{{ BASE_DIR }}/sink-1.yml"
 
 links:
   - from:


### PR DESCRIPTION
The `descriptor` field of a Node is, in fact, a Url. This commit makes that change which allows us to remove one error scenario from our code base.