### PR TITLE
refactor(daemon): leverage the RuntimeBuilder

### DIFF
--- a/zenoh-flow-daemon/src/configuration.rs
+++ b/zenoh-flow-daemon/src/configuration.rs
@@ -12,14 +12,14 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use serde::Deserialize;
 use zenoh_flow_runtime::Extensions;
 
 #[derive(Deserialize, Debug)]
 pub struct ZenohFlowConfiguration {
-    pub name: Arc<str>,
+    pub name: String,
     pub extensions: Option<ExtensionsConfiguration>,
     #[cfg(not(feature = "plugin"))]
     pub zenoh: ZenohConfiguration,

--- a/zenoh-flow-runtime/src/runtime/mod.rs
+++ b/zenoh-flow-runtime/src/runtime/mod.rs
@@ -116,39 +116,6 @@ impl Runtime {
         self.session.clone()
     }
 
-    /// TODO@J-Loudet
-    ///
-    /// Creates a new Zenoh-Flow runtime.
-    ///
-    /// Runtime manages data flows:
-    /// - node management,
-    /// - library management
-    ///
-    /// # Features
-    ///
-    /// - "zenoh": requires a Zenoh session to be able to communicate with other Zenoh nodes
-    /// - "shared-memory": enables the Zenoh shared-memory transport (experimental)
-    pub fn new(
-        id: RuntimeId,
-        name: Arc<str>,
-        loader: Loader,
-        hlc: Arc<HLC>,
-        #[cfg(feature = "zenoh")] session: Arc<Session>,
-        #[cfg(feature = "shared-memory")] shared_memory: SharedMemoryConfiguration,
-    ) -> Self {
-        Self {
-            name,
-            runtime_id: id,
-            #[cfg(feature = "zenoh")]
-            session,
-            hlc,
-            loader: Mutex::new(loader),
-            #[cfg(feature = "shared-memory")]
-            shared_memory,
-            flows: RwLock::new(HashMap::default()),
-        }
-    }
-
     /// Returns the [DataFlowRecord] associated with the provided instance, *if that instance is not in a failed state*.
     ///
     /// # Errors

--- a/zenoh-plugin-zenoh-flow/src/lib.rs
+++ b/zenoh-plugin-zenoh-flow/src/lib.rs
@@ -58,15 +58,13 @@ impl Plugin for ZenohFlowPlugin {
                     }
                 };
 
-            let daemon = match Daemon::from_config(zenoh_session, zenoh_flow_config).await {
+            let daemon = match Daemon::spawn_from_config(zenoh_session, zenoh_flow_config).await {
                 Ok(daemon) => daemon,
                 Err(e) => {
-                    tracing::error!("Failed to build Daemon from configuration: {e:?}");
+                    tracing::error!("Failed to spawn the Daemon from a configuration: {e:?}");
                     return;
                 }
             };
-
-            let daemon = daemon.start().await;
 
             if let Err(e) = abort_rx.recv_async().await {
                 tracing::error!("Abort channel failed with: {e:?}");


### PR DESCRIPTION
Leveraging the runtime builder made the `DeamonBuilder` obsolete, which impacted both the zenoh-flow-standalone-daemon crate and zenoh-plugin-zenoh-flow.

It also led to a simplification of the code base.