### PR TITLE
refacto(descriptors): only specify runtime in `mapping` section

### DIFF
--- a/zenoh-flow-descriptors/src/nodes/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/mod.rs
@@ -19,13 +19,11 @@ pub(crate) mod source;
 
 use serde::{Deserialize, Serialize};
 use url::Url;
-use zenoh_flow_commons::{Configuration, RuntimeId};
+use zenoh_flow_commons::Configuration;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct RemoteNodeDescriptor {
     pub descriptor: Url,
     #[serde(default)]
     pub configuration: Configuration,
-    #[serde(default)]
-    pub runtime: Option<RuntimeId>,
 }

--- a/zenoh-flow-descriptors/src/nodes/operator/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/operator/mod.rs
@@ -18,7 +18,7 @@ use super::RemoteNodeDescriptor;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use url::Url;
-use zenoh_flow_commons::{Configuration, NodeId, PortId, RuntimeId};
+use zenoh_flow_commons::{Configuration, NodeId, PortId};
 
 /// A `OperatorDescriptor` uniquely identifies a Operator.
 ///
@@ -78,9 +78,7 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId, RuntimeId};
 ///
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct OperatorDescriptor {
-    pub id: NodeId,
-    #[serde(default)]
-    pub runtime: Option<RuntimeId>,
+    pub(crate) id: NodeId,
     #[serde(flatten)]
     pub(crate) variant: OperatorVariants,
 }


### PR DESCRIPTION
These fields were wrongfully forgotten during the major refactoring.