### PR TITLE
fix(runtime): call `on_resume` when (re)starting a Runner

### DIFF
--- a/zenoh-flow-runtime/src/runners/builtin/zenoh/source.rs
+++ b/zenoh-flow-runtime/src/runners/builtin/zenoh/source.rs
@@ -72,9 +72,6 @@ impl<'a> ZenohSource<'a> {
             futs: Arc::new(Mutex::new(Vec::with_capacity(key_exprs.len()))),
         };
 
-        // NOTE: Calling this function avoids repeating code initialising the `futs` and `subscribers`.
-        zenoh_source.on_resume().await?;
-
         Ok(zenoh_source)
     }
 }


### PR DESCRIPTION
This fixes #239.

By always calling `on_resume`, be it when first starting the Runner or when restarting it, we avoid the issue raised in #239 where "active" resources are created at initialisation but are only consumed when the Runner is running.

In the case of the Zenoh built-in Source, this resulted in declaring subscribers which would buffer the publications made even before the Runner is running. Thus creating so-called slow subscribers.

A consequence of always calling `on_resume` is that the `State` enumeration was no longer needed, simplifying the code base.

* zenoh-flow-runtime/src/runners/builtin/zenoh/source.rs: do not call `on_resume` in the constructor as Zenoh-Flow will always call it before starting the iteration.
* zenoh-flow-runtime/src/runners/mod.rs:
  - always call `on_resume` when starting a Runner,
  - remove the, now useless, `State` enum.