### PR TITLE
feat(zfctl): allow providing an optional Zenoh configuration

### DIFF
--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -13,8 +13,6 @@
 //
 
 mod instance_command;
-use std::path::PathBuf;
-
 use instance_command::InstanceCommand;
 
 mod runtime_command;
@@ -22,6 +20,8 @@ use runtime_command::RuntimeCommand;
 
 mod utils;
 use utils::{get_random_runtime, get_runtime_by_name};
+
+use std::path::PathBuf;
 
 use anyhow::anyhow;
 use clap::{Parser, Subcommand};

--- a/zfctl/src/main.rs
+++ b/zfctl/src/main.rs
@@ -13,6 +13,8 @@
 //
 
 mod instance_command;
+use std::path::PathBuf;
+
 use instance_command::InstanceCommand;
 
 mod runtime_command;
@@ -46,6 +48,13 @@ macro_rules! row {
 
 #[derive(Parser)]
 struct Zfctl {
+    /// The path to a Zenoh configuration to manage the connection to the Zenoh
+    /// network.
+    ///
+    /// If no configuration is provided, `zfctl` will default to connecting as
+    /// a peer with multicast scouting enabled.
+    #[arg(short = 'z', long, verbatim_doc_comment)]
+    zenoh_configuration: Option<PathBuf>,
     #[command(subcommand)]
     command: Command,
 }
@@ -86,7 +95,17 @@ async fn main() -> Result<()> {
 
     let zfctl = Zfctl::parse();
 
-    let session = zenoh::open(zenoh::config::peer())
+    let zenoh_config = match zfctl.zenoh_configuration {
+        Some(path) => zenoh::prelude::Config::from_file(path.clone()).map_err(|e| {
+            anyhow!(
+                "Failed to parse the Zenoh configuration from < {} >:\n{e:?}",
+                path.display()
+            )
+        })?,
+        None => zenoh::config::peer(),
+    };
+
+    let session = zenoh::open(zenoh_config)
         .res()
         .await
         .map_err(|e| anyhow!("Failed to open Zenoh session:\n{:?}", e))?;


### PR DESCRIPTION
Providing a Zenoh configuration allows, among other advantages, connecting to remote Zenoh networks.

* zfctl/src/main.rs: add the '-z' option to provide the path to a Zenoh configuration.