### PR TITLE
refactor(daemon): selector creation returns no error

### DIFF
--- a/zenoh-flow-daemon/src/instances/abort.rs
+++ b/zenoh-flow-daemon/src/instances/abort.rs
@@ -71,17 +71,7 @@ pub(crate) async fn query_abort(
     };
 
     for runtime_id in runtimes {
-        let selector = match selectors::selector_instances(runtime_id) {
-            Ok(selector) => selector,
-            Err(e) => {
-                tracing::error!(
-                    "Generation of selector 'instances' for runtime < {} > failed: {:?}",
-                    runtime_id,
-                    e
-                );
-                continue;
-            }
-        };
+        let selector = selectors::selector_instances(runtime_id);
 
         if let Err(e) = session
             .get(selector)

--- a/zenoh-flow-daemon/src/instances/create.rs
+++ b/zenoh-flow-daemon/src/instances/create.rs
@@ -129,11 +129,7 @@ Query:
         );
 
         for runtime_id in involved_runtimes {
-            let selector = rollback_if_err!(
-                selectors::selector_instances(&runtime_id),
-                r#"Failed to generate 'instances' selector for runtime < {} >"#,
-                &runtime_id
-            );
+            let selector = selectors::selector_instances(&runtime_id);
 
             let receiver_reply = rollback_if_err!(
                 runtime

--- a/zenoh-flow-daemon/src/instances/delete.rs
+++ b/zenoh-flow-daemon/src/instances/delete.rs
@@ -34,17 +34,7 @@ pub(crate) async fn query_delete(
     .expect("serde_json failed to serialize InstancesQuery::Delete");
 
     for runtime_id in runtimes {
-        let selector = match selectors::selector_instances(runtime_id) {
-            Ok(selector) => selector,
-            Err(e) => {
-                tracing::error!(
-                    "Generating selector 'instances' for runtime < {} > failed: {:?}",
-                    runtime_id,
-                    e
-                );
-                continue;
-            }
-        };
+        let selector = selectors::selector_instances(runtime_id);
 
         // NOTE: No need to process the request, as, even if the query failed, this is not something we want to recover
         // from.

--- a/zenoh-flow-daemon/src/instances/mod.rs
+++ b/zenoh-flow-daemon/src/instances/mod.rs
@@ -45,7 +45,7 @@ pub(crate) async fn spawn_instances_queryable(
     abort_rx: Receiver<()>,
     abort_ack_tx: Sender<()>,
 ) -> Result<()> {
-    let ke_instances = selectors::selector_instances(runtime.id())?;
+    let ke_instances = selectors::selector_instances(runtime.id());
     let queryable = match zenoh_session
         .declare_queryable(ke_instances.clone())
         .res()

--- a/zenoh-flow-daemon/src/instances/start.rs
+++ b/zenoh-flow-daemon/src/instances/start.rs
@@ -166,11 +166,7 @@ Caused by:
     // -----------------------------------------------------------------------------------------------------------------
 
     for runtime_id in runtimes {
-        let selector = rollback_if_err!(
-            selectors::selector_instances(runtime_id),
-            "Failed to generate selector 'instances' for runtime < {} >",
-            runtime_id
-        );
+        let selector = selectors::selector_instances(runtime_id);
 
         rollback_if_err!(
             session

--- a/zenoh-flow-daemon/src/runtime.rs
+++ b/zenoh-flow-daemon/src/runtime.rs
@@ -109,12 +109,7 @@ pub(crate) async fn spawn_runtime_queryable(
     abort_rx: Receiver<()>,
     abort_ack_tx: Sender<()>,
 ) -> Result<()> {
-    let ke_runtime = match selector_runtimes(runtime.id()) {
-        Ok(ke) => ke,
-        Err(e) => {
-            bail!("Failed to create 'runtimes' selector: {:?}", e);
-        }
-    };
+    let ke_runtime = selector_runtimes(runtime.id());
 
     let queryable = match zenoh_session
         .declare_queryable(ke_runtime.clone())

--- a/zenoh-flow-daemon/src/selectors.rs
+++ b/zenoh-flow-daemon/src/selectors.rs
@@ -12,21 +12,31 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use anyhow::anyhow;
 use zenoh::key_expr::OwnedKeyExpr;
-use zenoh_flow_commons::Result;
 use zenoh_flow_commons::RuntimeId;
 
 const ZENOH_FLOW: &str = "zenoh-flow";
 const INSTANCES: &str = "instances";
 const RUNTIMES: &str = "runtimes";
 
-fn try_autocanonize(maybe_ke: String) -> Result<OwnedKeyExpr> {
-    OwnedKeyExpr::autocanonize(maybe_ke.clone()).map_err(|e| {
-        anyhow!(
-            "Failed to generate a valid, canonical, Zenoh key expression from < {} >:\n{:?}",
-            maybe_ke,
-            e
+/// This function generates an [OwnedKeyExpr] from the provided String.
+///
+/// # Panic
+///
+/// This function will panic if the provided String cannot be transformed into a canonical key expression. See the
+/// [documentation of Zenoh's autocanonize](OwnedKeyExpr::autocanonize()) for all the possible scenarios where this
+/// could happen.
+///
+/// Although panicking seems like a strong posture, we believe this choice strikes a correct balance: we, the Zenoh-Flow
+/// team, know the internals of Zenoh and can guarantee the validity of the key expressions we are building. Plus, all
+/// the exposed API leveraging this function only accepts [RuntimeId] which is a thin wrapper over ZenohId.
+fn autocanonize(maybe_ke: String) -> OwnedKeyExpr {
+    OwnedKeyExpr::autocanonize(maybe_ke.clone()).unwrap_or_else(|e| {
+        panic!(
+            r#"Zenoh-Flow internal error: < {} > is not a valid or canonical key expression
+
+{e:?}"#,
+            maybe_ke
         )
     })
 }
@@ -38,9 +48,12 @@ fn try_autocanonize(maybe_ke: String) -> Result<OwnedKeyExpr> {
 ///
 /// where `<runtime id>` corresponds to the unique identifier of the chosen runtime.
 ///
-/// To obtain the list of available Zenoh-Flow runtimes, a query can be made on [runtime::KE_ALL].
-pub fn selector_instances(runtime_id: &RuntimeId) -> Result<OwnedKeyExpr> {
-    try_autocanonize(format!("{ZENOH_FLOW}/{runtime_id}/{INSTANCES}"))
+/// # Panic
+///
+/// This function will panic in the impossible scenario (although never say never…) where the provided [RuntimeId] would
+/// make the key expression not valid or not canonical.
+pub fn selector_instances(runtime_id: &RuntimeId) -> OwnedKeyExpr {
+    autocanonize(format!("{ZENOH_FLOW}/{runtime_id}/{INSTANCES}"))
 }
 
 /// Helper function to generate an [OwnedKeyExpr] to query the data flow instances managed by all the reachable
@@ -52,8 +65,13 @@ pub fn selector_instances(runtime_id: &RuntimeId) -> Result<OwnedKeyExpr> {
 ///
 /// As this selector will attempt to reach all the Zenoh-Flow runtime, it is possible that the query will take
 /// longer to finish and consume more network resources.
-pub fn selector_all_instances() -> Result<OwnedKeyExpr> {
-    try_autocanonize(format!("{ZENOH_FLOW}/*/{INSTANCES}"))
+///
+/// # Panic
+///
+/// This function will panic in the impossible scenario where the key expression we internally rely on is no longer
+/// valid or canonical.
+pub fn selector_all_instances() -> OwnedKeyExpr {
+    autocanonize(format!("{ZENOH_FLOW}/*/{INSTANCES}"))
 }
 
 /// Helper function to generate an [OwnedKeyExpr] to query the provided runtime.
@@ -61,8 +79,13 @@ pub fn selector_all_instances() -> Result<OwnedKeyExpr> {
 /// The generated key expression has the following structure: " zenoh-flow/<runtime id>/runtime "
 ///
 /// where `{runtime id}` corresponds to the unique identifier of the chosen runtime.
-pub fn selector_runtimes(runtime_id: &RuntimeId) -> Result<OwnedKeyExpr> {
-    try_autocanonize(format!("{ZENOH_FLOW}/{runtime_id}/{RUNTIMES}"))
+///
+/// # Panic
+///
+/// This function will panic in the impossible scenario (although never say never…) where the provided [RuntimeId] would
+/// make the key expression not valid or not canonical.
+pub fn selector_runtimes(runtime_id: &RuntimeId) -> OwnedKeyExpr {
+    autocanonize(format!("{ZENOH_FLOW}/{runtime_id}/{RUNTIMES}"))
 }
 
 /// Helper function to generate an [OwnedKeyExpr] to query all the reachable Zenoh-Flow runtimes.
@@ -73,6 +96,11 @@ pub fn selector_runtimes(runtime_id: &RuntimeId) -> Result<OwnedKeyExpr> {
 ///
 /// As this selector will attempt to reach all the Zenoh-Flow runtime, it is possible that the query will take
 /// longer to finish and consume more network resources.
-pub fn selector_all_runtimes() -> Result<OwnedKeyExpr> {
-    try_autocanonize(format!("{ZENOH_FLOW}/*/{RUNTIMES}"))
+///
+/// # Panic
+///
+/// This function will panic in the impossible scenario where the key expression we internally rely on is no longer
+/// valid or canonical.
+pub fn selector_all_runtimes() -> OwnedKeyExpr {
+    autocanonize(format!("{ZENOH_FLOW}/*/{RUNTIMES}"))
 }

--- a/zfctl/src/instance_command.rs
+++ b/zfctl/src/instance_command.rs
@@ -74,14 +74,7 @@ pub(crate) enum InstanceCommand {
 
 impl InstanceCommand {
     pub async fn run(self, session: Session, orchestrator_id: RuntimeId) -> Result<()> {
-        let mut selector = selectors::selector_instances(&orchestrator_id).map_err(|e| {
-            tracing::error!(
-                "Failed to generate a valid Zenoh key expression for runtime with id < {} >:\n{:?}",
-                &orchestrator_id,
-                e
-            );
-            anyhow!(ZENOH_FLOW_INTERNAL_ERROR)
-        })?;
+        let mut selector = selectors::selector_instances(&orchestrator_id);
         let query = match self {
             InstanceCommand::Create { flow, vars } => {
                 let vars = match vars {
@@ -114,7 +107,7 @@ impl InstanceCommand {
             InstanceCommand::List => InstancesQuery::List,
 
             InstanceCommand::Status { instance_id } => {
-                selector = selectors::selector_all_instances().unwrap();
+                selector = selectors::selector_all_instances();
                 InstancesQuery::Status(instance_id.into())
             }
             InstanceCommand::Start { instance_id } => InstancesQuery::Start {

--- a/zfctl/src/runtime_command.rs
+++ b/zfctl/src/runtime_command.rs
@@ -38,7 +38,7 @@ pub(crate) async fn get_all_runtimes(session: &Session) -> Result<Vec<RuntimeInf
     })?;
 
     let runtime_replies = session
-        .get(zenoh_flow_daemon::selectors::selector_all_runtimes().unwrap())
+        .get(zenoh_flow_daemon::selectors::selector_all_runtimes())
         .with_value(value)
         // We want to address all the Zenoh-Flow runtimes that are reachable on the Zenoh network.
         .consolidation(ConsolidationMode::None)
@@ -107,9 +107,7 @@ impl RuntimeCommand {
             }
 
             RuntimeCommand::Status { runtime_id } => {
-                let selector = selector_runtimes(&runtime_id).map_err(|e| {
-                    anyhow!("Failed to generate a valid selector for runtime {runtime_id}: {e:?}")
-                })?;
+                let selector = selector_runtimes(&runtime_id);
 
                 let value = serde_json::to_vec(&RuntimesQuery::Status).map_err(|e| {
                     tracing::error!(


### PR DESCRIPTION
Although panicking seems like a strong posture, we believe this choice strikes a correct balance: we, the Zenoh-Flow team, know the internals of Zenoh and can guarantee the validity of the key expressions we are building. Plus, all the exposed API leveraging this function only accepts `RuntimeId` which is a thin wrapper over ZenohId.

The benefit is that this simplifies our API, removing an error that, realistically, would never occur.