### PR TITLE
fix(daemon): missing `anyhow` import without "plugin" feature

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,6 +18,8 @@ BUILD := "debug"
 
 # Perform all verification on the code
 code-checks:
+    cargo build -p zenoh-flow-daemon
+    cargo build -p zenoh-flow-daemon --features plugin
     cargo nextest run
     cargo test --doc
     cargo clippy --all-targets -- --deny warnings

--- a/zenoh-flow-daemon/src/daemon/mod.rs
+++ b/zenoh-flow-daemon/src/daemon/mod.rs
@@ -61,7 +61,7 @@ impl Daemon {
         #[cfg(not(feature = "plugin"))]
         let zenoh_config = match configuration.zenoh {
             ZenohConfiguration::File(path) => {
-                zenoh::prelude::Config::from_file(path).map_err(|e| anyhow!("{e:?}"))
+                zenoh::prelude::Config::from_file(path).map_err(|e| anyhow::anyhow!("{e:?}"))
             }
             ZenohConfiguration::Configuration(config) => Ok(config),
         }?;
@@ -71,7 +71,7 @@ impl Daemon {
             .res()
             .await
             .map(|session| session.into_arc())
-            .map_err(|e| anyhow!("{e:?}"))?;
+            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
         let extensions = if let Some(extensions) = configuration.extensions {
             match extensions {


### PR DESCRIPTION
* justfile: added two separate actions to build the crate with and without the feature "plugin".
* daemon/mod.rs: used the fully qualified path when using the `anyhow!` macro.