### PR TITLE
refactor(daemon): configuration of extensions must be inline

### DIFF
--- a/zenoh-flow-daemon/src/daemon/configuration.rs
+++ b/zenoh-flow-daemon/src/daemon/configuration.rs
@@ -12,8 +12,6 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::path::PathBuf;
-
 use serde::Deserialize;
 use zenoh_flow_runtime::Extensions;
 
@@ -23,76 +21,5 @@ pub struct ZenohFlowConfiguration {
     /// A human-readable name for this Daemon and its embedded Runtime.
     pub name: String,
     /// Additionally supported [Extensions].
-    pub extensions: Option<ExtensionsConfiguration>,
-}
-
-/// Enumeration to facilitate defining the [Extensions] supported by the wrapped Zenoh-Flow [Runtime].
-///
-/// This enumeration allows either having the definition in the same configuration file or in a separate one.
-///
-/// [Runtime]: zenoh_flow_runtime::Runtime
-#[derive(Deserialize, Debug, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum ExtensionsConfiguration {
-    File(PathBuf),
-    Extensions(Extensions),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_deserialize() {
-        let configuration_extension_path_yaml = r#"
-name: My test daemon
-
-extensions: /home/zenoh-flow/extensions/configuration.ext
-"#;
-
-        let config = serde_yaml::from_str::<ZenohFlowConfiguration>(
-            configuration_extension_path_yaml,
-        )
-        .expect(
-            "Failed to parse ZenohFlowConfiguration with Zenoh as a PathBuf + Extensions as a PathBuf",
-        );
-
-        let expected_configuration = ZenohFlowConfiguration {
-            name: "My test daemon".into(),
-            extensions: Some(ExtensionsConfiguration::File(PathBuf::from(
-                "/home/zenoh-flow/extensions/configuration.ext",
-            ))),
-        };
-
-        assert_eq!(expected_configuration.name, config.name);
-        assert_eq!(expected_configuration.extensions, config.extensions);
-
-        let configuration_extension_inline_yaml = r#"
-name: My test daemon
-
-extensions:
-  - file_extension: py
-    libraries:
-      source: /home/zenoh-flow/extension/libpython_source.so
-      operator: /home/zenoh-flow/extension/libpython_operator.so
-      sink: /home/zenoh-flow/extension/libpython_sink.so
-"#;
-
-        let config =
-            serde_yaml::from_str::<ZenohFlowConfiguration>(configuration_extension_inline_yaml)
-                .expect(
-                    "Failed to parse ZenohFlowConfiguration with Zenoh inline + Extensions inline",
-                );
-
-        assert_eq!(expected_configuration.name, config.name);
-        assert!(config.extensions.is_some());
-        let config_extensions = config.extensions.unwrap();
-        assert!(matches!(
-            config_extensions,
-            ExtensionsConfiguration::Extensions(_)
-        ));
-        if let ExtensionsConfiguration::Extensions(extensions) = config_extensions {
-            assert!(extensions.get("py").is_some());
-        }
-    }
+    pub extensions: Option<Extensions>,
 }

--- a/zenoh-flow-daemon/src/daemon/mod.rs
+++ b/zenoh-flow-daemon/src/daemon/mod.rs
@@ -22,7 +22,7 @@
 mod configuration;
 mod queryables;
 
-pub use configuration::{ExtensionsConfiguration, ZenohFlowConfiguration};
+pub use configuration::ZenohFlowConfiguration;
 pub use zenoh_flow_runtime::{Extension, Extensions, Runtime};
 
 use crate::queries::{instances::delete::delete_instance, Origin};
@@ -30,7 +30,7 @@ use crate::queries::{instances::delete::delete_instance, Origin};
 use flume::{Receiver, Sender};
 use std::sync::Arc;
 use zenoh::prelude::r#async::*;
-use zenoh_flow_commons::{try_parse_from_file, Result, Vars};
+use zenoh_flow_commons::Result;
 
 /// A Zenoh-Flow daemon declares 2 queryables:
 /// 1. `zenoh-flow/<uuid>/runtime`
@@ -73,16 +73,7 @@ impl Daemon {
         zenoh_session: Arc<Session>,
         configuration: ZenohFlowConfiguration,
     ) -> Result<Self> {
-        let extensions = if let Some(extensions) = configuration.extensions {
-            match extensions {
-                ExtensionsConfiguration::File(path) => {
-                    try_parse_from_file::<Extensions>(path, Vars::default()).map(|(ext, _)| ext)
-                }
-                ExtensionsConfiguration::Extensions(extensions) => Ok(extensions),
-            }?
-        } else {
-            Extensions::default()
-        };
+        let extensions = configuration.extensions.unwrap_or_default();
 
         let runtime = Runtime::builder(configuration.name)
             .add_extensions(extensions)?


### PR DESCRIPTION
`serde_yaml` consistently failed to deserialise the configuration of Zenoh-Flow when the extensions were declared in another file.

This commit removes the possibility of declaring the extensions in another file.

* zenoh-flow-daemon/src/daemon/configuration.rs:
  - removed the `ExtensionsConfiguration` enum,
  - removed the associated tests,
* zenoh-flow-daemon/src/daemon/mod.rs:
  - updated the code due to the removal of the `ExtensionsConfiguration` enum.