### PR TITLE
feat(runtime): check extensions libraries before loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
  "zenoh-flow-descriptors",
  "zenoh-flow-nodes",
  "zenoh-flow-records",
+ "zenoh-flow-runtime",
 ]
 
 [[package]]

--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -49,3 +49,4 @@ plugin = []
 
 [dev-dependencies]
 serde_yaml = { workspace = true }
+zenoh-flow-runtime = { workspace = true, features = ["test-utils"] }

--- a/zenoh-flow-daemon/src/configuration.rs
+++ b/zenoh-flow-daemon/src/configuration.rs
@@ -86,19 +86,15 @@ extensions:
                     "Failed to parse ZenohFlowConfiguration with Zenoh inline + Extensions inline",
                 );
 
-        let expected_configuration = ZenohFlowConfiguration {
-            name: "My test daemon".into(),
-            extensions: Some(ExtensionsConfiguration::Extensions(
-                Extensions::default().add_extension(
-                    "py",
-                    "/home/zenoh-flow/extension/libpython_source.so".into(),
-                    "/home/zenoh-flow/extension/libpython_operator.so".into(),
-                    "/home/zenoh-flow/extension/libpython_sink.so".into(),
-                ),
-            )),
-        };
-
         assert_eq!(expected_configuration.name, config.name);
-        assert_eq!(expected_configuration.extensions, config.extensions);
+        assert!(config.extensions.is_some());
+        let config_extensions = config.extensions.unwrap();
+        assert!(matches!(
+            config_extensions,
+            ExtensionsConfiguration::Extensions(_)
+        ));
+        if let ExtensionsConfiguration::Extensions(extensions) = config_extensions {
+            assert!(extensions.get("py").is_some());
+        }
     }
 }

--- a/zenoh-flow-runtime/Cargo.toml
+++ b/zenoh-flow-runtime/Cargo.toml
@@ -47,6 +47,8 @@ zenoh-flow-records = { workspace = true }
 default = ["zenoh"]
 zenoh = ["dep:zenoh"]
 shared-memory = ["zenoh"]
+test-utils = []
 
 [dev-dependencies]
 serde_yaml = { workspace = true }
+zenoh-flow-runtime = { path = ".", features = ["test-utils"] }


### PR DESCRIPTION
This commit ensures that the libraries that are used to support additional programming languages (i.e. "extensions") expose the correct symbols.

Hence, if a library is not suitable (wrong path, wrong symbol) the Zenoh-Flow runtime will raise an error while parsing its configuration, not when trying to load a data flow.

To keep the actual tests from consistently failing, the feature "test-utils" was introduced in the `zenoh-flow-runtime` crate which is enabled by the `zenoh-flow-daemon` crate only as a dev-dependency.