### PR TITLE
docs(commons): improve / rephrase documentation

### DIFF
--- a/zenoh-flow-commons/src/configuration.rs
+++ b/zenoh-flow-commons/src/configuration.rs
@@ -34,41 +34,41 @@ use std::{ops::Deref, sync::Arc};
 /// When two configuration keys collide, the configuration with the highest order is kept. The priorities are (from
 /// highest to lowest):
 /// - the configuration in a node within a data flow descriptor,
-/// - the configuration in a data flow descriptor,
-/// - the configuration in a node within a composite operator,
-/// - the configuration in a composite operator,
+/// - the configuration at the top-level of a data flow descriptor,
+/// - the configuration in a node within a composite operator descriptor,
+/// - the configuration at the top-level of a composite operator descriptor,
 /// - the configuration in a dedicated file of a node.
 ///
 /// Hence, configuration at the data flow level are propagating to all nodes, possibly overwriting default values. The
 /// same rules apply at the composite operator level. If a node should have a slightly different setting compared to all
-/// others, then these priorities allow setting a global value and tweaking only the node that differs (either in the
-/// data flow or in the composite operator).
+/// others, then, thanks to these priorities, only that node needs to be tweaked (either in the data flow or in the
+/// composite operator).
 ///
 /// # Examples
 ///
-/// ## YAML
+/// - YAML
 ///
-/// ```yaml
-/// configuration:
-///   name: "John Doe",
-///   age: 43,
-///   phones:
-///     - "+44 1234567"
-///     - "+44 2345678"
-/// ```
+///   ```yaml
+///   configuration:
+///     name: "John Doe",
+///     age: 43,
+///     phones:
+///       - "+44 1234567"
+///       - "+44 2345678"
+///   ```
 ///
-/// ## JSON
+/// - JSON
 ///
-/// ```json
-/// "configuration": {
-///   "name": "John Doe",
-///   "age": 43,
-///   "phones": [
-///       "+44 1234567",
-///       "+44 2345678"
-///   ]
-/// }
-/// ```
+///   ```json
+///   "configuration": {
+///     "name": "John Doe",
+///     "age": 43,
+///     "phones": [
+///         "+44 1234567",
+///         "+44 2345678"
+///     ]
+///   }
+///   ```
 //
 // NOTE: we take the `serde_json` representation because:
 // - JSON is the most supported representation when going online,

--- a/zenoh-flow-commons/src/deserialize.rs
+++ b/zenoh-flow-commons/src/deserialize.rs
@@ -21,13 +21,17 @@ use serde::Deserializer;
 use std::{str::FromStr, sync::Arc};
 use zenoh_keyexpr::OwnedKeyExpr;
 
-/// Deserialise, from a [String], an `Arc<str>` that is guaranteed to be a valid Zenoh-Flow [NodeId](crate::NodeId) or
+/// Deserialise, from a String, an `Arc<str>` that is guaranteed to be a valid Zenoh-Flow [NodeId](crate::NodeId) or
 /// [PortId](crate::PortId).
 ///
-/// To be valid, the following properties must be upheld:
-/// - the String does not contain any of the symbols: * # $ ? >
-/// - the String is a valid Zenoh key expression in its canonical form (see
-///   [autocanonize](zenoh_keyexpr::OwnedKeyExpr::autocanonize)).
+/// # Errors
+///
+/// The deserialisation will fail if:
+/// - the String is empty,
+/// - the String contains any of the symbols: * # $ ? >
+/// - the String is not a valid Zenoh key expression in its canonical form (see [autocanonize]).
+///
+/// [autocanonize]: zenoh_keyexpr::OwnedKeyExpr::autocanonize
 pub fn deserialize_id<'de, D>(deserializer: D) -> std::result::Result<Arc<str>, D::Error>
 where
     D: Deserializer<'de>,
@@ -68,6 +72,10 @@ Caused by:
 /// Deserialise a bytes size leveraging the [bytesize] crate.
 ///
 /// This allows parsing, for instance, "1Ko" into "1024" bytes. For more example, see the [bytesize] crate.
+///
+/// # Errors
+///
+/// See the [bytesize] documentation.
 pub fn deserialize_size<'de, D>(deserializer: D) -> std::result::Result<usize, D::Error>
 where
     D: Deserializer<'de>,
@@ -91,6 +99,10 @@ where
 /// Deserialise a duration in *microseconds* leveraging the [humantime] crate.
 ///
 /// This allows parsing, for instance, "1ms" as 1000 microseconds.
+///
+/// # Errors
+///
+/// See the [humantime] documentation.
 pub fn deserialize_time<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
 where
     D: Deserializer<'de>,

--- a/zenoh-flow-commons/src/vars.rs
+++ b/zenoh-flow-commons/src/vars.rs
@@ -113,6 +113,13 @@ impl<T: AsRef<str>, U: AsRef<str>> From<Vec<(T, U)>> for Vars {
 }
 
 /// Parse a single [Var](Vars) from a string of the format "KEY=VALUE".
+///
+/// Note that if several "=" characters are present in the string, only the first one will be considered as a separator
+/// and the others will be treated as being part of the VALUE.
+///
+/// # Errors
+///
+/// This function will return an error if no "=" character was found.
 pub fn parse_vars<T, U>(
     s: &str,
 ) -> std::result::Result<(T, U), Box<dyn Error + Send + Sync + 'static>>


### PR DESCRIPTION
* zenoh-flow-commons/src/configuration.rs: improve documentation of `Configuration` structure.
* zenoh-flow-commons/src/deserialize.rs: rephrased errors to use affirmative "tense".
* zenoh-flow-commons/src/utils.rs:
  - internal documentation of `deserializer` function (to obtain the function that would deserialise a structure based on the Path of the file),
  - internal documentation of error cases when attempting to parse a structure from a file.
* zenoh-flow-commons/src/vars.rs: improve documentation and explain error case when parsing `vars` from a String.