### PR TITLE
feat(daemon): delete all instances before stopping the Daemon

### DIFF
--- a/zenoh-flow-daemon/src/queries/instances/delete.rs
+++ b/zenoh-flow-daemon/src/queries/instances/delete.rs
@@ -17,6 +17,7 @@ use crate::queries::selectors;
 
 use std::sync::Arc;
 
+use async_std::task::JoinHandle;
 use zenoh::prelude::r#async::*;
 use zenoh_flow_commons::{InstanceId, RuntimeId};
 use zenoh_flow_runtime::{DataFlowErr, Runtime};
@@ -58,7 +59,11 @@ pub(crate) async fn query_delete(
 ///
 /// If the query comes from a [Client](Origin::Client) then this daemon will query all the runtimes involved in this
 /// instance to make them also delete the data flow instance.
-pub(crate) fn delete_instance(runtime: Arc<Runtime>, origin: Origin, instance_id: InstanceId) {
+pub(crate) fn delete_instance(
+    runtime: Arc<Runtime>,
+    origin: Origin,
+    instance_id: InstanceId,
+) -> JoinHandle<()> {
     async_std::task::spawn(async move {
         if matches!(origin, Origin::Client) {
             match runtime.try_get_record(&instance_id).await {
@@ -83,5 +88,5 @@ pub(crate) fn delete_instance(runtime: Arc<Runtime>, origin: Origin, instance_id
         if let Err(e) = runtime.try_delete_instance(&instance_id).await {
             tracing::error!("Failed to delete instance < {} >: {:?}", instance_id, e);
         }
-    });
+    })
 }

--- a/zenoh-flow-daemon/src/queries/instances/mod.rs
+++ b/zenoh-flow-daemon/src/queries/instances/mod.rs
@@ -12,10 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-mod abort;
-mod create;
-mod delete;
-mod start;
+pub(crate) mod abort;
+pub(crate) mod create;
+pub(crate) mod delete;
+pub(crate) mod start;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -121,7 +121,9 @@ impl InstancesQuery {
             InstancesQuery::Delete {
                 origin,
                 instance_id,
-            } => delete::delete_instance(runtime, origin, instance_id),
+            } => {
+                delete::delete_instance(runtime, origin, instance_id);
+            }
 
             InstancesQuery::Status(instance_id) => {
                 if let Err(e) = reply(


### PR DESCRIPTION
This commit makes the Daemon delete the instances it manages before stopping. In particular, for all the data flow instances that are spanning on multiple Daemons, it will ask the involved Daemons to also delete them.

* queries/instances/delete.rs: make the function `delete_instance` return a `JoinHandle` so I can await it. This is needed when stopping the Daemon as, if these are not awaited, the Daemon will stop before the requests to delete have been sent out.

* queries/instances/mod.rs:
  - make all submodules `pub(crate)` such that they can be called from other submodules in the zenoh_flow_daemon crate. I was interested more specifically in the delete crate as I needed to access the `delete_instance` function.
  - as `delete_instance` now returns a `JoinHandle`, the match case had to be update to reflect that change.

* daemon/mod.rs: fetch all the data flow instances state, to get their instance id, then sent out the delete requests to other Daemon(s).