### PR TITLE
refactor: an Input only accepts a single Output

### DIFF
--- a/zenoh-flow-descriptors/src/flattened/validator/mod.rs
+++ b/zenoh-flow-descriptors/src/flattened/validator/mod.rs
@@ -137,7 +137,26 @@ Does it declare an input named < {} >?
                     link.to.input
                 );
             }
-            unused_inputs.remove(&(&link.to.node, &link.to.input));
+
+            // Contrary to outputs, there cannot be multiple incoming links pointing to a single input.
+            if !unused_inputs.remove(&(&link.to.node, &link.to.input)) {
+                let links = data_flow
+                    .links
+                    .iter()
+                    .filter(|&l| l.to == link.to)
+                    .collect::<Vec<_>>();
+
+                bail!(
+                    r#"
+An Input can only receive data from a single Output.
+We have detected several links that point the same Input < {} >:
+
+{:?}
+"#,
+                    link.to,
+                    links
+                )
+            }
         }
 
         if !unused_inputs.is_empty() {

--- a/zenoh-flow-nodes/src/io/tests/input-tests.rs
+++ b/zenoh-flow-nodes/src/io/tests/input-tests.rs
@@ -48,7 +48,7 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
 
     let input_raw = InputRaw {
         port_id: "test-id".into(),
-        receivers: vec![rx],
+        receiver: rx,
     };
 
     let input = Input {
@@ -62,7 +62,10 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
     );
     tx.send(message).expect("Failed to send message");
 
-    let (data, _) = input.try_recv().expect("Message (serialized) was not sent");
+    let (data, _) = input
+        .try_recv()
+        .expect("Message (serialized) was not sent")
+        .expect("No message was received");
     if let Message::Data(data) = data {
         assert_eq!(expected_data, *data);
     }
@@ -79,7 +82,8 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
 
     let (data, _) = input
         .try_recv()
-        .expect("Message (dyn SendSyncAny) was not sent");
+        .expect("Message (dyn SendSyncAny) was not sent")
+        .expect("No message was received");
     if let Message::Data(data) = data {
         assert_eq!(expected_data, *data);
     }


### PR DESCRIPTION
Handling multiple incoming links to the same Input introduced unnecessary complexity on multiple fronts: internally, to manage the errors and at the API level, on how to expose that some links failed yet a result is still produced (a form of "partial error").

By ensuring that an Input only accepts a single Output we simplify our API.