### PR TITLE
fix(runtime): add missing `cfg(feature)`

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,6 +18,8 @@ BUILD := "debug"
 
 # Perform all verification on the code
 code-checks:
+    cargo build -p zenoh-flow-runtime --no-default-features
+    cargo build -p zenoh-flow-runtime --no-default-features --features zenoh
     cargo build -p zenoh-flow-daemon
     cargo build -p zenoh-flow-daemon --features plugin
     cargo nextest run

--- a/zenoh-flow-runtime/src/runtime/builder.rs
+++ b/zenoh-flow-runtime/src/runtime/builder.rs
@@ -16,9 +16,9 @@ use crate::{loader::Loader, Extensions, Runtime};
 
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
-use anyhow::{anyhow, bail};
 use async_std::sync::{Mutex, RwLock};
 use uhlc::HLC;
+#[cfg(feature = "zenoh")]
 use zenoh::prelude::r#async::*;
 #[cfg(feature = "shared-memory")]
 use zenoh_flow_commons::SharedMemoryConfiguration;
@@ -79,7 +79,7 @@ impl RuntimeBuilder {
 
         #[cfg(feature = "zenoh")]
         if self.session.is_some() {
-            bail!(
+            anyhow::bail!(
                 "Cannot set the identifier of this runtime, a Zenoh session was already provided"
             );
         }
@@ -249,7 +249,9 @@ impl RuntimeBuilder {
                 zenoh::open(zenoh_config)
                     .res_async()
                     .await
-                    .map_err(|e| anyhow!("Failed to open a Zenoh session in peer mode:\n{e:?}"))?
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to open a Zenoh session in peer mode:\n{e:?}")
+                    })?
                     .into_arc()
             }
         };

--- a/zenoh-flow-runtime/src/runtime/load.rs
+++ b/zenoh-flow-runtime/src/runtime/load.rs
@@ -25,7 +25,9 @@
 
 use super::Runtime;
 use crate::loader::NodeSymbol;
+#[cfg(feature = "zenoh")]
 use crate::runners::builtin::zenoh::sink::ZenohSink;
+#[cfg(feature = "zenoh")]
 use crate::runners::builtin::zenoh::source::ZenohSource;
 use crate::InstanceState;
 use crate::{instance::DataFlowInstance, runners::Runner};


### PR DESCRIPTION
The crate `zenoh_flow_runtime` was not compiled, in our tests, with the different flags turned on / off, which led to few imports that were not guarded.

This commit fixes these errors and adds the necessary tests in the `justfile`.

* justfile: add two compilation checks.
* runtime/builder.rs:
  - guard the zenoh import below a `cfg(feature)` directive,
  - removed the `anyhow` import and instead fully qualify their usage.
* runtime/load.rs: guard the imports of the builtin Zenoh source / sink with a `cfg(feature)` directive.