### PR TITLE
refactor: expose `try_add_extension` at Loader and Daemon

### DIFF
--- a/zenoh-flow-runtime/src/lib.rs
+++ b/zenoh-flow-runtime/src/lib.rs
@@ -16,7 +16,7 @@ mod instance;
 pub use instance::{DataFlowInstance, InstanceState, InstanceStatus};
 
 mod loader;
-pub use loader::{Extensions, Loader};
+pub use loader::{Extension, Extensions, Loader};
 
 #[cfg(feature = "shared-memory")]
 mod shared_memory;

--- a/zenoh-flow-standalone-runtime/src/main.rs
+++ b/zenoh-flow-standalone-runtime/src/main.rs
@@ -62,7 +62,7 @@ async fn main() {
         None => Extensions::default(),
     };
 
-    let loader = Loader::new(extensions);
+    let loader = Loader::with_extensions(extensions);
 
     let vars = match cli.vars {
         Some(v) => Vars::from(v),


### PR DESCRIPTION
Users manually creating a Zenoh-Flow runtime or daemon could need to add extensions. This commit makes it easier to add extensions by exposing the function `try_add_extension` both at the Loader and Daemon levels.

The `Extension` structure was also made public with methods to access the values of the different fields composing it.