### PR TITLE
refacto(descriptors): change visibility of base descriptors

### DIFF
--- a/zenoh-flow-descriptors/src/dataflow.rs
+++ b/zenoh-flow-descriptors/src/dataflow.rs
@@ -12,12 +12,15 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use crate::{LinkDescriptor, OperatorDescriptor, SinkDescriptor, SourceDescriptor};
+use crate::nodes::operator::OperatorDescriptor;
+use crate::nodes::sink::SinkDescriptor;
+use crate::nodes::source::SourceDescriptor;
+use crate::LinkDescriptor;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
 use uuid::Uuid;
 use zenoh_flow_commons::{Configuration, NodeId, RuntimeId};
 
@@ -77,17 +80,20 @@ pub struct DataFlowDescriptor {
     /// If provided, Zenoh-Flow will not generate one when instantiating the flow and keep this value instead. This
     /// behavior can be useful when it is impossible to rely on a correctly configured Zenoh router (i.e. where a
     /// storage subscribing to Zenoh-Flow's key expression exists).
+    pub(crate) uuid: Option<Uuid>,
+    pub(crate) name: Arc<str>,
     #[serde(default)]
-    pub uuid: Option<Uuid>,
-    pub name: Arc<str>,
+    pub(crate) configuration: Configuration,
+    /// *(optional)* A list of Operator(s), the nodes that manipulate and / or produce data.
     #[serde(default)]
-    pub configuration: Configuration,
-    pub operators: Vec<OperatorDescriptor>,
-    pub sources: Vec<SourceDescriptor>,
-    pub sinks: Vec<SinkDescriptor>,
-    pub links: Vec<LinkDescriptor>,
+    pub(crate) operators: Vec<OperatorDescriptor>,
+    /// A non-empty list of Source(s), the nodes that provide data to the data flow.
+    pub(crate) sources: Vec<SourceDescriptor>,
+    /// A non-empty list of Sink(s), the nodes that returns the result of the manipulation.
+    pub(crate) sinks: Vec<SinkDescriptor>,
+    pub(crate) links: Vec<LinkDescriptor>,
     #[serde(default)]
-    pub mapping: HashMap<RuntimeId, HashSet<NodeId>>,
+    pub(crate) mapping: HashMap<RuntimeId, HashSet<NodeId>>,
 }
 
 #[cfg(test)]

--- a/zenoh-flow-descriptors/src/flattened/nodes/operator.rs
+++ b/zenoh-flow-descriptors/src/flattened/nodes/operator.rs
@@ -12,23 +12,19 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use crate::flattened::{Patch, Substitutions};
+use crate::nodes::operator::composite::CompositeOperatorDescriptor;
+use crate::nodes::operator::{CustomOperatorDescriptor, OperatorDescriptor, OperatorVariants};
+use crate::{uri, InputDescriptor, LinkDescriptor, OutputDescriptor};
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Display;
+use std::sync::Arc;
+
 use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Display,
-    sync::Arc,
-};
 use url::Url;
 use zenoh_flow_commons::{Configuration, IMergeOverwrite, NodeId, PortId, Result, Vars};
-
-use crate::{
-    flattened::{Patch, Substitutions},
-    nodes::operator::{
-        composite::CompositeOperatorDescriptor, CustomOperatorDescriptor, OperatorVariants,
-    },
-    uri, InputDescriptor, LinkDescriptor, OperatorDescriptor, OutputDescriptor,
-};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct FlattenedOperatorDescriptor {
@@ -56,7 +52,7 @@ impl Display for FlattenedOperatorDescriptor {
 }
 
 impl FlattenedOperatorDescriptor {
-    pub fn try_flatten(
+    pub(crate) fn try_flatten(
         operator_descriptor: OperatorDescriptor,
         mut outer_configuration: Configuration,
         mut overwritting_configuration: Configuration,

--- a/zenoh-flow-descriptors/src/flattened/nodes/sink.rs
+++ b/zenoh-flow-descriptors/src/flattened/nodes/sink.rs
@@ -12,13 +12,14 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use crate::{
-    nodes::sink::{CustomSinkDescriptor, SinkVariants},
-    uri, SinkDescriptor, ZenohSinkDescriptor,
-};
+use crate::nodes::builtin::zenoh::ZenohSinkDescriptor;
+use crate::nodes::sink::{CustomSinkDescriptor, SinkDescriptor, SinkVariants};
+use crate::uri;
+
+use std::{collections::HashMap, fmt::Display, sync::Arc};
+
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, sync::Arc};
 use url::Url;
 use zenoh_flow_commons::{Configuration, IMergeOverwrite, NodeId, PortId, Result, Vars};
 use zenoh_keyexpr::OwnedKeyExpr;
@@ -56,7 +57,7 @@ impl Display for FlattenedSinkDescriptor {
 }
 
 impl FlattenedSinkDescriptor {
-    pub fn try_flatten(
+    pub(crate) fn try_flatten(
         sink_desc: SinkDescriptor,
         overwritting_vars: Vars,
         mut overwritting_configuration: Configuration,

--- a/zenoh-flow-descriptors/src/flattened/nodes/source.rs
+++ b/zenoh-flow-descriptors/src/flattened/nodes/source.rs
@@ -12,22 +12,19 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+use crate::nodes::builtin::zenoh::ZenohSourceDescriptor;
+use crate::nodes::source::{CustomSourceDescriptor, SourceDescriptor, SourceVariants};
+use crate::uri;
+
+use std::{collections::HashMap, fmt::Display, sync::Arc};
+
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, sync::Arc};
 use url::Url;
 use zenoh_flow_commons::{Configuration, IMergeOverwrite, NodeId, PortId, Result, Vars};
 use zenoh_keyexpr::OwnedKeyExpr;
 
-use crate::{
-    nodes::source::{CustomSourceDescriptor, SourceVariants},
-    uri, SourceDescriptor, ZenohSourceDescriptor,
-};
-
-/// TODO@J-Loudet
-/// - documentation
-/// - validation would be a nice addition: what if users decide to write their own yaml/json and write something that is
-/// wrong? For instance, assuming a built-in Zenoh Source is wanted, some keys that are not mapped to a subscriber.
+/// A `FlattenedSourceDescriptor` is a self-contained description of a Source node.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FlattenedSourceDescriptor {
     pub id: NodeId,
@@ -60,7 +57,7 @@ impl Display for FlattenedSourceDescriptor {
 }
 
 impl FlattenedSourceDescriptor {
-    pub fn try_flatten(
+    pub(crate) fn try_flatten(
         source_desc: SourceDescriptor,
         overwritting_vars: Vars,
         mut overwritting_configuration: Configuration,

--- a/zenoh-flow-descriptors/src/lib.rs
+++ b/zenoh-flow-descriptors/src/lib.rs
@@ -25,7 +25,3 @@ pub use flattened::nodes::sink::{FlattenedSinkDescriptor, SinkVariant};
 pub use flattened::nodes::source::{FlattenedSourceDescriptor, SourceVariant};
 
 pub use io::{InputDescriptor, LinkDescriptor, OutputDescriptor};
-pub use nodes::builtin::zenoh::{ZenohSinkDescriptor, ZenohSourceDescriptor};
-pub use nodes::operator::{composite::CompositeOperatorDescriptor, OperatorDescriptor};
-pub use nodes::sink::SinkDescriptor;
-pub use nodes::source::SourceDescriptor;

--- a/zenoh-flow-descriptors/src/nodes/builtin/zenoh.rs
+++ b/zenoh-flow-descriptors/src/nodes/builtin/zenoh.rs
@@ -33,34 +33,13 @@ use zenoh_keyexpr::OwnedKeyExpr;
 ///
 /// # Examples
 ///
-/// ```
-/// use zenoh_flow_descriptors::ZenohSourceDescriptor;
-///
-/// let yaml_description = r#"
-/// description: My zenoh source
+/// ```yaml
 /// zenoh-subscribers:
 ///   "cmd_vel": "rt/*/cmd_vel"
 ///   "status": "rt/*/status"
-/// "#;
-///
-/// let z_source_yaml = serde_yaml::from_str::<ZenohSourceDescriptor>(yaml_description).unwrap();
-///
-/// let json_description = r#"
-/// {
-///    "description": "My zenoh source",
-///    "zenoh-subscribers": {
-///      "cmd_vel": "rt/*/cmd_vel",
-///      "status": "rt/*/status"
-///    }
-/// }
-/// "#;
-///
-/// let z_source_json = serde_json::from_str::<ZenohSourceDescriptor>(json_description).unwrap();
-///
-/// assert_eq!(z_source_yaml, z_source_json);
 /// ```
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-pub struct ZenohSourceDescriptor {
+pub(crate) struct ZenohSourceDescriptor {
     pub description: Arc<str>,
     #[serde(deserialize_with = "deserialize_canon", alias = "zenoh-subscribers")]
     pub subscribers: HashMap<PortId, OwnedKeyExpr>,
@@ -79,34 +58,14 @@ pub struct ZenohSourceDescriptor {
 ///
 /// # Examples
 ///
-/// ```
-/// use zenoh_flow_descriptors::ZenohSinkDescriptor;
-///
-/// let yaml_description = r#"
+/// ```yaml
 /// description: My zenoh sink
 /// zenoh-publishers:
 ///   cmd_vel: rt/cmd_vel
 ///   status: rt/status
-/// "#;
-///
-/// let z_sink_yaml = serde_yaml::from_str::<ZenohSinkDescriptor>(yaml_description).unwrap();
-///
-/// let json_description = r#"
-/// {
-///    "description": "My zenoh sink",
-///    "zenoh-publishers": {
-///      "cmd_vel": "rt/cmd_vel",
-///      "status": "rt/status"
-///    }
-/// }
-/// "#;
-///
-/// let z_sink_json = serde_json::from_str::<ZenohSinkDescriptor>(json_description).unwrap();
-///
-/// assert_eq!(z_sink_yaml, z_sink_json);
 /// ```
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-pub struct ZenohSinkDescriptor {
+pub(crate) struct ZenohSinkDescriptor {
     pub description: Arc<str>,
     #[serde(deserialize_with = "deserialize_canon", alias = "zenoh-publishers")]
     pub publishers: HashMap<PortId, OwnedKeyExpr>,

--- a/zenoh-flow-descriptors/src/nodes/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/mod.rs
@@ -22,7 +22,7 @@ use url::Url;
 use zenoh_flow_commons::Configuration;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-pub struct RemoteNodeDescriptor {
+pub(crate) struct RemoteNodeDescriptor {
     pub descriptor: Url,
     #[serde(default)]
     pub configuration: Configuration,

--- a/zenoh-flow-descriptors/src/nodes/operator/composite.rs
+++ b/zenoh-flow-descriptors/src/nodes/operator/composite.rs
@@ -12,7 +12,8 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use crate::{InputDescriptor, LinkDescriptor, OperatorDescriptor, OutputDescriptor};
+use crate::nodes::operator::OperatorDescriptor;
+use crate::{InputDescriptor, LinkDescriptor, OutputDescriptor};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use zenoh_flow_commons::{Configuration, NodeId, PortId};
@@ -20,20 +21,10 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 /// TODO@J-Loudet example?
 /// TODO@J-Loudet documentation?
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CompositeOutputDescriptor {
+pub(crate) struct CompositeOutputDescriptor {
     pub id: PortId,
     pub node: NodeId,
     pub output: PortId,
-}
-
-impl CompositeOutputDescriptor {
-    pub fn new(id: impl AsRef<str>, node: impl AsRef<str>, output: impl AsRef<str>) -> Self {
-        Self {
-            id: id.as_ref().into(),
-            node: node.as_ref().into(),
-            output: output.as_ref().into(),
-        }
-    }
 }
 
 impl From<CompositeOutputDescriptor> for OutputDescriptor {
@@ -55,20 +46,10 @@ impl From<CompositeOutputDescriptor> for OutputDescriptor {
 /// input: Input
 /// ```
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct CompositeInputDescriptor {
+pub(crate) struct CompositeInputDescriptor {
     pub id: PortId,
     pub node: NodeId,
     pub input: PortId,
-}
-
-impl CompositeInputDescriptor {
-    pub fn new(id: impl AsRef<str>, node: impl AsRef<str>, input: impl AsRef<str>) -> Self {
-        Self {
-            id: id.as_ref().into(),
-            node: node.as_ref().into(),
-            input: input.as_ref().into(),
-        }
-    }
 }
 
 impl From<CompositeInputDescriptor> for InputDescriptor {
@@ -92,10 +73,7 @@ impl From<CompositeInputDescriptor> for InputDescriptor {
 ///
 /// # Examples
 ///
-/// ```
-/// use zenoh_flow_descriptors::CompositeOperatorDescriptor;
-///
-/// let yaml = r#"
+/// ```yaml
 /// description: CompositeOperator
 ///
 /// configuration:
@@ -125,65 +103,9 @@ impl From<CompositeInputDescriptor> for InputDescriptor {
 ///   - id: CompositeOperator-out
 ///     node: InnerOperator2
 ///     output: out-1
-/// "#;
-///
-/// let composite_operator_yaml = serde_yaml::from_str::<CompositeOperatorDescriptor>(&yaml).unwrap();
-///
-/// let json = r#"
-/// {
-///   "description": "CompositeOperator",
-///
-///   "configuration": {
-///     "name": "foo"
-///   },
-///
-///   "operators": [
-///     {
-///       "id": "InnerOperator1",
-///       "descriptor": "file:///home/zenoh-flow/nodes/operator1.yaml"
-///     },
-///     {
-///       "id": "InnerOperator2",
-///       "descriptor": "file:///home/zenoh-flow/nodes/operator2.yaml"
-///     }
-///   ],
-///
-///   "links": [
-///     {
-///       "from": {
-///         "node": "InnerOperator1",
-///         "output": "out-2"
-///       },
-///       "to": {
-///         "node": "InnerOperator2",
-///         "input": "in-1"
-///       }
-///     }
-///   ],
-///
-///   "inputs": [
-///     {
-///       "id": "CompositeOperator-in",
-///       "node": "InnerOperator1",
-///       "input": "in-1"
-///     }
-///   ],
-///
-///   "outputs": [
-///     {
-///       "id": "CompositeOperator-out",
-///       "node": "InnerOperator2",
-///       "output": "out-1"
-///     }
-///   ]
-/// }"#;
-///
-/// let composite_operator_json = serde_json::from_str::<CompositeOperatorDescriptor>(&json).unwrap();
-/// assert_eq!(composite_operator_yaml, composite_operator_json);
-/// assert_eq!(composite_operator_yaml.configuration.get("name").unwrap().as_str(), Some("foo"));
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct CompositeOperatorDescriptor {
+pub(crate) struct CompositeOperatorDescriptor {
     pub description: Arc<str>,
     pub inputs: Vec<CompositeInputDescriptor>,
     pub outputs: Vec<CompositeOutputDescriptor>,

--- a/zenoh-flow-descriptors/src/nodes/operator/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/operator/mod.rs
@@ -43,25 +43,29 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 ///
 /// ## Remote descriptor
 ///
-/// ```
-/// use zenoh_flow_descriptors::OperatorDescriptor;
+/// ⚠️ For now only the `file://` schema is supported. We are planning to support other protocols in future releases of
+/// Zenoh-Flow.
 ///
-/// let operator_desc_uri = r#"
+/// ```yaml
 /// id: my-operator-1
 /// descriptor: file:///home/zenoh-flow/my-operator.yaml
 /// configuration:
 ///   answer: 1
-/// "#;
+/// ```
 ///
-/// assert!(serde_yaml::from_str::<OperatorDescriptor>(operator_desc_uri).is_ok());
+/// With the file at `/home/zenoh-flow/my-operator.yaml` containing:
+/// ```yaml
+/// description: This is my Operator
+/// library: file:///home/zenoh-flow/libmy_operator.so
+/// inputs:
+///   - in-1
+/// outputs:
+///   - out-1
 /// ```
 ///
 /// ## Inline declaration: custom operator
 ///
-/// ```
-/// use zenoh_flow_descriptors::OperatorDescriptor;
-///
-/// let operator_desc_custom = r#"
+/// ```yaml
 /// id: my-operator-1
 /// description: This is my Operator
 /// library: file:///home/zenoh-flow/libmy_operator.so
@@ -71,16 +75,13 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 ///   - out-1
 /// configuration:
 ///   answer: 1
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<OperatorDescriptor>(operator_desc_custom).is_ok());
 /// ```
 ///
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
-pub struct OperatorDescriptor {
-    pub(crate) id: NodeId,
+pub(crate) struct OperatorDescriptor {
+    pub id: NodeId,
     #[serde(flatten)]
-    pub(crate) variant: OperatorVariants,
+    pub variant: OperatorVariants,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]

--- a/zenoh-flow-descriptors/src/nodes/sink.rs
+++ b/zenoh-flow-descriptors/src/nodes/sink.rs
@@ -13,7 +13,7 @@
 //
 
 use super::RemoteNodeDescriptor;
-use crate::ZenohSinkDescriptor;
+use crate::nodes::builtin::zenoh::ZenohSinkDescriptor;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use url::Url;
@@ -34,26 +34,17 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 /// # Examples
 /// ## Remote descriptor
 ///
-/// ```
-/// use zenoh_flow_descriptors::SinkDescriptor;
-///
-/// let sink_desc_uri = r#"
+/// ```yaml
 /// id: my-sink-0
 /// descriptor: file:///home/zenoh-flow/my-sink.yaml
 /// configuration:
 ///   answer: 0
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<SinkDescriptor>(sink_desc_uri).is_ok());
 /// ```
 ///
 /// ## Inline declaration
 /// ### Custom sink
 ///
-/// ```
-/// use zenoh_flow_descriptors::SinkDescriptor;
-///
-/// let sink_desc_custom = r#"
+/// ```yaml
 /// id: my-sink-0
 /// description: This is my Sink
 /// library: file:///home/zenoh-flow/libmy_sink.so
@@ -62,32 +53,23 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 ///   - out-1
 /// configuration:
 ///   answer: 42
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<SinkDescriptor>(sink_desc_custom).is_ok());
 /// ```
 ///
 /// ### Zenoh built-in Sink
 ///
-/// ```
-/// use zenoh_flow_descriptors::SinkDescriptor;
-///
-/// let sink_desc_zenoh = r#"
+/// ```yaml
 /// id: my-sink-0
 /// description: My zenoh sink
 /// zenoh-publishers:
 ///   key_0: key/expr/0
 ///   key_1: key/expr/1
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<SinkDescriptor>(sink_desc_zenoh).is_ok());
 /// ```
 ///
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct SinkDescriptor {
+pub(crate) struct SinkDescriptor {
     pub id: NodeId,
     #[serde(flatten)]
-    pub(crate) variant: SinkVariants,
+    pub variant: SinkVariants,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/zenoh-flow-descriptors/src/nodes/source.rs
+++ b/zenoh-flow-descriptors/src/nodes/source.rs
@@ -13,7 +13,7 @@
 //
 
 use super::RemoteNodeDescriptor;
-use crate::ZenohSourceDescriptor;
+use crate::nodes::builtin::zenoh::ZenohSourceDescriptor;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use url::Url;
@@ -34,26 +34,17 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 /// # Examples
 /// ## Remote descriptor
 ///
-/// ```
-/// use zenoh_flow_descriptors::SourceDescriptor;
-///
-/// let source_desc_uri = r#"
+/// ```yaml
 /// id: my-source-0
 /// descriptor: file:///home/zenoh-flow/my-source.yaml
 /// configuration:
 ///   answer: 0
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<SourceDescriptor>(source_desc_uri).is_ok());
 /// ```
 ///
 /// ## Inline declaration
 /// ### Custom source
 ///
-/// ```
-/// use zenoh_flow_descriptors::SourceDescriptor;
-///
-/// let source_desc_custom = r#"
+/// ```yaml
 /// id: my-source-0
 /// description: This is my Source
 /// library: file:///home/zenoh-flow/libmy_source.so
@@ -62,31 +53,22 @@ use zenoh_flow_commons::{Configuration, NodeId, PortId};
 ///   - out-1
 /// configuration:
 ///   answer: 42
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<SourceDescriptor>(source_desc_custom).is_ok());
 /// ```
 ///
 /// ### Zenoh built-in Source
 ///
-/// ```
-/// use zenoh_flow_descriptors::SourceDescriptor;
-///
-/// let source_desc_zenoh = r#"
+/// ```yaml
 /// id: my-source-0
 /// description: My zenoh source
 /// zenoh-subscribers:
 ///   ke-0: key/expr/0
 ///   ke-1: key/expr/1
-/// "#;
-///
-/// assert!(serde_yaml::from_str::<SourceDescriptor>(source_desc_zenoh).is_ok());
 /// ```
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct SourceDescriptor {
+pub(crate) struct SourceDescriptor {
     pub id: NodeId,
     #[serde(flatten)]
-    pub(crate) variant: SourceVariants,
+    pub variant: SourceVariants,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
The different "base" node descriptors (i.e. not flattened) were not designed to be exposed in the public API.

This commit changes the visibility of these structures to `pub(crate)`.