### PR TITLE
refactor(daemon): removed feature "plugin"

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,7 +21,6 @@ code-checks:
     cargo build -p zenoh-flow-runtime --no-default-features
     cargo build -p zenoh-flow-runtime --no-default-features --features zenoh
     cargo build -p zenoh-flow-daemon
-    cargo build -p zenoh-flow-daemon --features plugin
     cargo nextest run
     cargo test --doc
     cargo clippy --all-targets -- --deny warnings

--- a/zenoh-flow-daemon/src/daemon/configuration.rs
+++ b/zenoh-flow-daemon/src/daemon/configuration.rs
@@ -24,9 +24,6 @@ pub struct ZenohFlowConfiguration {
     pub name: String,
     /// Additionally supported [Extensions].
     pub extensions: Option<ExtensionsConfiguration>,
-    /// The configuration to connect to Zenoh.
-    #[cfg(not(feature = "plugin"))]
-    pub zenoh: ZenohConfiguration,
 }
 
 /// Enumeration to facilitate defining the [Extensions] supported by the wrapped Zenoh-Flow [Runtime].
@@ -39,17 +36,6 @@ pub struct ZenohFlowConfiguration {
 pub enum ExtensionsConfiguration {
     File(PathBuf),
     Extensions(Extensions),
-}
-
-/// Enumeration to facilitate defining the Zenoh configuration.
-///
-/// This enumeration allows either having the definition in the same configuration file or in a separate one.
-#[cfg(not(feature = "plugin"))]
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
-pub enum ZenohConfiguration {
-    File(PathBuf),
-    Configuration(zenoh::prelude::Config),
 }
 
 #[cfg(test)]

--- a/zenoh-flow-daemon/src/daemon/mod.rs
+++ b/zenoh-flow-daemon/src/daemon/mod.rs
@@ -22,8 +22,6 @@
 mod configuration;
 mod queryables;
 
-#[cfg(not(feature = "plugin"))]
-pub use configuration::ZenohConfiguration;
 pub use configuration::{ExtensionsConfiguration, ZenohFlowConfiguration};
 pub use zenoh_flow_runtime::{Extension, Extensions, Runtime};
 
@@ -72,24 +70,9 @@ impl Daemon {
     /// [runtime]: Runtime
     /// [configuration]: ZenohFlowConfiguration
     pub async fn spawn_from_config(
-        #[cfg(feature = "plugin")] zenoh_session: Arc<Session>,
+        zenoh_session: Arc<Session>,
         configuration: ZenohFlowConfiguration,
     ) -> Result<Self> {
-        #[cfg(not(feature = "plugin"))]
-        let zenoh_config = match configuration.zenoh {
-            ZenohConfiguration::File(path) => {
-                zenoh::prelude::Config::from_file(path).map_err(|e| anyhow::anyhow!("{e:?}"))
-            }
-            ZenohConfiguration::Configuration(config) => Ok(config),
-        }?;
-
-        #[cfg(not(feature = "plugin"))]
-        let zenoh_session = zenoh::open(zenoh_config)
-            .res()
-            .await
-            .map(|session| session.into_arc())
-            .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-
         let extensions = if let Some(extensions) = configuration.extensions {
             match extensions {
                 ExtensionsConfiguration::File(path) => {

--- a/zenoh-flow-daemon/src/lib.rs
+++ b/zenoh-flow-daemon/src/lib.rs
@@ -24,10 +24,6 @@
 //! Users interested in integrating a [Daemon] in their system should look into the [spawn()] and [spawn_from_config()]
 //! methods.
 //!
-//! # Feature: "plugin"
-//!
-//! This create defines the feature `plugin` for when the Daemon is embedded as a plugin on a Zenoh router.
-//!
 //! [Daemon]: crate::daemon::Daemon
 //! [Runtime]: crate::daemon::Runtime
 //! [spawn()]: crate::daemon::Daemon::spawn()

--- a/zenoh-plugin-zenoh-flow/Cargo.toml
+++ b/zenoh-plugin-zenoh-flow/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uhlc = { workspace = true }
 zenoh = { workspace = true, features = ["unstable"] }
-zenoh-flow-daemon = { path = "../zenoh-flow-daemon", features = ["plugin"] }
+zenoh-flow-daemon = { path = "../zenoh-flow-daemon" }
 zenoh-plugin-trait = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-util = { workspace = true }


### PR DESCRIPTION
Because of the way features work in Rust, in particular the fact that they are additive, it is impossible to have mutually exclusive features.

In the case of the `zenoh-flow-daemon` crate, we wanted to have the feature "plugin" enabled for the `zenoh-plugin-zenoh-flow` crate and not for the `zenoh-flow-standalone-daemon`. Having that feature enabled for one, enabled it for all crates --- which was not the desired behaviour.

To achieve the desired behaviour we should: (i) remove the feature and (ii) separate the Zenoh configuration from the Zenoh-Flow configuration.

This commit addresses (i).

* justfile: removed the build test with `--features plugin` as this feature no longer exists.
* zenoh-flow-daemon/src/daemon/configuration.rs: removed the embedded `ZenohConfiguration` structure from the `ZenohFlowConfiguration`. We have to separate them.
* zenoh-flow-daemon/src/daemon/mod.rs: removed the code that was called with the feature "plugin" disabled,
* zenoh-flow-daemon/src/lib.rs: removed the documentation regarding the feature "plugin".
* zenoh-plugin-zenoh-flow/Cargo.toml: removed the feature plugin.