### PR TITLE
log(runtime): add `info!` logging when loading an extension

### DIFF
--- a/zenoh-flow-runtime/src/loader/extensions.rs
+++ b/zenoh-flow-runtime/src/loader/extensions.rs
@@ -328,6 +328,11 @@ where
                     extension.file_extension, e
                 ))
             })?;
+
+            tracing::info!(
+                "Successfully loaded extension < {} >",
+                extension.file_extension
+            );
         }
     }
 


### PR DESCRIPTION
* zenoh-flow-runtime/src/loader/extensions.rs: added the logging