### PR TITLE
refacto: use `InstanceId` instead of `Uuid` for consistency

### DIFF
--- a/zenoh-flow-descriptors/Cargo.toml
+++ b/zenoh-flow-descriptors/Cargo.toml
@@ -30,7 +30,6 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-uuid = { workspace = true }
 zenoh-flow-commons = { workspace = true }
 zenoh-keyexpr = { workspace = true }
 

--- a/zenoh-flow-descriptors/src/dataflow.rs
+++ b/zenoh-flow-descriptors/src/dataflow.rs
@@ -21,8 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-use zenoh_flow_commons::{Configuration, NodeId, RuntimeId};
+use zenoh_flow_commons::{Configuration, InstanceId, NodeId, RuntimeId};
 
 /// A `DataFlowDescriptor` describes an entire Zenoh-Flow application and is obtained after a parsing step.
 ///
@@ -239,7 +238,7 @@ pub struct DataFlowDescriptor {
     /// If provided, Zenoh-Flow will not generate one when instantiating the flow and keep this value instead.
     ///
     /// ⚠️ *Note that this will prevent having multiple instances of this data flow on the same Zenoh network*.
-    pub(crate) uuid: Option<Uuid>,
+    pub(crate) id: Option<InstanceId>,
     /// A human-readable description of the data flow.
     pub(crate) name: Arc<str>,
     /// *(optional)* Pairs of `(key, value)` that are transmitted to the nodes at their creation.

--- a/zenoh-flow-descriptors/src/flattened/dataflow.rs
+++ b/zenoh-flow-descriptors/src/flattened/dataflow.rs
@@ -23,8 +23,7 @@ use std::{
     fmt::Display,
     sync::Arc,
 };
-use uuid::Uuid;
-use zenoh_flow_commons::{Configuration, NodeId, Result, RuntimeId, Vars};
+use zenoh_flow_commons::{Configuration, InstanceId, NodeId, Result, RuntimeId, Vars};
 
 use super::validator::Validator;
 
@@ -48,7 +47,7 @@ pub struct FlattenedDataFlowDescriptor {
     /// If provided, Zenoh-Flow will not generate one when instantiating the flow and keep this value instead.
     ///
     /// ⚠️ *Note that this will prevent having multiple instances of this data flow on the same Zenoh network*.
-    pub uuid: Option<Uuid>,
+    pub id: Option<InstanceId>,
     /// A human-readable description of the data flow.
     pub name: Arc<str>,
     /// A non-empty list of Sources.
@@ -159,7 +158,7 @@ impl FlattenedDataFlowDescriptor {
             .collect::<Result<Vec<_>>>()?;
 
         let flattened_data_flow = Self {
-            uuid: data_flow.uuid,
+            id: data_flow.id,
             name: data_flow.name,
             sources,
             operators: flattened_operators,

--- a/zenoh-flow-descriptors/src/flattened/tests.rs
+++ b/zenoh-flow-descriptors/src/flattened/tests.rs
@@ -12,7 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 use crate::{
     flattened::nodes::{sink::SinkVariant, source::SourceVariant},
@@ -23,6 +26,7 @@ use crate::{
 };
 use serde_json::json;
 use url::Url;
+use uuid::Uuid;
 use zenoh_flow_commons::{NodeId, RuntimeId, Vars};
 
 const BASE_DIR: &str = "./tests/descriptors";
@@ -422,13 +426,15 @@ links:
             .expect("Failed to deserialize flow from JSON");
 
     assert_eq!(flat_flow_yaml, flat_flow_json);
-    assert!(flat_flow_json.uuid.is_none());
+    assert!(flat_flow_json.id.is_none());
     assert!(flat_flow_yaml.mapping.is_empty());
 }
 
 #[test]
 fn test_serialize_deserialize_no_operators() {
     let flow_yaml = r#"
+id: e8f1f252-e984-4d0f-92f6-0cd97b5cfc1e
+
 name: test-flow
 
 sources:
@@ -469,6 +475,13 @@ links:
             .expect("Failed to deserialize flow from JSON");
 
     assert_eq!(flat_flow_yaml, flat_flow_json);
-    assert!(flat_flow_json.uuid.is_none());
+    assert_eq!(
+        flat_flow_json.id,
+        Some(
+            Uuid::from_str("e8f1f252-e984-4d0f-92f6-0cd97b5cfc1e")
+                .unwrap()
+                .into()
+        )
+    );
     assert!(flat_flow_yaml.mapping.is_empty());
 }

--- a/zenoh-flow-records/src/tests.rs
+++ b/zenoh-flow-records/src/tests.rs
@@ -220,7 +220,7 @@ mapping:
 
     // assert the connectors
     let key_expr_thing_edge =
-        OwnedKeyExpr::autocanonize(format!("{}/source-0/out-0", record.record_id)).unwrap();
+        OwnedKeyExpr::autocanonize(format!("{}/source-0/out-0", record.instance_id())).unwrap();
     let sender_thing_edge: NodeId = format!("source-0{}", SENDER_SUFFIX).into();
     let receiver_thing_edge: NodeId = format!("operator-1{}", RECEIVER_SUFFIX).into();
     assert_eq!(
@@ -239,7 +239,7 @@ mapping:
     );
 
     let key_expr_edge_default =
-        OwnedKeyExpr::autocanonize(format!("{}/operator-1/out-1", record.record_id)).unwrap();
+        OwnedKeyExpr::autocanonize(format!("{}/operator-1/out-1", record.instance_id())).unwrap();
     let sender_edge_default: NodeId = format!("operator-1{}", SENDER_SUFFIX).into();
     let receiver_edge_default: NodeId = format!("sink-2{}", RECEIVER_SUFFIX).into();
     assert_eq!(


### PR DESCRIPTION
Even though internally an `InstanceId` is a wrapper around a `Uuid`, by using the former everywhere we provide a more consistent API.