### PR TITLE
docs(zfctl): remove backtick quotes

### DIFF
--- a/zfctl/src/instance_command.rs
+++ b/zfctl/src/instance_command.rs
@@ -39,7 +39,7 @@ pub(crate) enum InstanceCommand {
     /// - This call returns the unique identifier before the creation is
     ///   completed. To verify the status, one can call the following:
     ///
-    ///       `zfctl instance status <uuid>`
+    ///       zfctl instance status <uuid>
     ///
     /// - This call will **not** start the data flow instance, only load on all
     ///   the involved runtimes the nodes composing the data flow.


### PR DESCRIPTION
The rust doc was wrongly picking them as code.

* zfctl/src/instance_command.rs: remove backtick.