### PR TITLE
refacto(descriptors): make description section optional

### DIFF
--- a/zenoh-flow-descriptors/src/flattened/tests.rs
+++ b/zenoh-flow-descriptors/src/flattened/tests.rs
@@ -63,21 +63,21 @@ fn test_flatten_descriptor() {
     let expected_sources = vec![
         FlattenedSourceDescriptor {
             id: "source-1".into(),
-            description: "source".into(),
+            description: Some("source".into()),
             outputs: vec!["source-out".into()],
             source: SourceVariant::Library(Url::parse("file://source.so").unwrap()),
             configuration: json!({ "foo": "global-outer" }).into(),
         },
         FlattenedSourceDescriptor {
             id: "source-2".into(),
-            description: "source".into(),
+            description: Some("source".into()),
             outputs: vec!["source-out".into()],
             source: SourceVariant::Library(Url::parse("file://source.so").unwrap()),
             configuration: json!({ "foo": "global-outer" }).into(),
         },
         FlattenedSourceDescriptor {
             id: "source-composite".into(),
-            description: "composite-source".into(),
+            description: Some("composite-source".into()),
             outputs: vec![
                 "source-composite-out-1".into(),
                 "source-composite-out-2".into(),
@@ -103,7 +103,7 @@ fn test_flatten_descriptor() {
     let expected_operators = vec![
         FlattenedOperatorDescriptor {
             id: "operator-1".into(),
-            description: "operator".into(),
+            description: Some("Outer description".into()),
             inputs: vec!["operator-in".into()],
             outputs: vec!["operator-out".into()],
             library: Url::parse("file://operator.so").unwrap(),
@@ -111,7 +111,7 @@ fn test_flatten_descriptor() {
         },
         FlattenedOperatorDescriptor {
             id: "operator-2".into(),
-            description: "operator".into(),
+            description: Some("operator".into()),
             inputs: vec!["operator-in".into()],
             outputs: vec!["operator-out".into()],
             library: Url::parse("file://operator.so").unwrap(),
@@ -128,7 +128,7 @@ fn test_flatten_descriptor() {
          */
         FlattenedOperatorDescriptor {
             id: "operator-composite>sub-operator-1".into(),
-            description: "leaf-operator-1".into(),
+            description: Some("leaf-operator-1".into()),
             inputs: vec!["sub-operator-1-in-1".into(), "sub-operator-1-in-2".into()],
             outputs: vec!["sub-operator-1-out".into()],
             library: Url::parse("file://sub-operator-1.so").unwrap(),
@@ -144,7 +144,7 @@ fn test_flatten_descriptor() {
          */
         FlattenedOperatorDescriptor {
             id: "operator-composite>sub-operator-composite>sub-sub-operator-1".into(),
-            description: "sub-leaf-operator-1".into(),
+            description: Some("sub-leaf-operator-1".into()),
             inputs: vec!["sub-sub-operator-1-in".into()],
             outputs: vec!["sub-sub-operator-1-out".into()],
             library: Url::parse("file://sub-sub-operator-1.so").unwrap(),
@@ -156,7 +156,7 @@ fn test_flatten_descriptor() {
          */
         FlattenedOperatorDescriptor {
             id: "operator-composite>sub-operator-composite>sub-sub-operator-2".into(),
-            description: "sub-leaf-operator-2".into(),
+            description: Some("sub-leaf-operator-2".into()),
             inputs: vec!["sub-sub-operator-2-in".into()],
             outputs: vec!["sub-sub-operator-2-out".into()],
             library: Url::parse("file://sub-sub-operator-2.so").unwrap(),
@@ -168,7 +168,7 @@ fn test_flatten_descriptor() {
          */
         FlattenedOperatorDescriptor {
             id: "operator-composite>sub-operator-2".into(),
-            description: "leaf-operator-2".into(),
+            description: Some("leaf-operator-2".into()),
             inputs: vec!["sub-operator-2-in".into()],
             outputs: vec!["sub-operator-2-out-1".into(), "sub-operator-2-out-2".into()],
             library: Url::parse("file://sub-operator-2.so").unwrap(),
@@ -194,21 +194,21 @@ fn test_flatten_descriptor() {
     let expected_sinks = vec![
         FlattenedSinkDescriptor {
             id: "sink-1".into(),
-            description: "sink".into(),
+            description: Some("sink".into()),
             inputs: vec!["sink-in".into()],
             sink: SinkVariant::Library(Url::parse("file://sink.so").unwrap()),
             configuration: json!({ "foo": "global-outer" }).into(),
         },
         FlattenedSinkDescriptor {
             id: "sink-2".into(),
-            description: "sink".into(),
+            description: Some("sink".into()),
             inputs: vec!["sink-in".into()],
             sink: SinkVariant::Library(Url::parse("file://sink.so").unwrap()),
             configuration: json!({ "foo": "global-outer" }).into(),
         },
         FlattenedSinkDescriptor {
             id: "sink-composite".into(),
-            description: "composite-sink".into(),
+            description: Some("composite-sink".into()),
             inputs: vec!["sink-composite-in-1".into(), "sink-composite-in-2".into()],
             sink: SinkVariant::Library(Url::parse("file://sink-composite.so").unwrap()),
             configuration: json!({ "foo": "global-outer", "bar": "reverse" }).into(),

--- a/zenoh-flow-descriptors/src/nodes/builtin/zenoh.rs
+++ b/zenoh-flow-descriptors/src/nodes/builtin/zenoh.rs
@@ -40,7 +40,7 @@ use zenoh_keyexpr::OwnedKeyExpr;
 /// ```
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ZenohSourceDescriptor {
-    pub description: Arc<str>,
+    pub description: Option<Arc<str>>,
     #[serde(deserialize_with = "deserialize_canon", alias = "zenoh-subscribers")]
     pub subscribers: HashMap<PortId, OwnedKeyExpr>,
 }
@@ -66,7 +66,7 @@ pub(crate) struct ZenohSourceDescriptor {
 /// ```
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ZenohSinkDescriptor {
-    pub description: Arc<str>,
+    pub description: Option<Arc<str>>,
     #[serde(deserialize_with = "deserialize_canon", alias = "zenoh-publishers")]
     pub publishers: HashMap<PortId, OwnedKeyExpr>,
 }

--- a/zenoh-flow-descriptors/src/nodes/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/mod.rs
@@ -18,12 +18,14 @@ pub(crate) mod sink;
 pub(crate) mod source;
 
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use url::Url;
 use zenoh_flow_commons::Configuration;
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RemoteNodeDescriptor {
     pub descriptor: Url,
+    pub description: Option<Arc<str>>,
     #[serde(default)]
     pub configuration: Configuration,
 }

--- a/zenoh-flow-descriptors/src/nodes/operator/mod.rs
+++ b/zenoh-flow-descriptors/src/nodes/operator/mod.rs
@@ -93,7 +93,7 @@ pub(crate) enum OperatorVariants {
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CustomOperatorDescriptor {
-    pub description: Arc<str>,
+    pub description: Option<Arc<str>>,
     pub library: Url,
     pub inputs: Vec<PortId>,
     pub outputs: Vec<PortId>,

--- a/zenoh-flow-descriptors/src/nodes/sink.rs
+++ b/zenoh-flow-descriptors/src/nodes/sink.rs
@@ -82,7 +82,7 @@ pub(crate) enum SinkVariants {
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CustomSinkDescriptor {
-    pub description: Arc<str>,
+    pub description: Option<Arc<str>>,
     pub library: Url,
     pub inputs: Vec<PortId>,
     #[serde(default)]

--- a/zenoh-flow-descriptors/src/nodes/source.rs
+++ b/zenoh-flow-descriptors/src/nodes/source.rs
@@ -81,7 +81,7 @@ pub(crate) enum SourceVariants {
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CustomSourceDescriptor {
-    pub description: Arc<str>,
+    pub description: Option<Arc<str>>,
     pub library: Url,
     pub outputs: Vec<PortId>,
     #[serde(default)]

--- a/zenoh-flow-descriptors/tests/descriptors/data-flow.yml
+++ b/zenoh-flow-descriptors/tests/descriptors/data-flow.yml
@@ -23,6 +23,7 @@ sources:
 
 operators:
   - id: operator-1
+    description: "Outer description"
     descriptor: "{{ SCHEME }}{{BASE_DIR }}/operator.yml"
 
   - id: operator-2


### PR DESCRIPTION
Before this commit, the `description` field for each node was mandatory. It is now optional for all.

Additionally, when two descriptions are provided (e.g. inside the descriptor file of a node + when it is included in the data flow descriptor), the "outer" description will overwrite the "inner" one. See the modifications made in the flattened tests.