### PR TITLE
Refactor/remove watermark variant

### DIFF
--- a/examples/examples/file-writer/src/lib.rs
+++ b/examples/examples/file-writer/src/lib.rs
@@ -25,17 +25,14 @@ pub struct FileWriter {
 #[async_trait::async_trait]
 impl Node for FileWriter {
     async fn iteration(&self) -> Result<()> {
-        let (message, _) = self.input.recv().await?;
+        let (greeting, _) = self.input.recv().await?;
 
-        if let Message::Data(greeting) = message {
-            let mut file = self.file.lock().await;
-            file.write_all(greeting.as_bytes())
-                .await
-                .map_err(|e| anyhow!("{:?}", e))?;
-            return file.flush().await.map_err(|e| anyhow!("{:?}", e));
-        }
+        let mut file = self.file.lock().await;
+        file.write_all(greeting.as_bytes())
+            .await
+            .map_err(|e| anyhow!("{:?}", e))?;
 
-        Ok(())
+        file.flush().await.map_err(|e| anyhow!("{:?}", e))
     }
 }
 

--- a/examples/examples/greetings-maker/src/lib.rs
+++ b/examples/examples/greetings-maker/src/lib.rs
@@ -45,20 +45,16 @@ impl Operator for GreetingsMaker {
 #[async_trait::async_trait]
 impl Node for GreetingsMaker {
     async fn iteration(&self) -> Result<()> {
-        let (message, _) = self.input.recv().await?;
-        if let Message::Data(characters) = message {
-            let name = characters.trim_end();
+        let (characters, _) = self.input.recv().await?;
+        let name = characters.trim_end();
 
-            let greetings = match name {
-                "Sofia" | "Leonardo" => format!("Ciao, {}!\n", name),
-                "Lucia" | "Martin" => format!("¡Hola, {}!\n", name),
-                "Jade" | "Gabriel" => format!("Bonjour, {} !\n", name),
-                _ => format!("Hello, {}!\n", name),
-            };
+        let greetings = match name {
+            "Sofia" | "Leonardo" => format!("Ciao, {}!\n", name),
+            "Lucia" | "Martin" => format!("¡Hola, {}!\n", name),
+            "Jade" | "Gabriel" => format!("Bonjour, {} !\n", name),
+            _ => format!("Hello, {}!\n", name),
+        };
 
-            return self.output.send(greetings, None).await;
-        }
-
-        Ok(())
+        self.output.send(greetings, None).await
     }
 }

--- a/zenoh-flow-nodes/src/io/tests/input-tests.rs
+++ b/zenoh-flow-nodes/src/io/tests/input-tests.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use super::{Input, InputRaw};
 use crate::{
-    messages::{LinkMessage, Message, Payload},
+    messages::{LinkMessage, Payload},
     traits::SendSyncAny,
 };
 
@@ -56,7 +56,7 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
         deserializer: Arc::new(deserializer),
     };
 
-    let message = LinkMessage::from_payload(
+    let message = LinkMessage::new(
         Payload::Bytes(Arc::new(expected_serialized)),
         hlc.new_timestamp(),
     );
@@ -66,11 +66,10 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
         .try_recv()
         .expect("Message (serialized) was not sent")
         .expect("No message was received");
-    if let Message::Data(data) = data {
-        assert_eq!(expected_data, *data);
-    }
 
-    let message = LinkMessage::from_payload(
+    assert_eq!(expected_data, *data);
+
+    let message = LinkMessage::new(
         Payload::Typed((
             Arc::new(expected_data.clone()) as Arc<dyn SendSyncAny>,
             // The serializer should never be called, hence the panic.
@@ -84,9 +83,7 @@ fn test_typed_input<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'stat
         .try_recv()
         .expect("Message (dyn SendSyncAny) was not sent")
         .expect("No message was received");
-    if let Message::Data(data) = data {
-        assert_eq!(expected_data, *data);
-    }
+    assert_eq!(expected_data, *data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/zenoh-flow-nodes/src/io/tests/output-tests.rs
+++ b/zenoh-flow-nodes/src/io/tests/output-tests.rs
@@ -68,22 +68,19 @@ fn test_typed_output<T: Send + Sync + Clone + std::fmt::Debug + PartialEq + 'sta
         .expect("Failed to send the message");
 
     let message = rx.recv().expect("Received no message");
-    match message {
-        LinkMessage::Data(data) => match &*data {
-            Payload::Bytes(_) => panic!("Unexpected bytes payload"),
-            Payload::Typed((dyn_data, serializer)) => {
-                let mut dyn_serialized = Vec::new();
-                (serializer)(&mut dyn_serialized, dyn_data.clone()).expect("Failed to serialize");
-                assert_eq!(expected_serialized, dyn_serialized);
+    match message.payload {
+        Payload::Bytes(_) => panic!("Unexpected bytes payload"),
+        Payload::Typed((dyn_data, serializer)) => {
+            let mut dyn_serialized = Vec::new();
+            (serializer)(&mut dyn_serialized, dyn_data.clone()).expect("Failed to serialize");
+            assert_eq!(expected_serialized, dyn_serialized);
 
-                let data = (**dyn_data)
-                    .as_any()
-                    .downcast_ref::<T>()
-                    .expect("Failed to downcast");
-                assert_eq!(expected_data, *data);
-            }
-        },
-        LinkMessage::Watermark(_) => panic!("Unexpected watermark message"),
+            let data = (*dyn_data)
+                .as_any()
+                .downcast_ref::<T>()
+                .expect("Failed to downcast");
+            assert_eq!(expected_data, *data);
+        }
     }
 }
 

--- a/zenoh-flow-nodes/src/lib.rs
+++ b/zenoh-flow-nodes/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) mod traits;
 pub mod prelude {
     pub use crate::context::Context;
     pub use crate::io::{Input, InputRaw, Inputs, Output, OutputRaw, Outputs};
-    pub use crate::messages::{Data, DataMessage, LinkMessage, Message};
+    pub use crate::messages::{Data, LinkMessage};
     pub use crate::traits::{Node, Operator, SendSyncAny, Sink, Source};
     pub use anyhow::{anyhow, bail};
     pub use zenoh_flow_commons::{Configuration, Result};

--- a/zenoh-flow-nodes/src/messages.rs
+++ b/zenoh-flow-nodes/src/messages.rs
@@ -15,6 +15,7 @@
 use crate::traits::SendSyncAny;
 use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -144,6 +145,26 @@ pub struct LinkMessage {
     pub(crate) payload: Payload,
     pub(crate) timestamp: Timestamp,
 }
+
+impl Ord for LinkMessage {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.get_timestamp().cmp(other.get_timestamp())
+    }
+}
+
+impl PartialOrd for LinkMessage {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for LinkMessage {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_timestamp() == other.get_timestamp()
+    }
+}
+
+impl Eq for LinkMessage {}
 
 impl Deref for LinkMessage {
     type Target = Payload;

--- a/zenoh-flow-nodes/src/messages.rs
+++ b/zenoh-flow-nodes/src/messages.rs
@@ -15,9 +15,9 @@
 use crate::traits::SendSyncAny;
 use anyhow::{bail, Context};
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::{cmp::Ordering, fmt::Debug};
 use uhlc::Timestamp;
 use zenoh_flow_commons::Result;
 
@@ -132,23 +132,20 @@ impl From<&[u8]> for Payload {
     }
 }
 
-impl From<DataMessage> for Payload {
-    fn from(data_message: DataMessage) -> Self {
+impl From<LinkMessage> for Payload {
+    fn from(data_message: LinkMessage) -> Self {
         data_message.payload
     }
 }
 
-/// Zenoh-Flow data message.
-///
-/// It contains the actual data, the timestamp associated, the end to end deadline, the end to end
-/// deadline misses and loop contexts.
+/// A message send on a Zenoh-Flow link: a [Payload] and a [Timestamp].
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DataMessage {
+pub struct LinkMessage {
     pub(crate) payload: Payload,
     pub(crate) timestamp: Timestamp,
 }
 
-impl Deref for DataMessage {
+impl Deref for LinkMessage {
     type Target = Payload;
 
     fn deref(&self) -> &Self::Target {
@@ -156,7 +153,11 @@ impl Deref for DataMessage {
     }
 }
 
-impl DataMessage {
+impl LinkMessage {
+    pub fn new(payload: Payload, timestamp: Timestamp) -> Self {
+        Self { payload, timestamp }
+    }
+
     /// Creates a new message from serialised data.
     ///
     /// This is used when the message is coming from Zenoh or from a non-rust node.
@@ -172,26 +173,6 @@ impl DataMessage {
     // NOTE: This method is used by, at least, our Python API.
     pub fn get_timestamp(&self) -> &Timestamp {
         &self.timestamp
-    }
-}
-
-/// The Zenoh-Flow message that is sent across `Link` and across Zenoh.
-///
-/// It contains either a [`DataMessage`](`DataMessage`) or a [`Timestamp`](`uhlc::Timestamp`),
-/// in such case the `LinkMessage` variant is `Watermark`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum LinkMessage {
-    Data(DataMessage),
-    Watermark(Timestamp),
-}
-
-impl LinkMessage {
-    /// Creates a `LinkMessage::Data` from a [`Payload`](`Payload`).
-    pub fn from_payload(output: Payload, timestamp: Timestamp) -> Self {
-        Self::Data(DataMessage {
-            payload: output,
-            timestamp,
-        })
     }
 
     /// Serializes the [LinkMessage] using [bincode] into the given `buffer`.
@@ -216,69 +197,21 @@ impl LinkMessage {
         payload_buffer.clear(); // empty the buffers but keep their allocated capacity
         message_buffer.clear();
 
-        match &self {
-            LinkMessage::Data(data_message) => match &data_message.payload {
-                Payload::Bytes(_) => bincode::serialize_into(message_buffer, &self)
-                    .context("Failed to serialize `Payload::Bytes``"),
-                Payload::Typed((data, serializer)) => {
-                    (serializer)(payload_buffer, Arc::clone(data))?;
-                    let serialized_message = LinkMessage::Data(DataMessage {
-                        payload: Payload::Bytes(Arc::new(payload_buffer.clone())),
-                        timestamp: data_message.timestamp,
-                    });
+        match &self.payload {
+            Payload::Bytes(_) => bincode::serialize_into(message_buffer, &self)
+                .context("Failed to serialize `Payload::Bytes``"),
+            Payload::Typed((data, serializer)) => {
+                (serializer)(payload_buffer, Arc::clone(data))?;
+                let serialized_message = Self {
+                    payload: Payload::Bytes(Arc::new(payload_buffer.clone())),
+                    timestamp: self.timestamp,
+                };
 
-                    bincode::serialize_into(message_buffer, &serialized_message)
-                        .context("Failed to serialize `Payload::Typed`")
-                }
-            },
-            _ => bincode::serialize_into(message_buffer, &self)
-                .context("Failed to serialize `LinkMessage::Watermark`"),
+                bincode::serialize_into(message_buffer, &serialized_message)
+                    .context("Failed to serialize `Payload::Typed`")
+            }
         }
     }
-
-    /// Returns the `Timestamp` associated with the message.
-    pub fn get_timestamp(&self) -> Timestamp {
-        match self {
-            Self::Data(data) => data.timestamp,
-            Self::Watermark(ref ts) => *ts,
-            // Self::Control(ref ctrl) => match ctrl {
-            //     ControlMessage::RecordingStart(ref rs) => rs.timestamp,
-            //     ControlMessage::RecordingStop(ref ts) => *ts,
-            // },
-            // _ => Err(ErrorKind::Unsupported),
-        }
-    }
-}
-
-// Manual Ord implementation for message ordering when replay
-impl Ord for LinkMessage {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.get_timestamp().cmp(&other.get_timestamp())
-    }
-}
-
-impl PartialOrd for LinkMessage {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for LinkMessage {
-    fn eq(&self, other: &Self) -> bool {
-        self.get_timestamp() == other.get_timestamp()
-    }
-}
-
-impl Eq for LinkMessage {}
-
-/// A `Message<T>` is what is received on an `Input<T>`, typically after a call to `try_recv` or
-/// `recv`.
-///
-/// A `Message<T>` can either contain [`Data<T>`](`Data`), or signal a _Watermark_.
-#[derive(Debug)]
-pub enum Message<T> {
-    Data(Data<T>),
-    Watermark,
 }
 
 /// A `Data<T>` is a convenience wrapper around `T`.

--- a/zenoh-flow-nodes/src/messages.rs
+++ b/zenoh-flow-nodes/src/messages.rs
@@ -189,7 +189,7 @@ impl LinkMessage {
         }
     }
 
-    /// Return the [Timestamp] associated with this [DataMessage].
+    /// Return the [Timestamp] associated with this message.
     //
     // NOTE: This method is used by, at least, our Python API.
     pub fn get_timestamp(&self) -> &Timestamp {

--- a/zenoh-flow-nodes/src/traits.rs
+++ b/zenoh-flow-nodes/src/traits.rs
@@ -173,15 +173,12 @@ pub trait Source: Node + Send + Sync {
 ///         })
 ///     }
 /// }
+///
 /// #[async_trait]
 /// impl Node for NoOp {
 ///     async fn iteration(&self) -> Result<()> {
 ///         let (message, _timestamp) = self.input.recv().await?;
-///         match message {
-///             Message::Data(t) => self.output.send(*t, None).await?,
-///             Message::Watermark => println!("Watermark"),
-///         }
-///         Ok(())
+///         self.output.send(*message, None).await
 ///     }
 /// }
 /// ```
@@ -249,10 +246,7 @@ pub trait Operator: Node + Send + Sync {
 /// impl Node for GenericSink {
 ///     async fn iteration(&self) -> Result<()> {
 ///         let (message, _timestamp) = self.input.recv().await?;
-///         match message {
-///             Message::Data(t) => println!("{}", *t),
-///             Message::Watermark => println!("Watermark"),
-///         }
+///         println!("{}", *message);
 ///
 ///         Ok(())
 ///     }

--- a/zenoh-flow-runtime/src/runners/builtin/zenoh/sink.rs
+++ b/zenoh-flow-runtime/src/runners/builtin/zenoh/sink.rs
@@ -155,7 +155,7 @@ impl<'a> Node for ZenohSink<'a> {
         let (key_expr, input, publisher) = self.get(&id);
 
         match message {
-            Ok(LinkMessage::Data(data)) => {
+            Ok(data) => {
                 // NOTE: In most of cases sending through the shared memory should suffice.
                 //
                 // This holds true EVEN IF THERE IS NO SHARED MEMORY. Zenoh will, by default, automatically fallback to
@@ -210,7 +210,6 @@ Caused by:
                         .map_err(|e| anyhow!("{:?}", e))?
                 }
             }
-            Ok(_) => (), // Not the right message, ignore it.
             Err(e) => tracing::error!(
                 "[built-in zenoh sink: {}][port: {}] Channel returned an error: {e:?}",
                 self.id,


### PR DESCRIPTION
Integrating a separate kind of message for `Watermark` within Zenoh-Flow made
our API complex for little benefits.

Removing its integration does not remove the possibility of exchanging these
types of messages in a data flow: dedicated Input(s) / Output(s) are simply
required. It also makes the access to the contained payload instantaneous: no
need to perform first pattern matching.

Hence, this commit removes the Watermark variant from our API.