### PR TITLE
fix: clap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,6 @@ version = "0.6.0-dev"
 dependencies = [
  "anyhow",
  "async-std",
- "clap",
  "flume",
  "futures",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1.50"
 base64 = "0.21"
 bytesize = "1.2.0"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 flume = "0.11"
 futures = "0.3.15"
 git-version = "0.3"

--- a/zenoh-flow-daemon/Cargo.toml
+++ b/zenoh-flow-daemon/Cargo.toml
@@ -26,7 +26,6 @@ version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-std = { workspace = true }
-clap = { workspace = true }
 flume = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
This is the reason why the release of version `0.6.0-alpha` failed
starting at the `zenoh-flow-daemon` crate: the constraint was not strict
enough, it authorised pulling the version 4.5.x which require a MRSV of
1.74.

* Cargo.toml: force clap to be at 4.4.x (which requires a MRSV of 1.70)

--------

This is, unfortunately, a historical artefact: before the major
crate-split the crate `zenoh-flow-daemon` was containing the executable
and thus needed to provide a CLI (leveraging `clap`).

This dependency should have been removed.

* Cargo.lock: removed clap from the dependencies of zenoh-flow-daemon
* zenoh-flow-daemon/Cargo.toml: removed clap from the dependencies