### PR TITLE
refactor: improve data flow state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1754,7 +1763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.33",
@@ -3494,6 +3503,7 @@ dependencies = [
  "libloading",
  "serde",
  "serde_yaml",
+ "thiserror",
  "tracing",
  "uhlc",
  "url",
@@ -3906,6 +3916,7 @@ dependencies = [
  "derive_more",
  "dirs",
  "git-version",
+ "itertools 0.12.1",
  "log",
  "rand",
  "semver",

--- a/zenoh-flow-daemon/src/instances/start.rs
+++ b/zenoh-flow-daemon/src/instances/start.rs
@@ -66,11 +66,8 @@ Caused by:
         // -------------------------------------------------------------------------------------------------------------
 
         let record = return_if_err!(
-            runtime
-                .get_record(&instance_id)
-                .await
-                .ok_or(anyhow::anyhow!("Not found")),
-            "Found no data flow with id: {}",
+            runtime.try_get_record(&instance_id).await,
+            "Could not get record associated with < {} >",
             instance_id
         );
 

--- a/zenoh-flow-runtime/Cargo.toml
+++ b/zenoh-flow-runtime/Cargo.toml
@@ -33,6 +33,7 @@ flume = { workspace = true }
 futures = { workspace = true }
 libloading = "0.8"
 serde = { workspace = true }
+thiserror = "1"
 tracing = { workspace = true }
 uhlc = { workspace = true }
 url = { workspace = true }

--- a/zenoh-flow-runtime/src/lib.rs
+++ b/zenoh-flow-runtime/src/lib.rs
@@ -24,7 +24,7 @@ mod shared_memory;
 mod runners;
 
 mod runtime;
-pub use runtime::Runtime;
+pub use runtime::{DataFlowErr, Runtime};
 
 #[cfg(feature = "zenoh")]
 pub mod zenoh {

--- a/zfctl/Cargo.toml
+++ b/zfctl/Cargo.toml
@@ -34,6 +34,7 @@ comfy-table = "7.1.0"
 derive_more = "0.99.10"
 dirs = "5.0"
 git-version = { workspace = true }
+itertools = "0.12"
 log = { workspace = true }
 rand = "0.8.3"
 semver = { version = "1.0.4", features = ["serde"] }


### PR DESCRIPTION
The main changes introduced by this commit pertain to the `InstanceState` structure.

Two variants were added:
- Creating
- Failed

For each variant a timestamp was added, e.g. `Creating(Timestamp)`, such that users can track when modifications were performed on their data flow.

The `Failed` state had additional consequences, on the runtime, daemon and zfctl.
The purpose of introducing this state is to allow users to keep track of what went wrong when trying to create their data flow. In order to do so, we need to keep the failed instance within the runtime --- we cannot immediately drop it as was done before.

If we keep the failed instance, we suddenly "allow" start / abort requests on it. Which should not be done. The changes on the runtime, daemon and zfctl address this problem.