### PR TITLE
fix(descriptors): make operators section optional

### DIFF
--- a/zenoh-flow-descriptors/src/flattened/dataflow.rs
+++ b/zenoh-flow-descriptors/src/flattened/dataflow.rs
@@ -54,6 +54,7 @@ pub struct FlattenedDataFlowDescriptor {
     /// A non-empty list of Sources.
     pub sources: Vec<FlattenedSourceDescriptor>,
     /// A list of Operators.
+    #[serde(default)]
     pub operators: Vec<FlattenedOperatorDescriptor>,
     /// A non-empty list of Sinks.
     pub sinks: Vec<FlattenedSinkDescriptor>,

--- a/zenoh-flow-descriptors/src/flattened/tests.rs
+++ b/zenoh-flow-descriptors/src/flattened/tests.rs
@@ -425,3 +425,50 @@ links:
     assert!(flat_flow_json.uuid.is_none());
     assert!(flat_flow_yaml.mapping.is_empty());
 }
+
+#[test]
+fn test_serialize_deserialize_no_operators() {
+    let flow_yaml = r#"
+name: test-flow
+
+sources:
+  - id: source-0
+    description: source-0
+    library: "file:///home/zenoh-flow/libsource.so"
+    outputs:
+      - out-1
+    configuration:
+      id: source-0
+
+sinks:
+  - id: sink-2
+    description: sink-2
+    library: "file:///home/zenoh-flow/libsink.so"
+    inputs:
+      - in-1
+    configuration:
+      id: sink-2
+
+links:
+  - from:
+      node: source-0
+      output: out-1
+    to:
+      node: sink-2
+      input: in-1
+"#;
+
+    let flat_flow_yaml = serde_yaml::from_str::<FlattenedDataFlowDescriptor>(flow_yaml)
+        .expect("Failed to deserialize flow from YAML");
+
+    let json_string_flow =
+        serde_json::to_string(&flat_flow_yaml).expect("Failed to serialize flow as JSON");
+
+    let flat_flow_json =
+        serde_json::from_str::<FlattenedDataFlowDescriptor>(json_string_flow.as_str())
+            .expect("Failed to deserialize flow from JSON");
+
+    assert_eq!(flat_flow_yaml, flat_flow_json);
+    assert!(flat_flow_json.uuid.is_none());
+    assert!(flat_flow_yaml.mapping.is_empty());
+}


### PR DESCRIPTION
Conceptually, a data flow does not need an Operator to be valid.

This commit allows omitting the `operators` section.